### PR TITLE
feat: Add packaged default spec template with improved structure

### DIFF
--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -5,6 +5,7 @@ const yaml = require('js-yaml');
 const SPECS_DIR = 'specs';
 const CURRENT_LINK = path.join(SPECS_DIR, 'current');
 const TEMPLATE_PATH = '.zest-spec/template/spec.md';
+const DEFAULT_TEMPLATE_PATH = path.join(__dirname, 'template', 'spec.md');
 
 /**
  * Get all spec directories
@@ -167,39 +168,9 @@ function createSpec(slug) {
 
   fs.mkdirSync(specDirPath, { recursive: true });
 
-  // Read template
-  let template = '';
-  if (fs.existsSync(TEMPLATE_PATH)) {
-    template = fs.readFileSync(TEMPLATE_PATH, 'utf-8');
-  } else {
-    // Fallback template
-    template = `---
-id: "{id}"
-name: "{name}"
-status: planned
-created: "{date}"
----
-
-## Overview
-
-<!-- What are we solving? Why now? -->
-
-## Design
-
-<!-- Technical approach, architecture decisions -->
-
-## Plan
-
-<!-- Break down implementation into steps -->
-
-- [ ] Task 1
-- [ ] Task 2
-
-## Notes
-
-<!-- Optional: Alternatives considered, open questions -->
-`;
-  }
+  // Read template (user override first, packaged default second)
+  const templatePath = fs.existsSync(TEMPLATE_PATH) ? TEMPLATE_PATH : DEFAULT_TEMPLATE_PATH;
+  const template = fs.readFileSync(templatePath, 'utf-8');
 
   // Replace template variables
   const name = parseSpecName(specDirName);

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -1,0 +1,38 @@
+---
+id: "{id}"
+name: "{name}"
+status: new
+created: "{date}"
+---
+
+## Overview
+
+<!-- What are we solving? Why now? -->
+
+## Research
+
+<!-- What have we found out? What are the alternatives considered? -->
+
+## Design
+
+<!-- Technical approach, architecture decisions -->
+
+## Plan
+
+<!-- Break down implementation and verification into steps -->
+
+- [ ] Phase 1: Implement the first part of the feature
+  - [ ] Task 1
+  - [ ] Task 2
+  - [ ] Task 3
+- [ ] Phase 2: Implement the second part of the feature
+  - [ ] Task 1
+  - [ ] Task 2
+  - [ ] Task 3
+- [ ] Phase 3: Test and verify
+  - [ ] Test criteria 1
+  - [ ] Test criteria 2
+
+## Notes
+
+<!-- Optional: Alternatives considered, open questions, etc. -->


### PR DESCRIPTION
## Summary

This PR replaces the inline fallback template in spec-manager.js with a packaged default template file. Users can still override with a custom template, but now there's a proper default that includes a Research section and improved plan structure.

## Changes

- Add packaged default spec template with improved structure including Research section and phased plan format
- Replace inline fallback template logic with clean file-based template loading
- Simplify template selection: user override takes precedence, then packaged default
- Add comprehensive integration tests for both default template fallback and custom template override
- Refactor test infrastructure to support multiple test directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Custom template support: Provide your own template files that will override the default template when creating specifications.
* Structured default template added with sections for Overview, Research, Design, Plan, and Notes to guide specification creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->