### PR TITLE
feat: Add spec status management with forward-only transitions

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -102,10 +102,10 @@ gh pr create --base <main_branch_name> --title "PR title" --body "PR body"
 
 ### 9. Wait for PR checks to pass
 
-Run the following command to monitor PR checks (excluding coderabbit):
+Run the following command to monitor PR checks:
 
 ```bash
-gh pr checks --watch --fail-fast --required
+gh pr checks --watch --fail-fast
 ```
 
 Note: Wait until all required checks pass (coderabbit check can be ignored).

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -102,13 +102,13 @@ gh pr create --base <main_branch_name> --title "PR title" --body "PR body"
 
 ### 9. Wait for PR checks to pass
 
-Run the following command to monitor PR checks (excluding coderabbit):
+Run the following command to monitor PR checks:
 
 ```bash
-gh pr checks --watch --fail-fast --required
+gh pr checks --watch --fail-fast
 ```
 
-Note: Wait until all required checks pass (coderabbit check can be ignored).
+Note: `--required` only shows branch-protection-required checks and may report "no required checks" even when CI is running. Wait until all relevant CI checks pass (coderabbit check can be ignored).
 
 ### 10. Show the Pull Request link
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ node bin/zest-spec.js show 001
 node bin/zest-spec.js create <spec-name>
 node bin/zest-spec.js set-current <spec-id>
 node bin/zest-spec.js unset-current
+node bin/zest-spec.js update <spec-id> <status>
 ```
 
 #### Automated Testing
@@ -85,11 +86,11 @@ Specs are stored in `specs/`. Managed via `zest-spec` CLI.
 | `zest-spec create <spec-name>`  | Create new spec            |
 | `zest-spec set-current <id>`    | Set current working spec   |
 | `zest-spec unset-current`       | Unset current working spec |
+| `zest-spec update <id> <status>`| Update spec status         |
 
 ### Spec content rules
 
 - **Prioritize Brevity**: Write only the main flow and design ideas, not detailed implementation code
 - **Easy to Review**: Keep documents concise so others can quickly understand the plan
 - **Pseudocode/Flowcharts**: Use pseudocode or step lists for complex logic, instead of full code
-
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ zest-spec status
 Output:
 ```yaml
 specs_count: 3
-current: "001"
+current:
+  id: "001"
+  name: "Init Project"
+  path: "specs/001-init-project/spec.md"
+  status: "new"
 ```
 
 ### Show Spec Details
@@ -38,7 +42,7 @@ id: "001"
 name: "Init Project"
 path: "specs/001-init-project/spec.md"
 current: false
-status: "planned"
+status: "new"
 ```
 
 ### Create New Spec
@@ -55,7 +59,7 @@ spec:
   name: "Feature Name"
   path: "specs/002-feature-name/spec.md"
   current: false
-  status: "planned"
+  status: "new"
 ```
 
 ### Set Current Spec
@@ -82,25 +86,49 @@ ok: true
 current: null
 ```
 
+### Update Spec Status
+
+```bash
+zest-spec update 003 researched
+```
+
+Output:
+```yaml
+ok: true
+spec:
+  id: "003"
+  status: "researched"
+status:
+  from: "new"
+  to: "researched"
+  changed: true
+```
+
+Rules:
+- Valid status values: `new`, `researched`, `designed`, `implemented`
+- Forward-only transitions (skip allowed): e.g. `new -> designed` is valid
+- Backward transitions fail: e.g. `implemented -> designed`
+- No-op updates fail: setting the same status again returns an error
+
 ### Generate Prompts for Codex Editor
 
 The `prompt` command generates formatted prompts for editors like Codex that don't support project-level commands:
 
 ```bash
 # Create a new spec
-codex $(zest-spec prompt new "add user authentication system")
+codex "$(zest-spec prompt new 'some description')"
 
 # Work on research phase
-codex $(zest-spec prompt research)
+codex "$(zest-spec prompt research)"
 
 # Work on design phase
-codex $(zest-spec prompt design)
+codex "$(zest-spec prompt design)"
 
 # Work on implementation phase
-codex $(zest-spec prompt implement)
+codex "$(zest-spec prompt implement)"
 
 # Summarize a coding session
-codex $(zest-spec prompt summarize)
+codex "$(zest-spec prompt summarize)"
 ```
 
 This allows you to launch Codex with the appropriate initial prompt for each spec workflow phase.

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -6,6 +6,13 @@ const SPECS_DIR = 'specs';
 const CURRENT_LINK = path.join(SPECS_DIR, 'current');
 const TEMPLATE_PATH = '.zest-spec/template/spec.md';
 const DEFAULT_TEMPLATE_PATH = path.join(__dirname, 'template', 'spec.md');
+const VALID_STATUSES = ['new', 'researched', 'designed', 'implemented'];
+const STATUS_ORDER = {
+  new: 0,
+  researched: 1,
+  designed: 2,
+  implemented: 3
+};
 
 /**
  * Get all spec directories
@@ -86,10 +93,35 @@ function parseSpecFrontmatter(filePath) {
 function getSpecsStatus() {
   const specDirs = getSpecDirs();
   const currentId = getCurrentSpecId();
+  let current = null;
+
+  if (currentId) {
+    const specDir = specDirs.find(dir => parseSpecId(dir) === currentId);
+
+    if (specDir) {
+      const specPath = getSpecFilePath(specDir);
+      const frontmatter = parseSpecFrontmatter(specPath);
+
+      current = {
+        id: currentId,
+        name: parseSpecName(specDir),
+        path: specPath,
+        status: frontmatter.status || 'new'
+      };
+    } else {
+      // Keep id visible even if current symlink points to a removed spec.
+      current = {
+        id: currentId,
+        name: null,
+        path: null,
+        status: null
+      };
+    }
+  }
 
   return {
     specs_count: specDirs.length,
-    current: currentId
+    current
   };
 }
 
@@ -138,7 +170,7 @@ function getSpec(specIdentifier) {
     name: parseSpecName(specDir),
     path: specPath,
     current: specId === currentId,
-    status: frontmatter.status || 'planned'
+    status: frontmatter.status || 'new'
   };
 }
 
@@ -191,7 +223,7 @@ function createSpec(slug) {
       name: name,
       path: specPath,
       current: false,
-      status: 'planned'
+      status: 'new'
     }
   };
 }
@@ -240,10 +272,65 @@ function unsetCurrentSpec() {
   };
 }
 
+/**
+ * Update spec status with forward-only transitions (skip allowed)
+ */
+function updateSpecStatus(specIdentifier, nextStatus) {
+  if (!VALID_STATUSES.includes(nextStatus)) {
+    throw new Error(`Invalid status "${nextStatus}". Valid: ${VALID_STATUSES.join(', ')}`);
+  }
+
+  const spec = getSpec(specIdentifier);
+  const content = fs.readFileSync(spec.path, 'utf-8');
+  const match = content.match(/^---\n([\s\S]*?)\n---(\n[\s\S]*)?$/);
+
+  if (!match) {
+    throw new Error(`Spec file ${spec.path} has no valid frontmatter`);
+  }
+
+  const frontmatter = yaml.load(match[1]);
+  const currentStatus = frontmatter ? frontmatter.status : undefined;
+
+  if (!VALID_STATUSES.includes(currentStatus)) {
+    throw new Error(
+      `Invalid current status "${currentStatus}" for spec ${spec.id}. Valid: ${VALID_STATUSES.join(', ')}`
+    );
+  }
+
+  if (currentStatus === nextStatus) {
+    throw new Error(`Status is already "${nextStatus}" for spec ${spec.id}`);
+  }
+
+  if (STATUS_ORDER[nextStatus] < STATUS_ORDER[currentStatus]) {
+    throw new Error(`Invalid transition ${currentStatus} -> ${nextStatus}`);
+  }
+
+  frontmatter.status = nextStatus;
+  const body = match[2] || '\n';
+  const nextFrontmatter = yaml.dump(frontmatter, { lineWidth: -1 }).trimEnd();
+  const nextContent = `---\n${nextFrontmatter}\n---${body}`;
+
+  fs.writeFileSync(spec.path, nextContent, 'utf-8');
+
+  return {
+    ok: true,
+    spec: {
+      id: spec.id,
+      status: nextStatus
+    },
+    status: {
+      from: currentStatus,
+      to: nextStatus,
+      changed: true
+    }
+  };
+}
+
 module.exports = {
   getSpecsStatus,
   getSpec,
   createSpec,
   setCurrentSpec,
-  unsetCurrentSpec
+  unsetCurrentSpec,
+  updateSpecStatus
 };

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -56,9 +56,9 @@ Edit the spec file to add/update the Design section.
 - Flowcharts: For complex processes with branches
 
 **Step 5: Update Spec Status**
-Edit the spec frontmatter to update:
-- `status: designed`
-- `updated: <current-timestamp>`
+Execute: `zest-spec update <current-spec-id> designed`
+
+This updates the spec status using the CLI (do not edit frontmatter manually).
 
 **Step 6: Confirm Completion**
 Inform the user:

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -11,7 +11,7 @@ Execute: `zest-spec status`
 Confirm there is a current spec set and status is "designed". If:
 - No current spec: Guide user to set one
 - Status is "new" or "researched": Suggest completing previous phases first
-- Status is "implemented" or "delivered": Confirm if user wants to update existing plan
+- Status is "implemented": Confirm if user wants to update existing plan
 
 **Step 2: Read Current Spec**
 Execute: `zest-spec show <current-spec-id>` to get the spec file path.
@@ -56,9 +56,9 @@ Edit the spec file to add/update the Implementation section.
 - Testing included: Verification is part of implementation
 
 **Step 5: Update Spec Status**
-Edit the spec frontmatter to update:
-- `status: implemented`
-- `updated: <current-timestamp>`
+Execute: `zest-spec update <current-spec-id> implemented`
+
+This updates the spec status using the CLI (do not edit frontmatter manually).
 
 **Step 6: Confirm Completion**
 Inform the user:

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -52,9 +52,9 @@ Edit the spec file to add/update the Research section with:
 - Focus on "why": Document rationale for recommendations
 
 **Step 5: Update Spec Status**
-Edit the spec frontmatter to update:
-- `status: researched`
-- `updated: <current-timestamp>`
+Execute: `zest-spec update <current-spec-id> researched`
+
+This updates the spec status using the CLI (do not edit frontmatter manually).
 
 **Step 6: Confirm Completion**
 Inform the user:

--- a/plugin/commands/summarize.md
+++ b/plugin/commands/summarize.md
@@ -83,9 +83,11 @@ Add an **Implementation Summary** subsection under Plan:
 
 **Step 5: Update Spec Status**
 
-Edit the spec frontmatter to set:
-- `status: <inferred-phase>` (new/researched/designed/implemented)
-- Keep the auto-generated `created` timestamp
+Use `zest-spec update` for status transitions (do not edit frontmatter manually):
+- If inferred phase is `new`: skip status update (new spec is already `new`)
+- If inferred phase is `researched`: execute `zest-spec update <spec-id> researched`
+- If inferred phase is `designed`: execute `zest-spec update <spec-id> designed`
+- If inferred phase is `implemented`: execute `zest-spec update <spec-id> implemented`
 
 **Step 6: Add Notes Section**
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive spec status management capabilities to zest-spec, allowing users to track and update spec progress through a defined workflow.

## Changes

- Added \`zest-spec update <spec> <status>\` command with forward-only status transitions
- Valid statuses: new → researched → designed → implemented (skipping allowed)
- Enhanced \`status\` output to show full current spec object with id, name, path, and status
- Added agent hints when deployed command markdown files are detected
- Changed default status from \"planned\" to \"new\" for better clarity
- Updated all plugin commands (research, design, implement, summarize) to use CLI for status updates
- Added integration tests covering status transitions, edge cases, and agent hints
- Updated documentation in README.md and CLAUDE.md with new commands and examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to update spec status (forward-only transitions: new → researched → designed → implemented).
  * Status defaults changed from "planned" to "new" for newly created specs.

* **Documentation**
  * Updated guides and examples to use the CLI status command and show structured spec output (id, name, path, status).
  * Prompt examples standardized to quoted codex syntax.

* **Tests**
  * Added integration tests covering status updates, transition rules, and related status outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->