### PR TITLE
feat: Migrate spec IDs from numeric to date-based naming

### DIFF
--- a/specs/change/20260210-init-project/spec.md
+++ b/specs/change/20260210-init-project/spec.md
@@ -1,5 +1,5 @@
 ---
-id: "001"
+id: 20260210-init-project
 name: "Init Project"
 status: complete
 created: "2026-02-10"

--- a/specs/change/20260210-replace-lean-spec/spec.md
+++ b/specs/change/20260210-replace-lean-spec/spec.md
@@ -1,5 +1,5 @@
 ---
-id: "002"
+id: 20260210-replace-lean-spec
 name: "Replace Lean Spec"
 status: complete
 created: "2026-02-10"

--- a/specs/change/20260211-codex-compatibility-prompt-command/spec.md
+++ b/specs/change/20260211-codex-compatibility-prompt-command/spec.md
@@ -1,5 +1,5 @@
 ---
-id: "004"
+id: 20260211-codex-compatibility-prompt-command
 name: "Codex Compatibility Prompt Command"
 status: implemented
 created: "2026-02-11"

--- a/specs/change/20260211-plugin-deployment-script/spec.md
+++ b/specs/change/20260211-plugin-deployment-script/spec.md
@@ -1,5 +1,5 @@
 ---
-id: "003"
+id: 20260211-plugin-deployment-script
 name: "Plugin Deployment Script"
 status: implemented
 created: "2026-02-11"

--- a/specs/change/20260224-date-based-spec-naming/spec.md
+++ b/specs/change/20260224-date-based-spec-naming/spec.md
@@ -1,5 +1,5 @@
 ---
-id: '005'
+id: 20260224-date-based-spec-naming
 name: Date Based Spec Naming
 status: implemented
 created: '2026-02-24'


### PR DESCRIPTION
## Summary

This PR migrates all spec IDs from the old numeric format (001, 002, etc.) to date-based naming (20260210-init-project, etc.) to align with the date-based spec naming convention.

## Changes

- Renamed spec directories to use date-based slugs matching their creation dates
- Updated the `id` field in all spec frontmatter from numeric strings to date-based identifiers
- Affected specs: init-project, replace-lean-spec, plugin-deployment-script, codex-compatibility-prompt-command, date-based-spec-naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized specification document identifiers to use a date-based naming convention with descriptive labels for improved organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->