### PR TITLE
feat: add interactive spec selection for set-current

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(chmod:*)",
       "Bash(node bin/zest-dev.js:*)",
       "Bash(du:*)",
-      "Bash(pnpm install:*)"
+      "Bash(pnpm install:*)",
+      "Bash(pnpm test:local:*)"
     ]
   },
   "enabledPlugins": {

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -349,9 +349,29 @@ function updateSpecStatus(specIdentifier, nextStatus) {
   };
 }
 
+/**
+ * List all specs with id, name, status, and current flag
+ */
+function listSpecs() {
+  const specDirs = getSpecDirs();
+  const currentId = getCurrentSpecId();
+
+  return specDirs.map(dir => {
+    const specPath = getSpecFilePath(dir);
+    const frontmatter = parseSpecFrontmatter(specPath);
+    return {
+      id: dir,
+      name: parseSpecName(dir),
+      status: frontmatter.status || 'new',
+      current: dir === currentId
+    };
+  });
+}
+
 module.exports = {
   getSpecsStatus,
   getSpec,
+  listSpecs,
   createSpec,
   setCurrentSpec,
   unsetCurrentSpec,


### PR DESCRIPTION
## Summary

This PR improves the `set-current` workflow by allowing interactive spec selection when no spec ID is provided.

## Changes

- Updated `zest-dev set-current` to accept an optional spec ID and open a selector when omitted
- Added `fzf`-based interactive selection with a numbered `readline` fallback when `fzf` is unavailable
- Added and exported `listSpecs()` in the spec manager to provide spec metadata for the selector
- Added local command permission for `pnpm test:local` in `.claude/settings.local.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive spec picker for `zest-dev set-current` command—allows selection from available specs when no spec ID is provided
  * Supports fzf-based selection with readline fallback for improved workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->