### PR TITLE
fix: parse selected spec ID correctly in fzf mode

### DIFF
--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -51,8 +51,15 @@ async function selectSpecInteractively(specs) {
       return null; // user cancelled
     }
 
-    // Line format: "  <id>  [status]  Name" — ID is after the 2-char mark prefix
-    return result.stdout.trim().slice(2).split(/\s{2,}/)[0];
+    // Line format: "* <id>  [status]  Name" or "  <id>  [status]  Name"
+    // Use end-trim only to preserve leading marker spaces for parsing.
+    const selectedLine = result.stdout.trimEnd();
+    const match = selectedLine.match(/^(?:\* |  )(\S+)/);
+    if (!match) {
+      return null;
+    }
+
+    return match[1];
   }
 
   // Fallback: numbered list via readline


### PR DESCRIPTION
## Summary

This PR fixes a parsing issue in interactive spec selection when using `fzf`. The selected spec ID is now extracted reliably from both selected and unselected list lines.

## Changes

- Updated fzf output parsing to handle both `* ` and two-space line prefixes
- Switched from full trim to end-trim so leading marker spaces are preserved for parsing
- Added a safe regex-based extraction path and fallback to `null` when parsing fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced interactive spec selection parsing in the CLI tool to handle selection inputs more reliably across different format variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->