### PR TITLE
feat: map OpenCode agent deployments to gpt-5.3-codex

### DIFF
--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -2,6 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
+// OpenCode agent model deployed by `zest-dev init`.
+// Update this constant if you want to change the default model later.
+const OPENCODE_AGENT_MODEL = 'openai/gpt-5.3-codex';
+
 /**
  * Parse markdown file with frontmatter
  * @param {string} filePath - Path to markdown file
@@ -190,20 +194,25 @@ function deployAgents() {
     const sourcePath = path.join(agentsDir, filename);
     const { frontmatter, content } = parseMarkdownWithFrontmatter(sourcePath);
 
-    // Keep name, description, and model for agent frontmatter
-    const transformedFrontmatter = {};
-    if (frontmatter.name) transformedFrontmatter.name = frontmatter.name;
-    if (frontmatter.description) transformedFrontmatter.description = frontmatter.description;
-    if (frontmatter.model) transformedFrontmatter.model = frontmatter.model;
+    // Cursor keeps source model; OpenCode uses a dedicated configurable model.
+    const cursorFrontmatter = {};
+    if (frontmatter.name) cursorFrontmatter.name = frontmatter.name;
+    if (frontmatter.description) cursorFrontmatter.description = frontmatter.description;
+    if (frontmatter.model) cursorFrontmatter.model = frontmatter.model;
+
+    const opencodeFrontmatter = {
+      ...cursorFrontmatter,
+      model: OPENCODE_AGENT_MODEL
+    };
 
     // Deploy to Cursor
     const cursorPath = path.join(process.cwd(), '.cursor/agents', filename);
-    writeMarkdownWithFrontmatter(cursorPath, transformedFrontmatter, content);
+    writeMarkdownWithFrontmatter(cursorPath, cursorFrontmatter, content);
     result.cursor.push(filename);
 
     // Deploy to OpenCode
     const opencodePath = path.join(process.cwd(), '.opencode/agents', filename);
-    writeMarkdownWithFrontmatter(opencodePath, transformedFrontmatter, content);
+    writeMarkdownWithFrontmatter(opencodePath, opencodeFrontmatter, content);
     result.opencode.push(filename);
   });
 

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -30,6 +30,11 @@ const EXPECTED_COMMANDS = [
   'zest-dev-summarize-pr.md',
   'zest-dev-quick-implement.md'
 ];
+const EXPECTED_AGENTS = [
+  'code-architect.md',
+  'code-explorer.md',
+  'code-reviewer.md'
+];
 
 function cleanup(testDir = TEST_DIR) {
   if (fs.existsSync(testDir)) {
@@ -70,6 +75,10 @@ function readCommand(target, filename, testDir = TEST_DIR) {
   return fs.readFileSync(path.join(testDir, target, 'commands', filename), 'utf-8');
 }
 
+function readAgent(target, filename, testDir = TEST_DIR) {
+  return fs.readFileSync(path.join(testDir, target, 'agents', filename), 'utf-8');
+}
+
 function extractFrontmatter(content, filename) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   assert.ok(match, `${filename} has no frontmatter`);
@@ -92,14 +101,18 @@ test('zest-dev init integration', async (t) => {
       assert.ok(Array.isArray(result.cursor.commands), 'cursor.commands should be an array');
       assert.ok(Array.isArray(result.opencode.commands), 'opencode.commands should be an array');
       assert.ok(Array.isArray(result.cursor.skills), 'cursor.skills should be an array');
+      assert.ok(Array.isArray(result.cursor.agents), 'cursor.agents should be an array');
+      assert.ok(Array.isArray(result.opencode.agents), 'opencode.agents should be an array');
     });
 
     await t.test('directory structure', () => {
       const expectedDirs = [
         '.cursor/commands',
         '.cursor/skills',
+        '.cursor/agents',
         '.opencode/commands',
-        '.opencode/skills'
+        '.opencode/skills',
+        '.opencode/agents'
       ];
 
       for (const dir of expectedDirs) {
@@ -122,6 +135,26 @@ test('zest-dev init integration', async (t) => {
 
       assert.ok(fs.existsSync(cursorSkillPath), 'Cursor skill file should exist');
       assert.ok(fs.existsSync(opencodeSkillPath), 'OpenCode skill file should exist');
+    });
+
+    await t.test('agents deployment and model mapping', () => {
+      for (const file of EXPECTED_AGENTS) {
+        const cursorPath = path.join(TEST_DIR, '.cursor/agents', file);
+        const opencodePath = path.join(TEST_DIR, '.opencode/agents', file);
+
+        assert.ok(fs.existsSync(cursorPath), `Cursor agent should exist: ${file}`);
+        assert.ok(fs.existsSync(opencodePath), `OpenCode agent should exist: ${file}`);
+
+        const cursorFrontmatter = extractFrontmatter(readAgent('.cursor', file), `.cursor/agents/${file}`);
+        const opencodeFrontmatter = extractFrontmatter(readAgent('.opencode', file), `.opencode/agents/${file}`);
+
+        assert.equal(cursorFrontmatter.model, 'sonnet', `Cursor agent model should remain source model for ${file}`);
+        assert.equal(
+          opencodeFrontmatter.model,
+          'openai/gpt-5.3-codex',
+          `OpenCode agent model should be codex for ${file}`
+        );
+      }
     });
 
     await t.test('frontmatter transformation', () => {


### PR DESCRIPTION
- Add a dedicated OpenCode agent model constant and apply it when deploying agent frontmatter to .opencode/agents while preserving source models for Cursor deployments.
- Expand integration tests to verify agent directories are created, agent files are deployed to both targets, and Cursor/OpenCode model mapping is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent deployment now supports independent model configuration for Cursor and OpenCode targets.

* **Tests**
  * Added integration tests to validate agent deployment and model mapping across deployment targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->