### PR TITLE
feat: document new draft workflow

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(node bin/zest-dev.js:*)",
       "Bash(du:*)",
       "Bash(pnpm install:*)",
-      "Bash(pnpm test:local:*)"
+      "Bash(pnpm test:local:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh run:*)"
     ]
   },
   "enabledPlugins": {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -18,9 +18,12 @@ This plugin integrates the Zest Dev methodology into Claude Code, providing a st
 | Command | Purpose |
 |---------|---------|
 | `/new <description>` | Create a new spec from natural language description |
+| `/draft` | Crystallize a conversation into a spec, then proceed step by step |
 | `/research` | Fill research section and advance to researched phase |
 | `/design` | Fill design section and advance to designed phase |
 | `/implement` | Fill implementation plan and advance to implemented phase |
+| `/summarize-chat` | Capture a completed coding session into a spec (post-hoc) |
+| `/summarize-pr <pr>` | Summarize a GitHub PR into a spec (post-hoc) |
 
 ## Skills
 
@@ -40,10 +43,22 @@ This plugin integrates the Zest Dev methodology into Claude Code, providing a st
 cc --plugin-dir /path/to/zest-dev/plugin
 ```
 
-## Workflow
+## Workflows
 
-1. **Create** - Use `/new` with a description to create a new spec
-2. **Research** - Use `/research` to document research findings
-3. **Design** - Use `/design` to create the design approach
-4. **Implement** - Use `/implement` to create the implementation plan
-5. **Build** - Implement according to the spec
+### Step-by-step (planned)
+Start from a description and work through each phase:
+1. `/new <description>` — create spec with overview
+2. `/research` — explore codebase and options
+3. `/design` — design architecture, choose approach
+4. `/implement` — build the feature
+
+### Vibe coding first (post-hoc)
+Code first, then document what was built:
+1. Write code freely
+2. `/summarize-chat` or `/summarize-pr` — capture into a spec
+
+### Discussion-driven (new)
+Chat and brainstorm first, then formalize and proceed:
+1. Have a free-form discussion about the feature
+2. `/draft` — crystallize discussion into a spec with overview
+3. Optionally continue with `/research`, `/design`, `/implement`

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -1,0 +1,162 @@
+---
+description: Crystallize a discussion into a spec, then proceed step by step
+argument-hint: [optional spec-slug]
+allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
+---
+
+# Draft: Discussion → Spec → Guided Next Steps
+
+Synthesize the current conversation into a well-formed spec, then decide how to continue.
+
+**Spec slug (optional):** $ARGUMENTS
+
+This command is for when you've been chatting and brainstorming with the user and want to formalize the ideas into a spec before implementation. Unlike `/new` (brief description) or `/summarize-chat` (post-hoc capture), `/draft` captures an active discussion in progress and guides the next development steps.
+
+---
+
+## Step 1: Analyze Conversation
+
+Review the conversation history to extract:
+- **Core goal**: What the user ultimately wants to build or solve
+- **Problem context**: Why this matters and what pain it addresses
+- **Ideas discussed**: Approaches, options, constraints mentioned
+- **Open questions**: Things still undecided or unclear
+- **Scope signals**: What's in vs out, even if stated informally
+
+If the conversation is too early or vague to draft a spec, use AskUserQuestion to ask:
+- "What's the core thing you're trying to build?"
+- "What problem does this solve?"
+
+## Step 2: Infer or Confirm Spec Slug
+
+If `$ARGUMENTS` is provided, use it as the spec slug.
+
+Otherwise, infer a kebab-case slug from the main goal.
+Example: "Add webhook support for notifications" → `webhook-notifications`
+
+If unsure, confirm with the user before proceeding.
+
+## Step 3: Create Spec via CLI
+
+Execute: `zest-dev create <spec-slug>`
+
+Then set it as current: `zest-dev set-current <spec-id>`
+
+## Step 4: Fill Overview Section
+
+Read the created spec file from `specs/` directory.
+
+Write the Overview based on the conversation. **Only include sections for information that actually came up** — do not invent or assume details.
+
+**Possible sections (include only if discussed):**
+- **Problem Statement**: What problem is being solved and why it matters
+- **Goals**: What the feature should accomplish
+- **Scope**: What's included vs explicitly excluded
+- **Constraints**: Technical limitations, requirements, or dependencies
+- **Ideas & Approaches**: Options discussed (without picking one — that's for design)
+- **Open Questions**: Things not yet decided
+- **Success Criteria**: How to measure if the feature is successful
+
+**Format:**
+- Use bullet points for clarity
+- Keep descriptions brief (1-2 sentences per item)
+- Focus on "what" and "why", not "how" (implementation comes later)
+- Capture the spirit of the discussion, not a transcript
+
+**Example with discussion context:**
+
+```markdown
+## Overview
+
+### Problem Statement
+- Users lose context when switching between tasks mid-conversation
+- No way to bookmark a discussion state for later
+
+### Goals
+- Let users save and restore conversation checkpoints
+- Support tagging checkpoints for easy retrieval
+
+### Ideas & Approaches
+- Store checkpoints as local files vs remote database (not yet decided)
+- Could piggyback on existing export functionality
+
+### Open Questions
+- Should checkpoints be project-scoped or global?
+- What's the retention policy?
+
+### Constraints
+- Must not break existing conversation flow
+- No changes to backend schema in this phase
+```
+
+## Step 5: Determine Spec Status
+
+Evaluate the conversation to determine the appropriate starting status. Assess each stage in sequence:
+
+**`new`** — the default. The discussion identified the problem and goals but did not explore the codebase or settle on an architecture.
+
+**`researched`** — advance to this if the conversation included genuine codebase exploration: files were read, existing patterns were identified, and available approaches were surfaced. Casual mention of an idea does not count.
+
+**`designed`** — advance to this if the conversation went further and produced a concrete architectural decision: components, data flow, implementation steps, and key trade-offs were resolved and agreed upon.
+
+Apply the highest status the conversation genuinely reached, then execute the CLI command:
+- Status is `new`: no update needed (spec is already `new`)
+- Status is `researched`: fill the Research section from conversation context, then run `zest-dev update current researched`
+- Status is `designed`: fill both Research and Design sections from conversation context, then run `zest-dev update current designed`
+
+When filling sections from conversation context, follow the same content rules as `/research` and `/design` respectively — facts in Research, decisions and architecture in Design.
+
+## Step 6: Ask How to Proceed
+
+After the spec is created and status set, present next-step options **based on the current status**:
+
+**If status is `new`:**
+```
+1. Research — Explore the codebase and identify available approaches
+2. Design — Jump straight to architecture (skip research if not needed)
+3. Research then Design — Do both in sequence
+4. Stop here — I'll continue manually when ready
+```
+
+**If status is `researched`:**
+```
+1. Design — Design the architecture based on research findings
+2. Stop here — I'll continue manually when ready
+```
+
+**If status is `designed`:**
+```
+1. Implement — Start building the feature
+2. Stop here — I'll continue manually when ready
+```
+
+Use AskUserQuestion with these options, or proceed directly if the conversation makes the answer obvious.
+
+## Step 7: Execute Chosen Path
+
+Based on the user's choice:
+
+- **Research**: Proceed as `/research` would — clarify requirements, launch explorer agents, document findings, update status to `researched`
+- **Design**: Proceed as `/design` would — identify underspecified aspects, ask clarifying questions, launch architect agents, document chosen design, update status to `designed`
+- **Research then Design**: Run research phase fully, then run design phase
+- **Implement**: Guide user to `/implement` (do not run it inline — implementation is long-running)
+- **Stop here**: Confirm the spec is saved and guide them to the appropriate next command
+
+## Step 8: Confirm Completion
+
+Inform the user:
+- Spec id and name
+- Spec file location: `specs/<spec-id>/spec.md`
+- What sections were filled in Overview
+- Current status and what was run (if research/design was executed)
+- Next command to use when they're ready to continue
+
+---
+
+## Important Notes
+
+- **This is a discussion → spec bridge**: The goal is to capture what was talked about, not to start fresh
+- **Preserve open questions**: If something was undecided in conversation, record it as an open question — don't resolve it silently
+- **Don't fill in gaps**: If the user didn't discuss scope, don't invent scope
+- **Ideas ≠ Design**: Capture brainstormed approaches in "Ideas & Approaches" — leave evaluation for the design phase
+- **Lean toward asking**: When unsure whether to proceed with research or design, ask

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Zest Dev
-description: This skill should be used when the user asks to "create a spec", "write a spec", mentions "zest dev", "zest-dev", "spec-driven development", "human-interactive development", workflow phases like "research phase", "design phase", "implement phase", or asks "how do I write a spec", "what's the spec process", "spec methodology", or needs guidance on specification planning and development workflows.
+description: This skill should be used when the user asks to "create a spec", "write a spec", mentions "zest dev", "zest-dev", "spec-driven development", "human-interactive development", workflow phases like "research phase", "design phase", "implement phase", asks "how do I write a spec", "what's the spec process", "spec methodology", needs guidance on specification planning and development workflows, or wants to know which workflow to use ("draft", "summarize", "new", "vibe coding").
 version: 0.1.0
 ---
 
@@ -230,6 +230,30 @@ created: 2026-02-10
 ## Implementation
 [Task checklist, files, testing, progress]
 ```
+
+## Choosing a Workflow
+
+There are three ways to enter the workflow depending on how you started:
+
+### Step-by-step (planned)
+You know what you want to build. Start from a description and work through each phase:
+```
+/new <description> → /research → /design → /implement
+```
+
+### Vibe coding first (post-hoc)
+You coded freely and want to document after the fact:
+```
+/summarize-chat   ← from conversation
+/summarize-pr     ← from a PR
+```
+
+### Discussion-driven (draft)
+You've been discussing or brainstorming the idea and want to formalize it before coding:
+```
+/draft → (optionally) /research → (optionally) /design → /implement
+```
+Use `/draft` when you've had a meaningful conversation about the feature and want to crystallize the ideas into a spec before deciding how to proceed. Unlike `/new` (brief description → minimal spec), `/draft` captures the full context of the discussion and then asks how you want to continue.
 
 ## Adapting the Workflow
 

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -23,6 +23,7 @@ const CREATE_TEST_DIR = path.join(__dirname, '../test-project-create-temp');
 const EXPECTED_COMMANDS = [
   'zest-dev-compound.md',
   'zest-dev-design.md',
+  'zest-dev-draft.md',
   'zest-dev-implement.md',
   'zest-dev-new.md',
   'zest-dev-research.md',


### PR DESCRIPTION
## Summary

This PR adds documentation and tooling for a discussion-driven workflow so chats can be crystallized into specs before implementation.

## Changes

- add the `/draft` command guide and workflow steps for capturing conversations into specs
- expand the plugin README with the new commands and workflow flows
- clarify the Zest Dev skill description with workflow entry guidance for draft, new, and summarize modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/draft` to turn conversations into specs.
  * Added `/summarize-chat` and `/summarize-pr` for post-hoc spec capture.

* **Documentation**
  * Introduced three workflow modes: step-by-step planning, post-hoc documentation, and discussion-driven formalization.
  * Added workflow-selection guidance to help choose between `/new`, `/draft`, `/summarize-*`, and vibe-coding approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->