### PR TITLE
feat: rename active change spec workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Zest dev
-specs/change/current
+specs/change/active
 
 # Generated plugin deployment directories
 .cursor/**/zest-dev/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ To manually test the CLI during development:
 node bin/zest-dev.js status
 node bin/zest-dev.js show 20260224-init-project
 node bin/zest-dev.js create <slug>
-node bin/zest-dev.js set-current <spec-id>
-node bin/zest-dev.js unset-current
+node bin/zest-dev.js set-active <spec-id>
+node bin/zest-dev.js unset-active
 node bin/zest-dev.js update <spec-id> <status>
 ```
 
@@ -82,11 +82,13 @@ Specs are stored in `specs/change/`. Managed via `zest-dev` CLI.
 | Command                         | Purpose                    |
 | ------------------------------- | -------------------------- |
 | `zest-dev status`              | View project status        |
-| `zest-dev show <spec-id\|current>` | View spec content          |
+| `zest-dev show <spec-id\|active>` | View spec content          |
 | `zest-dev create <slug>`           | Create new spec            |
-| `zest-dev set-current <spec-id>`   | Set current working spec   |
-| `zest-dev unset-current`           | Unset current working spec |
-| `zest-dev update <spec-id\|current> <status>` | Update spec status |
+| `zest-dev set-active <spec-id>`   | Set active change spec   |
+| `zest-dev unset-active`           | Unset active change spec |
+| `zest-dev update <spec-id\|active> <status>` | Update spec status |
+
+Archive is handled through agent/editor workflows (`/zest-dev:archive` or `zest-dev prompt archive`), not a public CLI subcommand.
 
 ### Spec content rules
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ codex "$(zest-dev prompt summarize)"
 ```
 project/
 ├── specs/
-│   └── change/
+│   ├── change/
 │       ├── 20260224-init-project/
 │       │   └── spec.md
 │       ├── 20260225-feature-name/
 │       │   └── spec.md
 │       └── active -> 20260225-feature-name (symlink)
-│   ├── current/
+│   └── current/
 │       └── implementation.md
 └── .zest-dev/
     └── template/

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ npm install -g zest-dev
 Work through a feature spec one phase at a time, with human review between each stage.
 
 ```bash
-/zest-dev:new "My new feature"   # Create a spec and set it as current
+/zest-dev:new "My new feature"   # Create a spec and set it as active
 /zest-dev:research            # Research requirements and explore the codebase
 /zest-dev:design              # Clarify requirements and design the architecture
 /zest-dev:implement           # Build the feature following the design
+/zest-dev:archive             # Agent-guided merge into specs/current, then unset active
 ```
 
 Each command advances the spec to the next status: `new → researched → designed → implemented`.
@@ -45,7 +46,7 @@ Start from a description:
 Or start from an existing spec:
 
 ```bash
-zest-dev set-current <spec-id>
+zest-dev set-active <spec-id>
 /zest-dev:quick-implement
 ```
 
@@ -68,12 +69,14 @@ The `zest-dev` CLI manages spec files. Use it to inspect and update specs outsid
 | Command | Purpose |
 |---------|---------|
 | `zest-dev status` | View project status |
-| `zest-dev show <spec-id\|current>` | View spec content |
+| `zest-dev show <spec-id\|active>` | View spec content |
 | `zest-dev create <slug>` | Create new spec |
-| `zest-dev set-current <spec-id>` | Set current working spec |
-| `zest-dev unset-current` | Unset current working spec |
-| `zest-dev update <spec-id> <status>` | Update spec status |
-| `zest-dev create-branch` | Create a git branch from the current spec |
+| `zest-dev set-active <spec-id>` | Set active change spec |
+| `zest-dev unset-active` | Unset active change spec |
+| `zest-dev update <spec-id\|active> <status>` | Update spec status |
+| `zest-dev create-branch` | Create a git branch from the active change spec |
+
+Archive is intentionally **not** a public CLI subcommand. Use `/zest-dev:archive` in plugin-enabled editors or `zest-dev prompt archive` for prompt-driven flows.
 
 ### Status Transitions
 
@@ -92,6 +95,7 @@ codex "$(zest-dev prompt new 'some description')"
 codex "$(zest-dev prompt research)"
 codex "$(zest-dev prompt design)"
 codex "$(zest-dev prompt implement)"
+codex "$(zest-dev prompt archive)"
 codex "$(zest-dev prompt summarize)"
 ```
 
@@ -105,7 +109,9 @@ project/
 │       │   └── spec.md
 │       ├── 20260225-feature-name/
 │       │   └── spec.md
-│       └── current -> 20260225-feature-name (symlink)
+│       └── active -> 20260225-feature-name (symlink)
+│   ├── current/
+│       └── implementation.md
 └── .zest-dev/
     └── template/
         └── spec.md

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -11,10 +11,10 @@ const {
   getSpec,
   listSpecs,
   createSpec,
-  setCurrentSpec,
-  unsetCurrentSpec,
+  setActiveChangeSpec,
+  unsetActiveChangeSpec,
   updateSpecStatus,
-  createBranchFromCurrentSpec
+  createBranchFromActiveChangeSpec
 } = require('../lib/spec-manager');
 const { deployPlugin } = require('../lib/plugin-deployer');
 const { generatePrompt } = require('../lib/prompt-generator');
@@ -36,7 +36,7 @@ async function selectSpecInteractively(specs) {
   }
 
   const lines = specs.map(s => {
-    const mark = s.current ? '* ' : '  ';
+    const mark = s.active ? '* ' : '  ';
     return `${mark}${s.id}  [${s.status}]  ${s.name}`;
   });
 
@@ -65,7 +65,7 @@ async function selectSpecInteractively(specs) {
   // Fallback: numbered list via readline
   process.stderr.write('Select a spec:\n');
   specs.forEach((s, i) => {
-    const mark = s.current ? '*' : ' ';
+    const mark = s.active ? '*' : ' ';
     process.stderr.write(`  ${mark} ${i + 1}. ${s.id}  [${s.status}]  ${s.name}\n`);
   });
 
@@ -119,7 +119,7 @@ program
     }
   });
 
-// zest-dev show <spec_number|current>
+// zest-dev show <spec_id|active>
 program
   .command('show <spec>')
   .description('Show spec details')
@@ -147,10 +147,11 @@ program
     }
   });
 
-// zest-dev set-current [spec_id]
+// zest-dev set-active [spec_id]
 program
-  .command('set-current [spec]')
-  .description('Set the current spec (interactive picker when no ID given)')
+  .command('set-active [spec]')
+  .alias('set-current')
+  .description('Set the active change spec (interactive picker when no ID given)')
   .action(async (spec) => {
     try {
       if (!spec) {
@@ -161,7 +162,7 @@ program
           process.exit(1);
         }
       }
-      const result = setCurrentSpec(spec);
+      const result = setActiveChangeSpec(spec);
       console.log(yaml.dump(result));
     } catch (error) {
       console.error('Error:', error.message);
@@ -169,13 +170,14 @@ program
     }
   });
 
-// zest-dev unset-current
+// zest-dev unset-active
 program
-  .command('unset-current')
-  .description('Unset the current spec')
+  .command('unset-active')
+  .alias('unset-current')
+  .description('Unset the active change spec')
   .action(() => {
     try {
-      const result = unsetCurrentSpec();
+      const result = unsetActiveChangeSpec();
       console.log(yaml.dump(result));
     } catch (error) {
       console.error('Error:', error.message);
@@ -183,7 +185,7 @@ program
     }
   });
 
-// zest-dev update <spec_number|current> <status>
+// zest-dev update <spec_id|active> <status>
 program
   .command('update <spec> <status>')
   .description('Update spec status')
@@ -200,10 +202,10 @@ program
 // zest-dev create-branch
 program
   .command('create-branch')
-  .description('Create and switch to a git branch from the current spec slug')
+  .description('Create and switch to a git branch from the active change spec slug')
   .action(() => {
     try {
-      const result = createBranchFromCurrentSpec();
+      const result = createBranchFromActiveChangeSpec();
       console.log(yaml.dump(result));
     } catch (error) {
       console.error('Error:', error.message);

--- a/lib/prompt-generator.js
+++ b/lib/prompt-generator.js
@@ -3,12 +3,12 @@ const path = require('path');
 
 /**
  * Generate a prompt for Codex editor
- * @param {string} command - Command name (new, research, design, implement, summarize)
+ * @param {string} command - Command name (new, research, design, implement, summarize, archive)
  * @param {string} args - Command arguments (for 'new' command, this is the task description)
  * @returns {string} - The formatted prompt
  */
 function generatePrompt(command, args = '') {
-  const validCommands = ['new', 'research', 'design', 'implement', 'summarize'];
+  const validCommands = ['new', 'research', 'design', 'implement', 'summarize', 'archive'];
 
   if (!validCommands.includes(command)) {
     throw new Error(`Invalid command: ${command}. Must be one of: ${validCommands.join(', ')}`);

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -4,7 +4,8 @@ const yaml = require('js-yaml');
 const { execSync, spawnSync } = require('child_process');
 
 const SPECS_DIR = 'specs/change';
-const CURRENT_LINK = path.join(SPECS_DIR, 'current');
+const ACTIVE_CHANGE_LINK = path.join(SPECS_DIR, 'active');
+const LEGACY_CURRENT_LINK = path.join(SPECS_DIR, 'current');
 const TEMPLATE_PATH = '.zest-dev/template/spec.md';
 const DEFAULT_TEMPLATE_PATH = path.join(__dirname, 'template', 'spec.md');
 const VALID_STATUSES = ['new', 'researched', 'designed', 'implemented'];
@@ -51,19 +52,23 @@ function parseSpecName(dirName) {
 }
 
 /**
- * Get current spec ID (full directory name, e.g. "20260224-init-project")
+ * Get active change spec ID (full directory name, e.g. "20260224-init-project")
  */
-function getCurrentSpecId() {
-  if (!pathExistsIncludingDanglingSymlink(CURRENT_LINK)) {
+function readSpecLinkId(linkPath) {
+  if (!pathExistsIncludingDanglingSymlink(linkPath)) {
     return null;
   }
 
   try {
-    const linkTarget = fs.readlinkSync(CURRENT_LINK);
+    const linkTarget = fs.readlinkSync(linkPath);
     return path.basename(linkTarget);
   } catch (error) {
     return null;
   }
+}
+
+function getActiveChangeSpecId() {
+  return readSpecLinkId(ACTIVE_CHANGE_LINK) || readSpecLinkId(LEGACY_CURRENT_LINK);
 }
 
 /**
@@ -93,26 +98,26 @@ function parseSpecFrontmatter(filePath) {
  */
 function getSpecsStatus() {
   const specDirs = getSpecDirs();
-  const currentId = getCurrentSpecId();
-  let current = null;
+  const activeId = getActiveChangeSpecId();
+  let active_change = null;
 
-  if (currentId) {
-    const specDir = specDirs.find(dir => dir === currentId);
+  if (activeId) {
+    const specDir = specDirs.find(dir => dir === activeId);
 
     if (specDir) {
       const specPath = getSpecFilePath(specDir);
       const frontmatter = parseSpecFrontmatter(specPath);
 
-      current = {
-        id: currentId,
+      active_change = {
+        id: activeId,
         name: parseSpecName(specDir),
         path: specPath,
         status: frontmatter.status || 'new'
       };
     } else {
-      // Keep id visible even if current symlink points to a removed spec.
-      current = {
-        id: currentId,
+      // Keep id visible even if active symlink points to a removed spec.
+      active_change = {
+        id: activeId,
         name: null,
         path: null,
         status: null
@@ -122,7 +127,7 @@ function getSpecsStatus() {
 
   return {
     specs_count: specDirs.length,
-    current
+    active_change
   };
 }
 
@@ -143,15 +148,15 @@ function getSpecFilePath(specDir) {
 }
 
 /**
- * Get spec details by ID (full dir name) or "current"
+ * Get spec details by ID (full dir name) or "active"
  */
 function getSpec(specIdentifier) {
   let specId = specIdentifier;
 
-  if (specIdentifier === 'current') {
-    specId = getCurrentSpecId();
+  if (specIdentifier === 'active' || specIdentifier === 'current') {
+    specId = getActiveChangeSpecId();
     if (!specId) {
-      throw new Error('No current spec set');
+      throw new Error('No active change spec set');
     }
   }
 
@@ -164,13 +169,13 @@ function getSpec(specIdentifier) {
 
   const specPath = getSpecFilePath(specDir);
   const frontmatter = parseSpecFrontmatter(specPath);
-  const currentId = getCurrentSpecId();
+  const activeId = getActiveChangeSpecId();
 
   return {
     id: specId,
     name: parseSpecName(specDir),
     path: specPath,
-    current: specId === currentId,
+    active: specId === activeId,
     status: frontmatter.status || 'new'
   };
 }
@@ -219,16 +224,16 @@ function createSpec(slug) {
       id: specDirName,
       name: name,
       path: specPath,
-      current: false,
+      active: false,
       status: 'new'
     }
   };
 }
 
 /**
- * Set current spec
+ * Set active change spec
  */
-function setCurrentSpec(specId) {
+function setActiveChangeSpec(specId) {
   // Allow full relative paths like "specs/20260224-foo" or "specs/20260224-foo/"
   specId = path.basename(specId.replace(/\/+$/, ''));
   const specDirs = getSpecDirs();
@@ -238,35 +243,41 @@ function setCurrentSpec(specId) {
     throw new Error(`Spec ${specId} not found`);
   }
 
-  // Remove existing symlink if it exists
-  if (pathExistsIncludingDanglingSymlink(CURRENT_LINK)) {
-    fs.unlinkSync(CURRENT_LINK);
+  // Remove existing symlinks if they exist
+  if (pathExistsIncludingDanglingSymlink(ACTIVE_CHANGE_LINK)) {
+    fs.unlinkSync(ACTIVE_CHANGE_LINK);
+  }
+  if (pathExistsIncludingDanglingSymlink(LEGACY_CURRENT_LINK)) {
+    fs.unlinkSync(LEGACY_CURRENT_LINK);
   }
 
   // Create new symlink
-  const linkPath = path.resolve(CURRENT_LINK);
+  const linkPath = path.resolve(ACTIVE_CHANGE_LINK);
   const linkDir = path.dirname(linkPath);
   const relativePath = path.relative(linkDir, path.resolve(SPECS_DIR, specDir));
 
-  fs.symlinkSync(relativePath, CURRENT_LINK);
+  fs.symlinkSync(relativePath, ACTIVE_CHANGE_LINK);
 
   return {
     ok: true,
-    current: specId
+    active_change: specId
   };
 }
 
 /**
- * Unset current spec
+ * Unset active change spec
  */
-function unsetCurrentSpec() {
-  if (pathExistsIncludingDanglingSymlink(CURRENT_LINK)) {
-    fs.unlinkSync(CURRENT_LINK);
+function unsetActiveChangeSpec() {
+  if (pathExistsIncludingDanglingSymlink(ACTIVE_CHANGE_LINK)) {
+    fs.unlinkSync(ACTIVE_CHANGE_LINK);
+  }
+  if (pathExistsIncludingDanglingSymlink(LEGACY_CURRENT_LINK)) {
+    fs.unlinkSync(LEGACY_CURRENT_LINK);
   }
 
   return {
     ok: true,
-    current: null
+    active_change: null
   };
 }
 
@@ -278,18 +289,18 @@ function getSpecSlug(dirName) {
 }
 
 /**
- * Create a git branch from the current spec's slug
+ * Create a git branch from the active change spec's slug
  */
-function createBranchFromCurrentSpec() {
-  const currentId = getCurrentSpecId();
-  if (!currentId) {
-    throw new Error('No current spec set');
+function createBranchFromActiveChangeSpec() {
+  const activeId = getActiveChangeSpecId();
+  if (!activeId) {
+    throw new Error('No active change spec set');
   }
 
   const specDirs = getSpecDirs();
-  const specDir = specDirs.find(dir => dir === currentId);
+  const specDir = specDirs.find(dir => dir === activeId);
   if (!specDir) {
-    throw new Error(`Spec ${currentId} not found`);
+    throw new Error(`Spec ${activeId} not found`);
   }
 
   const slug = getSpecSlug(specDir);
@@ -359,11 +370,11 @@ function updateSpecStatus(specIdentifier, nextStatus) {
 }
 
 /**
- * List all specs with id, name, status, and current flag
+ * List all specs with id, name, status, and active flag
  */
 function listSpecs() {
   const specDirs = getSpecDirs();
-  const currentId = getCurrentSpecId();
+  const activeId = getActiveChangeSpecId();
 
   return specDirs.map(dir => {
     const specPath = getSpecFilePath(dir);
@@ -372,7 +383,7 @@ function listSpecs() {
       id: dir,
       name: parseSpecName(dir),
       status: frontmatter.status || 'new',
-      current: dir === currentId
+      active: dir === activeId
     };
   });
 }
@@ -382,8 +393,12 @@ module.exports = {
   getSpec,
   listSpecs,
   createSpec,
-  setCurrentSpec,
-  unsetCurrentSpec,
+  setActiveChangeSpec,
+  unsetActiveChangeSpec,
   updateSpecStatus,
-  createBranchFromCurrentSpec
+  createBranchFromActiveChangeSpec,
+  // Backwards-compatible internal aliases
+  setCurrentSpec: setActiveChangeSpec,
+  unsetCurrentSpec: unsetActiveChangeSpec,
+  createBranchFromCurrentSpec: createBranchFromActiveChangeSpec
 };

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,7 +10,7 @@ This plugin integrates the Zest Dev methodology into Claude Code, providing a st
 
 - **Spec creation** - Create new specs from natural language descriptions
 - **Phase management** - Guide specs through research → design → implementation phases
-- **Current spec context** - All commands work with the currently active spec
+- **Active change spec context** - All commands work with the active change spec
 - **CLI integration** - Seamlessly integrates with the `zest-dev` CLI tool
 
 ## Commands
@@ -22,6 +22,7 @@ This plugin integrates the Zest Dev methodology into Claude Code, providing a st
 | `/research` | Fill research section and advance to researched phase |
 | `/design` | Fill design section and advance to designed phase |
 | `/implement` | Fill implementation plan and advance to implemented phase |
+| `/archive` | Merge implemented active change spec knowledge into `specs/current/`, then unset active |
 | `/summarize-chat` | Capture a completed coding session into a spec (post-hoc) |
 | `/summarize-pr <pr>` | Summarize a GitHub PR into a spec (post-hoc) |
 
@@ -51,6 +52,7 @@ Start from a description and work through each phase:
 2. `/research` — explore codebase and options
 3. `/design` — design architecture, choose approach
 4. `/implement` — build the feature
+5. `/archive` — merge into `specs/current/` and unset active change spec
 
 ### Vibe coding first (post-hoc)
 Code first, then document what was built:

--- a/plugin/commands/archive.md
+++ b/plugin/commands/archive.md
@@ -1,0 +1,48 @@
+---
+description: Merge implemented active change spec into current specs and unset active
+allowed-tools: Read, Edit, Write, Bash(zest-dev:*), Glob, Grep
+---
+
+# Archive Active Change Spec
+
+Merge the implemented active change spec into `specs/current/` files, then unset the active change spec.
+
+## Step 1: Verify active change spec is ready
+
+1. Run `zest-dev status` and confirm there is an active change spec.
+2. Run `zest-dev show active` and confirm status is `implemented`.
+
+If not implemented, stop and tell the user to run implementation and set status first.
+
+## Step 2: Inspect existing `specs/current/`
+
+Inspect `specs/current/` files to understand current organization and topics before editing.
+
+## Step 3: Decide merge targets and shape
+
+Read the active change spec and decide how its knowledge should be merged into `specs/current/`.
+
+- Prefer semantic placement over rigid heading-to-file rules.
+- Update existing topic files when appropriate.
+- Create new topic files when needed.
+- Keep `specs/current/` concise and coherent.
+
+If merge target or structure is unclear, ask the user a short clarifying question before editing.
+
+## Step 4: Perform the merge directly in files
+
+Apply the chosen edits directly to `specs/current/` markdown files.
+
+## Step 5: Unset active change spec
+
+After merge edits are complete, run:
+
+`zest-dev unset-active`
+
+## Step 6: Report result
+
+Provide a concise summary including:
+- active change spec id
+- updated `specs/current/` files
+- whether a clarification was needed
+- confirmation that `zest-dev unset-active` succeeded

--- a/plugin/commands/archive.md
+++ b/plugin/commands/archive.md
@@ -1,6 +1,6 @@
 ---
 description: Merge implemented active change spec into current specs and unset active
-allowed-tools: Read, Edit, Write, Bash(zest-dev:*), Glob, Grep
+allowed-tools: Read, Edit, Write, Bash(zest-dev:*), Glob, Grep, AskUserQuestion
 ---
 
 # Archive Active Change Spec
@@ -12,7 +12,7 @@ Merge the implemented active change spec into `specs/current/` files, then unset
 1. Run `zest-dev status` and confirm there is an active change spec.
 2. Run `zest-dev show active` and confirm status is `implemented`.
 
-If not implemented, stop and tell the user to run implementation and set status first.
+If not implemented, stop and ask the user to run implementation and set status first.
 
 ## Step 2: Inspect existing `specs/current/`
 

--- a/plugin/commands/compound.md
+++ b/plugin/commands/compound.md
@@ -21,7 +21,7 @@ Every solved problem, key decision, or discovered pattern exists only in the cur
 ## Step 1: Check Project State
 
 Run `zest-dev status` to determine:
-- Whether there is a current spec set
+- Whether there is an active change spec set
 - The list of existing specs (for historical placement)
 
 ---
@@ -33,11 +33,11 @@ Present the user with storage options using AskUserQuestion. Build the options d
 **Always include:**
 - `specs/solutions/` — standalone solutions folder, for general knowledge not tied to a specific spec
 
-**Include if a current spec is set:**
-- Current spec folder: `specs/<current-spec-directory>/` — knowledge directly related to the work in progress
+**Include if an active change spec is set:**
+- Active change spec folder: `specs/change/<active-spec-directory>/` — knowledge directly related to the work in progress
 
 **Include if historical specs exist:**
-- A historical spec — let the user type the spec id directly (e.g. `20260224-my-feature`), then resolve details by running `zest-dev show <spec-id>`
+- A historical change spec — let the user type the spec id directly (e.g. `20260224-my-feature`), then resolve details by running `zest-dev show <spec-id>`
 
 ---
 
@@ -79,8 +79,8 @@ Create a slug-style filename that describes the content:
 
 Determine the final path based on the user's choice in Step 2:
 - Standalone: `specs/solutions/<filename>.md`
-- Current spec: `specs/<current-spec-directory>/<filename>.md`
-- Historical spec: `specs/<historical-spec-directory>/<filename>.md`
+- Active change spec: `specs/change/<active-spec-directory>/<filename>.md`
+- Historical spec: `specs/change/<historical-spec-directory>/<filename>.md`
 
 Create the directory if it does not exist (`mkdir -p`).
 

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -11,16 +11,16 @@ Resolve ambiguities and design implementation approaches with trade-offs before 
 
 **CRITICAL**: This is one of the most important steps. DO NOT SKIP.
 
-**Step 1: Verify Current Spec**
+**Step 1: Verify Active Change Spec**
 Execute: `zest-dev status`
 
-Confirm there is a current spec set and status is "researched". If:
-- No current spec: Guide user to set one
+Confirm there is an active change spec set and status is "researched". If:
+- No active change spec: Guide user to set one
 - Status is "new": Suggest completing `/research` first
 - Status is "designed" or later: Confirm if user wants to update existing design
 
-**Step 2: Read Current Spec**
-Execute: `zest-dev show current` to get the spec file path.
+**Step 2: Read Active Change Spec**
+Execute: `zest-dev show active` to get the spec file path.
 
 Read the spec file to understand:
 - Overview and problem statement
@@ -126,7 +126,7 @@ When filling Plan, keep it high-level — name what each phase covers, not indiv
 2-3 phases maximum. Do not nest sub-tasks under phases. These boxes will be checked off during the Implement stage.
 
 **Step 10: Update Spec Status**
-Execute: `zest-dev update current designed`
+Execute: `zest-dev update active designed`
 
 This updates the spec status using the CLI (do not edit frontmatter manually).
 

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -40,11 +40,11 @@ If unsure, confirm with the user before proceeding.
 
 Execute: `zest-dev create <spec-slug>`
 
-Then set it as current: `zest-dev set-current <spec-id>`
+Then set it as active: `zest-dev set-active <spec-id>`
 
 ## Step 4: Fill Overview Section
 
-Read the created spec file from `specs/` directory.
+Read the created spec file from `specs/change/`.
 
 Write the Overview based on the conversation. **Only include sections for information that actually came up** — do not invent or assume details.
 
@@ -101,8 +101,8 @@ Evaluate the conversation to determine the appropriate starting status. Assess e
 
 Apply the highest status the conversation genuinely reached, then execute the CLI command:
 - Status is `new`: no update needed (spec is already `new`)
-- Status is `researched`: fill the Research section from conversation context, then run `zest-dev update current researched`
-- Status is `designed`: fill both Research and Design sections from conversation context, then run `zest-dev update current designed`
+- Status is `researched`: fill the Research section from conversation context, then run `zest-dev update active researched`
+- Status is `designed`: fill both Research and Design sections from conversation context, then run `zest-dev update active designed`
 
 When filling sections from conversation context, follow the same content rules as `/research` and `/design` respectively — facts in Research, decisions and architecture in Design.
 
@@ -146,7 +146,7 @@ Based on the user's choice:
 
 Inform the user:
 - Spec id and name
-- Spec file location: `specs/<spec-id>/spec.md`
+- Spec file location: `specs/change/<spec-id>/spec.md`
 - What sections were filled in Overview
 - Current status and what was run (if research/design was executed)
 - Next command to use when they're ready to continue

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -7,16 +7,16 @@ allowed-tools: Read, Edit, Write, Bash, Task, Glob, Grep, TodoWrite
 
 Implement the feature following the design and document what was built.
 
-**Step 1: Verify Current Spec**
+**Step 1: Verify Active Change Spec**
 Execute: `zest-dev status`
 
-Confirm there is a current spec set and status is "designed". If:
-- No current spec: Guide user to set one
+Confirm there is an active change spec set and status is "designed". If:
+- No active change spec: Guide user to set one
 - Status is "new" or "researched": Suggest completing previous phases first
 - Status is "implemented": Confirm if user wants to continue/update implementation
 
-**Step 2: Read Current Spec**
-Execute: `zest-dev show current` to get the spec file path.
+**Step 2: Read Active Change Spec**
+Execute: `zest-dev show active` to get the spec file path.
 
 **IMPORTANT**: Read all research and design content before coding.
 
@@ -69,7 +69,7 @@ Edit the spec file to fill the `### Implementation` and `### Verification` subse
 Keep both sections brief. Use bullet points. Skip a subsection entirely if there's nothing worth noting.
 
 **Step 7: Update Spec Status**
-Execute: `zest-dev update current implemented`
+Execute: `zest-dev update active implemented`
 
 This updates the spec status using the CLI (do not edit frontmatter manually).
 

--- a/plugin/commands/new.md
+++ b/plugin/commands/new.md
@@ -23,19 +23,19 @@ Analyze the user's description and determine:
 Execute: `zest-dev create <spec-slug>`
 
 This will:
-- Create the spec file in `specs/` directory with a date-based id (e.g. `20260224-spec-slug`)
+- Create the spec file in `specs/change/` with a date-based id (e.g. `20260224-spec-slug`)
 - Generate frontmatter with `name` and `status`
 - Initialize empty sections
 
-**Step 3: Set as Current Spec**
+**Step 3: Set as Active Change Spec**
 
-Execute: `zest-dev set-current <spec-id>`
+Execute: `zest-dev set-active <spec-id>`
 
 Use the `id` from the created spec's CLI output (e.g. `20260224-spec-slug`).
 
 **Step 4: Understand the Feature**
 
-Read the created spec file from `specs/` directory.
+Read the created spec file from `specs/change/`.
 
 Evaluate the user's description:
 - **If comprehensive** (clear problem, scope, and context):
@@ -118,8 +118,8 @@ Full (user provided all details):
 
 Inform the user:
 - ✅ Spec id: `<spec-id>` (e.g. `20260224-spec-slug`), name: `<spec-name>`
-- ✅ Spec file location: `specs/<spec-id>/spec.md`
-- ✅ Set as current working spec
+- ✅ Spec file location: `specs/change/<spec-id>/spec.md`
+- ✅ Set as active change spec
 - ✅ Overview section completed
 
 **Next steps:**

--- a/plugin/commands/quick-implement.md
+++ b/plugin/commands/quick-implement.md
@@ -9,8 +9,8 @@ allowed-tools: Read, Edit, Write, Bash, Task, Glob, Grep, TodoWrite, AskUserQues
 Run through all remaining workflow stages — research, design, implement, and final review — in a single command. Suitable for straightforward, well-scoped tasks.
 
 Handles two scenarios:
-- **New requirement**: No current spec — creates a spec, confirms requirements, then runs all stages.
-- **Existing spec**: A spec is already set as current — picks up from the appropriate stage based on its status.
+- **New requirement**: No active change spec — creates a spec, confirms requirements, then runs all stages.
+- **Existing spec**: An active change spec is already set — picks up from the appropriate stage based on its status.
 
 **User's description:** $ARGUMENTS
 
@@ -18,10 +18,10 @@ Handles two scenarios:
 
 ## Step 0: Detect Starting Point
 
-Run `zest-dev status` to check if there is a current spec set.
+Run `zest-dev status` to check if there is an active change spec set.
 
-**If a current spec exists:**
-- Run `zest-dev show current` to read its content and current status
+**If an active change spec exists:**
+- Run `zest-dev show active` to read its content and status
 - Skip ahead based on status:
   - `new` → skip "New" and "Checkpoint 1", go directly to [Stage 1: Research](#stage-1-research)
   - `researched` → skip to [Stage 2: Design](#stage-2-design)
@@ -29,14 +29,14 @@ Run `zest-dev status` to check if there is a current spec set.
   - `implemented` → inform the user the spec is already fully implemented and exit
 - Create a task list covering only the remaining stages
 
-**If no current spec exists:**
+**If no active change spec exists:**
 - Proceed to the [New](#new) section below
 
 ---
 
 ## New
 
-*Only when no current spec exists.*
+*Only when no active change spec exists.*
 
 **Step 1: Create Spec**
 
@@ -46,7 +46,7 @@ Analyze the user's description and determine:
 
 Execute: `zest-dev create <spec-slug>`
 
-Then set it as current: `zest-dev set-current <spec-id>` (use the `id` from the create output, e.g. `20260224-spec-slug`)
+Then set it as active: `zest-dev set-active <spec-id>` (use the `id` from the create output, e.g. `20260224-spec-slug`)
 
 **Step 2: Fill Overview Section**
 
@@ -114,7 +114,7 @@ Edit the spec file's Research section with findings:
 
 **Step 8: Update Status**
 
-Execute: `zest-dev update current researched`
+Execute: `zest-dev update active researched`
 
 ---
 
@@ -138,7 +138,7 @@ Edit the spec file's Design section with the chosen architecture:
 
 **Step 11: Update Status**
 
-Execute: `zest-dev update current designed`
+Execute: `zest-dev update active designed`
 
 ---
 
@@ -192,7 +192,7 @@ Edit the spec file's Implementation section:
 
 **Step 16: Update Status**
 
-Execute: `zest-dev update current implemented`
+Execute: `zest-dev update active implemented`
 
 ---
 
@@ -223,4 +223,4 @@ Mark all todo items complete and inform the user:
 ## Important Notes
 
 - **Simple tasks only**: For complex features with many unknowns, use the individual stage commands (`/research`, `/design`, `/implement`) for more thorough handling.
-- **Picks up from current status**: If a spec is already in progress, this command continues from where it left off.
+- **Picks up from current status**: If an active change spec is already in progress, this command continues from where it left off.

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -11,15 +11,15 @@ Understand the feature requirements deeply and explore existing codebase pattern
 
 ## Discovery & Verification
 
-**Step 1: Verify Current Spec**
+**Step 1: Verify Active Change Spec**
 Execute: `zest-dev status`
 
-Confirm there is a current spec set. If no current spec:
+Confirm there is an active change spec set. If no active change spec:
 - Inform user no spec is currently active
-- Guide them to use `/new` to create a spec or `zest-dev set-current <spec-id>` to select one
+- Guide them to use `/new` to create a spec or `zest-dev set-active <spec-id>` to select one
 
-**Step 2: Read Current Spec**
-Execute: `zest-dev show current` to get the spec file path.
+**Step 2: Read Active Change Spec**
+Execute: `zest-dev show active` to get the spec file path.
 
 Read the spec file to understand:
 - The overview and problem statement
@@ -114,7 +114,7 @@ Edit the spec file to add/update the Research section.
 ```
 
 **Step 8: Update Spec Status**
-Execute: `zest-dev update current researched`
+Execute: `zest-dev update active researched`
 
 This updates the spec status using the CLI (do not edit frontmatter manually).
 

--- a/plugin/commands/summarize-chat.md
+++ b/plugin/commands/summarize-chat.md
@@ -47,13 +47,13 @@ Example: "Plugin deployment script" → "plugin-deployment-script"
 Execute: `zest-dev create <spec-slug>`
 
 This will:
-- Create the spec file in `specs/` directory
+- Create the spec file in `specs/change/`
 - Generate unique ID and frontmatter
 - Initialize empty sections
 
 **Step 4: Fill Spec Sections**
 
-Read the created spec file from the `specs/` directory.
+Read the created spec file from `specs/change/`.
 
 Fill sections based on the status:
 
@@ -96,9 +96,9 @@ Fill sections based on the status:
 
 Use `zest-dev update` for status transitions (do not edit frontmatter manually):
 - If inferred status is `new`: skip status update (new spec is already `new`)
-- If inferred status is `researched`: execute `zest-dev update current researched`
-- If inferred status is `designed`: execute `zest-dev update current designed`
-- If inferred status is `implemented`: execute `zest-dev update current implemented`
+- If inferred status is `researched`: execute `zest-dev update active researched`
+- If inferred status is `designed`: execute `zest-dev update active designed`
+- If inferred status is `implemented`: execute `zest-dev update active implemented`
 
 **Step 6: Add Notes Section**
 
@@ -111,7 +111,7 @@ Add relevant notes:
 
 **Step 7: Confirm and Show Result**
 
-Execute: `zest-dev show current`
+Execute: `zest-dev show active`
 
 Inform the user:
 - Spec has been created with ID and name

--- a/plugin/commands/summarize-pr.md
+++ b/plugin/commands/summarize-pr.md
@@ -34,13 +34,13 @@ Read the created file and fill sections. Keep content concise — omit subsectio
 **Step 4: Update status**
 
 ```
-zest-dev update current implemented
+zest-dev update active implemented
 ```
 
 **Step 5: Show result**
 
 ```
-zest-dev show current
+zest-dev show active
 ```
 
 **Guidelines:**

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -176,20 +176,22 @@ User Request → Check Cache → Found?
 zest-dev create <spec-slug>     # Create new spec
 zest-dev status                 # View all specs
 zest-dev show <spec-id>         # View specific spec (e.g. 20260224-my-feature)
-zest-dev set-current <spec-id>  # Set current spec
-zest-dev unset-current          # Unset current
+zest-dev set-active <spec-id>   # Set active change spec
+zest-dev unset-active           # Unset active change spec
 ```
+
+Archive is an agent workflow command (`/zest-dev:archive`) or prompt flow (`zest-dev prompt archive`), not a public CLI subcommand.
 
 **Important:** Never manually create spec files or edit frontmatter. Always use CLI.
 
-### Current Spec Context
+### Active Change Spec Context
 
-The "current spec" is the active specification. Plugin commands automatically operate on the current spec.
+The active change spec is the selected in-progress change specification. Plugin commands automatically operate on the active change spec.
 
 **Workflow:**
-1. Create spec (auto-sets as current)
+1. Create spec (auto-sets as active)
 2. Work through phases with plugin commands
-3. Switch specs via `zest-dev set-current <spec-id>`
+3. Switch specs via `zest-dev set-active <spec-id>`
 
 ## Best Practices
 

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -189,9 +189,10 @@ Archive is an agent workflow command (`/zest-dev:archive`) or prompt flow (`zest
 The active change spec is the selected in-progress change specification. Plugin commands automatically operate on the active change spec.
 
 **Workflow:**
-1. Create spec (auto-sets as active)
-2. Work through phases with plugin commands
-3. Switch specs via `zest-dev set-active <spec-id>`
+1. Create spec
+2. Set it as active via `zest-dev set-active <spec-id>`
+3. Work through phases with plugin commands
+4. Switch specs via `zest-dev set-active <spec-id>`
 
 ## Best Practices
 

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -21,6 +21,7 @@ const CLI_COMMAND = process.env.ZEST_DEV_CLI_PATH
 const TEST_DIR = path.join(__dirname, '../test-project-temp');
 const CREATE_TEST_DIR = path.join(__dirname, '../test-project-create-temp');
 const EXPECTED_COMMANDS = [
+  'zest-dev-archive.md',
   'zest-dev-compound.md',
   'zest-dev-design.md',
   'zest-dev-draft.md',
@@ -88,17 +89,17 @@ function extractFrontmatter(content, filename) {
   return frontmatter;
 }
 
-function createDanglingCurrentSymlink(targetId, testDir = TEST_DIR) {
-  const currentLinkPath = path.join(testDir, 'specs/change/current');
+function createDanglingActiveSymlink(targetId, testDir = TEST_DIR) {
+  const activeLinkPath = path.join(testDir, 'specs/change/active');
 
   try {
-    fs.lstatSync(currentLinkPath);
-    fs.unlinkSync(currentLinkPath);
+    fs.lstatSync(activeLinkPath);
+    fs.unlinkSync(activeLinkPath);
   } catch (error) {
     // ignore: link does not exist
   }
 
-  fs.symlinkSync(targetId, currentLinkPath);
+  fs.symlinkSync(targetId, activeLinkPath);
 }
 
 test('zest-dev init integration', async (t) => {
@@ -309,49 +310,40 @@ test('zest-dev status integration', async (t) => {
     runCreate('first-spec');
     runCreate('second-spec');
 
-    await t.test('current is null when not set', () => {
+    await t.test('active_change is null when not set', () => {
       const status = yaml.load(runCommand('status'));
       assert.equal(status.specs_count, 2);
-      assert.equal(status.current, null);
+      assert.equal(status.active_change, null);
       assert.equal(status.agent_hints, undefined);
     });
 
-    await t.test('current is an object when set', () => {
-      const secondResult = yaml.load(runCommand('status'));
-      // Get the second spec's id from the spec listing via show
-      // We need to find the id of 'second-spec' — create outputs were not captured, so list all specs
-      // by creating a second spec and capturing its id
-      // Re-run: we already ran runCreate('second-spec') above, so re-query via a fresh create would fail.
-      // Instead, capture from the initial creates by restructuring the test.
-      // Since we can't easily get it here, use show current after set-current on first spec
-      // and derive second spec id from status after the first set-current.
-      // Simplest fix: run status before set-current to find spec ids from paths isn't available.
+    await t.test('active_change is an object when set', () => {
       // Use the fact that both specs were created today — find by slug suffix.
       const specs = fs.readdirSync(path.join(TEST_DIR, 'specs/change'))
         .filter(d => /^\d{8}-/.test(d));
       const secondSpecDir = specs.find(d => d.endsWith('-second-spec'));
       assert.ok(secondSpecDir, 'second-spec directory should exist');
 
-      runCommand(`set-current ${secondSpecDir}`);
+      runCommand(`set-active ${secondSpecDir}`);
       const status = yaml.load(runCommand('status'));
 
       assert.equal(status.specs_count, 2);
-      assert.equal(typeof status.current, 'object');
-      assert.equal(status.current.id, secondSpecDir);
-      assert.equal(status.current.name, 'Second Spec');
-      assert.equal(status.current.path, path.join('specs/change', secondSpecDir, 'spec.md'));
-      assert.equal(status.current.status, 'new');
+      assert.equal(typeof status.active_change, 'object');
+      assert.equal(status.active_change.id, secondSpecDir);
+      assert.equal(status.active_change.name, 'Second Spec');
+      assert.equal(status.active_change.path, path.join('specs/change', secondSpecDir, 'spec.md'));
+      assert.equal(status.active_change.status, 'new');
       assert.equal(status.agent_hints, undefined);
     });
 
-    await t.test('status shows dangling current symlink with null fields', () => {
+    await t.test('status shows dangling active symlink with null fields', () => {
       const missingSpecId = '19990101-removed-spec';
-      createDanglingCurrentSymlink(missingSpecId);
+      createDanglingActiveSymlink(missingSpecId);
 
       const status = yaml.load(runCommand('status'));
 
       assert.equal(status.specs_count, 2);
-      assert.deepEqual(status.current, {
+      assert.deepEqual(status.active_change, {
         id: missingSpecId,
         name: null,
         path: null,
@@ -359,27 +351,27 @@ test('zest-dev status integration', async (t) => {
       });
     });
 
-    await t.test('set-current replaces dangling current symlink', () => {
+    await t.test('set-active replaces dangling active symlink', () => {
       const specs = fs.readdirSync(path.join(TEST_DIR, 'specs/change'))
         .filter(d => /^\d{8}-/.test(d));
       const firstSpecDir = specs.find(d => d.endsWith('-first-spec'));
       assert.ok(firstSpecDir, 'first-spec directory should exist');
 
-      createDanglingCurrentSymlink('19990101-removed-spec');
-      runCommand(`set-current ${firstSpecDir}`);
+      createDanglingActiveSymlink('19990101-removed-spec');
+      runCommand(`set-active ${firstSpecDir}`);
 
       const status = yaml.load(runCommand('status'));
-      assert.equal(status.current.id, firstSpecDir);
+      assert.equal(status.active_change.id, firstSpecDir);
     });
 
-    await t.test('unset-current removes dangling current symlink', () => {
-      const currentLinkPath = path.join(TEST_DIR, 'specs/change/current');
-      createDanglingCurrentSymlink('19990101-removed-spec');
+    await t.test('unset-active removes dangling active symlink', () => {
+      const activeLinkPath = path.join(TEST_DIR, 'specs/change/active');
+      createDanglingActiveSymlink('19990101-removed-spec');
 
-      const result = yaml.load(runCommand('unset-current'));
+      const result = yaml.load(runCommand('unset-active'));
       assert.equal(result.ok, true);
-      assert.equal(result.current, null);
-      assert.throws(() => fs.lstatSync(currentLinkPath), /ENOENT/);
+      assert.equal(result.active_change, null);
+      assert.throws(() => fs.lstatSync(activeLinkPath), /ENOENT/);
     });
 
     await t.test('agent hint appears when deployed zest command markdown exists', () => {
@@ -460,6 +452,37 @@ test('zest-dev update integration', async (t) => {
         /Invalid status "planned"\. Valid: new, researched, designed, implemented/
       );
     });
+
+    await t.test('accepts active alias for show/update', () => {
+      const aliasSpecId = yaml.load(runCreate('alias-spec')).spec.id;
+      runCommand(`set-active ${aliasSpecId}`);
+      const showActive = yaml.load(runCommand('show active'));
+      assert.equal(showActive.id, aliasSpecId);
+
+      const updateActive = yaml.load(runCommand('update active implemented'));
+      assert.equal(updateActive.ok, true);
+      assert.equal(updateActive.spec.id, aliasSpecId);
+      assert.equal(updateActive.spec.status, 'implemented');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('zest-dev prompt archive integration', () => {
+  setup();
+
+  try {
+    const prompt = runCommand('prompt archive');
+    assert.ok(prompt.includes('Archive Active Change Spec'));
+    assert.ok(prompt.includes('zest-dev show active'));
+    assert.ok(prompt.includes('zest-dev unset-active'));
+    assert.equal(prompt.includes('zest-dev archive active --no-merge'), false);
+
+    runInit();
+    const deployedArchive = readCommand('.cursor', 'zest-dev-archive.md');
+    assert.ok(deployedArchive.includes('zest-dev unset-active'));
+    assert.equal(deployedArchive.includes('zest-dev archive active --no-merge'), false);
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary
- rename the current working spec concept to an active change spec across the CLI, docs, plugin commands, and tests
- add archive as an agent-driven workflow via `/zest-dev:archive` and `zest-dev prompt archive` instead of a public CLI subcommand
- update integration coverage for active aliases, deployed archive command content, and packaged CLI behavior

## Testing
- pnpm test:local
- pnpm test:package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Archive workflow/command flow to merge and finalize an active change spec (prompt/editor and prompt-generator support).

* **Refactor**
  * Replaced the “current” spec concept with “active” across the CLI and tooling (aliases preserved).
  * `create-branch` and related commands now operate from the active change spec.

* **Documentation**
  * Updated CLI help and all workflow docs to use “active” terminology.

* **Tests**
  * Integration tests updated to exercise active-spec flows and archive prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->