### PR TITLE
fix: enforce user-language responses in plugin commands

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -15,6 +15,8 @@ This plugin integrates the Zest Dev methodology into Claude Code, providing a st
 
 ## Commands
 
+All command flows keep responding in the user's language unless the user asks to switch languages.
+
 | Command | Purpose |
 |---------|---------|
 | `/new <description>` | Create a new spec from natural language description |

--- a/plugin/commands/archive.md
+++ b/plugin/commands/archive.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Edit, Write, Bash(zest-dev:*), Glob, Grep, AskUserQuestion
 
 Merge the implemented active change spec into `specs/current/` files, then unset the active change spec.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 ## Step 1: Verify active change spec is ready
 
 1. Run `zest-dev status` and confirm there is an active change spec.

--- a/plugin/commands/compound.md
+++ b/plugin/commands/compound.md
@@ -8,6 +8,8 @@ allowed-tools: Read, Write, Bash(zest-dev:*), AskUserQuestion
 
 Capture knowledge, decisions, and hard-won experience from the current conversation into a permanent, searchable document.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 **Topic hint (if provided):** $ARGUMENTS
 
 ---

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Edit, Bash(zest-dev:*), Task, AskUserQuestion, TodoWrite
 
 Resolve ambiguities and design implementation approaches with trade-offs before coding.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 ## Clarifying Questions
 
 **CRITICAL**: This is one of the most important steps. DO NOT SKIP.

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -8,6 +8,8 @@ allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
 
 Synthesize the current conversation into a well-formed spec, then decide how to continue.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 **Spec slug (optional):** $ARGUMENTS
 
 This command is for when you've been chatting and brainstorming with the user and want to formalize the ideas into a spec before implementation. Unlike `/new` (brief description) or `/summarize-chat` (post-hoc capture), `/draft` captures an active discussion in progress and guides the next development steps.

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Edit, Write, Bash, Task, Glob, Grep, TodoWrite
 
 Implement the feature following the design and document what was built.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 **Step 1: Verify Active Change Spec**
 Execute: `zest-dev status`
 

--- a/plugin/commands/new.md
+++ b/plugin/commands/new.md
@@ -8,6 +8,8 @@ allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
 
 Create a new feature specification from the user's description and prepare for development.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 **User's description:** $ARGUMENTS
 
 ---

--- a/plugin/commands/quick-implement.md
+++ b/plugin/commands/quick-implement.md
@@ -8,6 +8,8 @@ allowed-tools: Read, Edit, Write, Bash, Task, Glob, Grep, TodoWrite, AskUserQues
 
 Run through all remaining workflow stages — research, design, implement, and final review — in a single command. Suitable for straightforward, well-scoped tasks.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 Handles two scenarios:
 - **New requirement**: No active change spec — creates a spec, confirms requirements, then runs all stages.
 - **Existing spec**: An active change spec is already set — picks up from the appropriate stage based on its status.

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Edit, Bash(zest-dev:*), Task, Glob, Grep, TodoWrite
 
 Understand the feature requirements deeply and explore existing codebase patterns before design.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 ---
 
 ## Discovery & Verification

--- a/plugin/commands/summarize-chat.md
+++ b/plugin/commands/summarize-chat.md
@@ -8,6 +8,8 @@ allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
 
 Capture the current conversation and development work into a structured feature spec.
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 **Spec slug (optional):** $ARGUMENTS
 
 This command is designed for capturing "vibe coding" sessions where you've been coding and realized the work is worth documenting.

--- a/plugin/commands/summarize-pr.md
+++ b/plugin/commands/summarize-pr.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(zest-dev:*), AskUserQuestion
 
 # Summarize GitHub PR into Spec
 
+**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
 **Arguments:** $ARGUMENTS
 - PR number (optional, defaults to current branch's PR)
 

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -37,6 +37,8 @@ const EXPECTED_AGENTS = [
   'code-explorer.md',
   'code-reviewer.md'
 ];
+const LANGUAGE_ALIGNMENT_RULE =
+  'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.';
 
 function cleanup(testDir = TEST_DIR) {
   if (fs.existsSync(testDir)) {
@@ -140,6 +142,18 @@ test('zest-dev init integration', async (t) => {
         for (const file of EXPECTED_COMMANDS) {
           const filePath = path.join(TEST_DIR, target, 'commands', file);
           assert.ok(fs.existsSync(filePath), `${target} command should exist: ${file}`);
+        }
+      }
+    });
+
+    await t.test('command language alignment rule', () => {
+      for (const target of ['.cursor', '.opencode']) {
+        for (const file of EXPECTED_COMMANDS) {
+          const content = readCommand(target, file);
+          assert.ok(
+            content.includes(LANGUAGE_ALIGNMENT_RULE),
+            `${target}/commands/${file} should include the language alignment rule`
+          );
         }
       }
     });


### PR DESCRIPTION
## Summary
- add a hard language-alignment rule to every plugin command template so responses stay in the user's language unless they ask to switch
- document the language consistency rule in the plugin README
- add integration coverage to verify deployed command files include the rule after init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added language handling guidelines to command documentation, specifying that responses follow the user's language preference throughout all workflows.

* **Tests**
  * Added integration test to verify language rule consistency across all command documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->