### PR TITLE
fix: support incremental implement phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 .llm-chat-history/
+.opencode/
 
 # Local debug conversation captures
 specs/change/20260226-cursor-debug-mode-skill/cursor-debug-mode-conversations/

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -79,7 +79,8 @@ Support incremental delivery by phase:
 Always update status via the CLI (do not edit frontmatter manually).
 
 **Step 8: Confirm Progress or Completion**
-Mark todo items complete and inform user:
+Mark only the todo items for the work completed in this run, leaving future phases unchecked. Then inform user:
 - ✅ Implemented scope completed (phase or full spec)
 - ✅ Spec status updated appropriately (only set to `implemented` when full spec is done)
+- ✅ Relevant todo items updated for this run
 - ✅ Implementation documented

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -70,13 +70,16 @@ Edit the spec file to fill the `### Implementation` and `### Verification` subse
 
 Keep both sections brief. Use bullet points. Skip a subsection entirely if there's nothing worth noting.
 
-**Step 7: Update Spec Status**
-Execute: `zest-dev update active implemented`
+**Step 7: Update Spec Status (Only When Fully Complete)**
+Support incremental delivery by phase:
+- If only part of the spec is implemented (for example, one phase), **do not** mark status as `implemented` yet.
+- Keep status at its current in-progress phase until all planned work for the spec is complete.
+- Only when the full spec is complete, execute: `zest-dev update active implemented`
 
-This updates the spec status using the CLI (do not edit frontmatter manually).
+Always update status via the CLI (do not edit frontmatter manually).
 
-**Step 8: Confirm Completion**
+**Step 8: Confirm Progress or Completion**
 Mark todo items complete and inform user:
-- ✅ Implementation complete
-- ✅ Spec status updated to "implemented"
+- ✅ Implemented scope completed (phase or full spec)
+- ✅ Spec status updated appropriately (only set to `implemented` when full spec is done)
 - ✅ Implementation documented

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -501,3 +501,22 @@ test('zest-dev prompt archive integration', () => {
     cleanup();
   }
 });
+
+test('zest-dev prompt implement supports incremental phases', () => {
+  setup();
+
+  try {
+    const prompt = runCommand('prompt implement');
+    assert.ok(prompt.includes('Step 7: Update Spec Status (Only When Fully Complete)'));
+    assert.ok(prompt.includes('If only part of the spec is implemented'));
+    assert.ok(prompt.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
+
+    runInit();
+    const deployedImplement = readCommand('.cursor', 'zest-dev-implement.md');
+    assert.ok(deployedImplement.includes('Step 7: Update Spec Status (Only When Fully Complete)'));
+    assert.ok(deployedImplement.includes('If only part of the spec is implemented'));
+    assert.ok(deployedImplement.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- update the implement workflow so partial phase work does not automatically mark a spec as `implemented`
- clarify that status should only move to `implemented` when the full spec is complete
- add integration coverage for both `zest-dev prompt implement` and deployed `zest-dev-implement.md`