### PR TITLE
refactor: simplify OpenCode-only plugin deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,25 @@
 
 Zest Dev: A lightweight, human-interactive development workflow for AI-assisted coding.
 
+## Command Prompt Environment
+
+This repository's custom command prompts are designed for **OpenCode / oh-my-opencode-slim**, not Claude Code.
+
+### Prompt writing guidance
+
+- Write prompts in terms of **capabilities and roles**, not Claude-specific tool names or fixed implementations.
+- Prefer flexible role names such as **explorer subagent**, **architect subagent**, and **reviewer subagent**.
+- Do **not** hardcode specific oh-my-opencode-slim agent handles in prompts unless there is a strong reason; let the runtime choose the best matching subagent.
+- For user interaction, say **ask the user directly** or **use the question tool** rather than Claude-specific names.
+- For codebase work, describe the goal (read files, search code, inspect references, run shell commands) rather than enumerating a Claude-only tool contract.
+
+### Prompt format constraints
+
+- Do **not** rely on `allowed-tools` frontmatter for deployed OpenCode commands. Our deploy step strips non-OpenCode frontmatter and keeps only `description`.
+- `argument-hint` may exist in source command files for authoring convenience, but it is not preserved in deployed `.opencode/commands/` files.
+- Avoid prompt text that assumes Claude Code-only primitives such as `AskUserQuestion` or Claude-specific plugin agent names.
+- When describing delegation, prefer generic subagent language over implementation-specific names so the same prompt remains portable across OpenCode setups.
+
 ## Development
 
 ### Testing Zest Dev CLI

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -216,7 +216,7 @@ program
 // zest-dev init
 program
   .command('init')
-  .description('Initialize plugin deployment to .cursor and .opencode directories')
+  .description('Initialize plugin deployment to .opencode directories')
   .action(() => {
     try {
       const result = deployPlugin();

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -76,6 +76,11 @@ function ensureDirectories() {
  */
 function cleanupLegacyAgentFiles() {
   const agentsDir = path.join(process.cwd(), '.opencode/agents');
+  const legacyAgentFilenames = new Set([
+    'code-architect.md',
+    'code-explorer.md',
+    'code-reviewer.md'
+  ]);
 
   if (!fs.existsSync(agentsDir)) {
     return;
@@ -83,7 +88,7 @@ function cleanupLegacyAgentFiles() {
 
   const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
   entries.forEach(entry => {
-    if (entry.isFile()) {
+    if (entry.isFile() && legacyAgentFilenames.has(entry.name)) {
       fs.unlinkSync(path.join(agentsDir, entry.name));
     }
   });

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -2,10 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-// OpenCode agent model deployed by `zest-dev init`.
-// Update this constant if you want to change the default model later.
-const OPENCODE_AGENT_MODEL = 'openai/gpt-5.3-codex';
-
 /**
  * Parse markdown file with frontmatter
  * @param {string} filePath - Path to markdown file
@@ -32,7 +28,7 @@ function parseMarkdownWithFrontmatter(filePath) {
 }
 
 /**
- * Transform frontmatter for Cursor/OpenCode (remove Claude Code specific fields)
+ * Transform frontmatter for OpenCode (remove Claude Code specific fields)
  * @param {Object} frontmatter - Original frontmatter object
  * @returns {Object} Transformed frontmatter with only description
  */
@@ -62,12 +58,8 @@ function writeMarkdownWithFrontmatter(targetPath, frontmatter, content) {
  */
 function ensureDirectories() {
   const dirs = [
-    '.cursor/commands',
-    '.cursor/skills',
-    '.cursor/agents',
     '.opencode/commands',
-    '.opencode/skills',
-    '.opencode/agents'
+    '.opencode/skills'
   ];
 
   dirs.forEach(dir => {
@@ -98,8 +90,8 @@ function copyDirectoryRecursive(source, target) {
 }
 
 /**
- * Deploy command files to Cursor and OpenCode directories
- * @returns {{ cursor: string[], opencode: string[] }} Deployed file lists
+ * Deploy command files to OpenCode directory
+ * @returns {string[]} Deployed file lists
  */
 function deployCommands() {
   const sourceDir = path.join(__dirname, '../plugin/commands');
@@ -107,10 +99,7 @@ function deployCommands() {
     .filter(f => f.endsWith('.md'))
     .sort(); // Ensure consistent order
 
-  const result = {
-    cursor: [],
-    opencode: []
-  };
+  const result = [];
 
   commandFiles.forEach(filename => {
     const sourcePath = path.join(sourceDir, filename);
@@ -122,23 +111,18 @@ function deployCommands() {
     // Generate prefixed filename
     const prefixedFilename = `zest-dev-${filename}`;
 
-    // Deploy to Cursor
-    const cursorPath = path.join(process.cwd(), '.cursor/commands', prefixedFilename);
-    writeMarkdownWithFrontmatter(cursorPath, transformedFrontmatter, content);
-    result.cursor.push(prefixedFilename);
-
     // Deploy to OpenCode
     const opencodePath = path.join(process.cwd(), '.opencode/commands', prefixedFilename);
     writeMarkdownWithFrontmatter(opencodePath, transformedFrontmatter, content);
-    result.opencode.push(prefixedFilename);
+    result.push(prefixedFilename);
   });
 
   return result;
 }
 
 /**
- * Deploy skill files to Cursor and OpenCode directories
- * @returns {{ cursor: string[], opencode: string[] }} Deployed directory lists
+ * Deploy skill files to OpenCode directory
+ * @returns {string[]} Deployed directory lists
  */
 function deploySkills() {
   const skillsDir = path.join(__dirname, '../plugin/skills');
@@ -147,73 +131,16 @@ function deploySkills() {
     .map(entry => entry.name)
     .sort();
 
-  const result = {
-    cursor: [],
-    opencode: []
-  };
+  const result = [];
 
   skillDirs.forEach(skillName => {
     const sourceDir = path.join(skillsDir, skillName);
-
-    // Copy to Cursor
-    const cursorTarget = path.join(process.cwd(), '.cursor/skills', skillName);
-    fs.mkdirSync(cursorTarget, { recursive: true });
-    copyDirectoryRecursive(sourceDir, cursorTarget);
-    result.cursor.push(skillName + '/');
 
     // Copy to OpenCode
     const opencodeTarget = path.join(process.cwd(), '.opencode/skills', skillName);
     fs.mkdirSync(opencodeTarget, { recursive: true });
     copyDirectoryRecursive(sourceDir, opencodeTarget);
-    result.opencode.push(skillName + '/');
-  });
-
-  return result;
-}
-
-/**
- * Deploy agent files to Cursor and OpenCode directories
- * @returns {{ cursor: string[], opencode: string[] }} Deployed file lists
- */
-function deployAgents() {
-  const agentsDir = path.join(__dirname, '../plugin/agents');
-  const result = {
-    cursor: [],
-    opencode: []
-  };
-
-  if (!fs.existsSync(agentsDir)) {
-    return result;
-  }
-
-  const agentFiles = fs.readdirSync(agentsDir)
-    .filter(f => f.endsWith('.md'))
-    .sort();
-
-  agentFiles.forEach(filename => {
-    const sourcePath = path.join(agentsDir, filename);
-    const { frontmatter, content } = parseMarkdownWithFrontmatter(sourcePath);
-
-    // Cursor keeps source model; OpenCode uses a dedicated configurable model.
-    const cursorFrontmatter = {};
-    if (frontmatter.name) cursorFrontmatter.name = frontmatter.name;
-    if (frontmatter.description) cursorFrontmatter.description = frontmatter.description;
-    if (frontmatter.model) cursorFrontmatter.model = frontmatter.model;
-
-    const opencodeFrontmatter = {
-      ...cursorFrontmatter,
-      model: OPENCODE_AGENT_MODEL
-    };
-
-    // Deploy to Cursor
-    const cursorPath = path.join(process.cwd(), '.cursor/agents', filename);
-    writeMarkdownWithFrontmatter(cursorPath, cursorFrontmatter, content);
-    result.cursor.push(filename);
-
-    // Deploy to OpenCode
-    const opencodePath = path.join(process.cwd(), '.opencode/agents', filename);
-    writeMarkdownWithFrontmatter(opencodePath, opencodeFrontmatter, content);
-    result.opencode.push(filename);
+    result.push(skillName + '/');
   });
 
   return result;
@@ -240,24 +167,18 @@ function deployPlugin() {
     // 4. Deploy skills
     const skillsResult = deploySkills();
 
-    // 5. Deploy agents
-    const agentsDir = path.join(__dirname, '../plugin/agents');
-    const agentsResult = fs.existsSync(agentsDir)
-      ? deployAgents()
-      : { cursor: [], opencode: [] };
-
-    // 6. Return result grouped by target
+    // 5. Return result grouped by target
     return {
       ok: true,
       cursor: {
-        commands: commandsResult.cursor,
-        skills: skillsResult.cursor,
-        agents: agentsResult.cursor
+        commands: [],
+        skills: [],
+        agents: []
       },
       opencode: {
-        commands: commandsResult.opencode,
-        skills: skillsResult.opencode,
-        agents: agentsResult.opencode
+        commands: commandsResult,
+        skills: skillsResult,
+        agents: []
       }
     };
   } catch (error) {

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -69,6 +69,27 @@ function ensureDirectories() {
 }
 
 /**
+ * Remove legacy deployed agent files without deleting directories
+ *
+ * Legacy installs may have written files into .opencode/agents.
+ * We no longer deploy agents, but should clean stale files on init.
+ */
+function cleanupLegacyAgentFiles() {
+  const agentsDir = path.join(process.cwd(), '.opencode/agents');
+
+  if (!fs.existsSync(agentsDir)) {
+    return;
+  }
+
+  const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+  entries.forEach(entry => {
+    if (entry.isFile()) {
+      fs.unlinkSync(path.join(agentsDir, entry.name));
+    }
+  });
+}
+
+/**
  * Copy directory recursively
  * @param {string} source - Source directory
  * @param {string} target - Target directory
@@ -160,6 +181,9 @@ function deployPlugin() {
 
     // 2. Create target directories
     ensureDirectories();
+
+    // 2.5. Clean stale legacy agent files (do not remove directories)
+    cleanupLegacyAgentFiles();
 
     // 3. Deploy commands
     const commandsResult = deployCommands();

--- a/plugin/commands/archive.md
+++ b/plugin/commands/archive.md
@@ -1,6 +1,5 @@
 ---
 description: Merge implemented active change spec into current specs and unset active
-allowed-tools: Read, Edit, Write, Bash(zest-dev:*), Glob, Grep, AskUserQuestion
 ---
 
 # Archive Active Change Spec

--- a/plugin/commands/compound.md
+++ b/plugin/commands/compound.md
@@ -1,7 +1,6 @@
 ---
 description: Document knowledge and experience from the current session into a permanent record
 argument-hint: "[optional: brief topic hint]"
-allowed-tools: Read, Write, Bash(zest-dev:*), AskUserQuestion
 ---
 
 # Compound: Knowledge Documentation
@@ -30,7 +29,7 @@ Run `zest-dev status` to determine:
 
 ## Step 2: Ask Where to Save
 
-Present the user with storage options using AskUserQuestion. Build the options dynamically based on the output of Step 1:
+Present the user with storage options using the question tool. Build the options dynamically based on the output of Step 1:
 
 **Always include:**
 - `specs/solutions/` — standalone solutions folder, for general knowledge not tied to a specific spec

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -1,6 +1,5 @@
 ---
 description: Clarify requirements and design architecture
-allowed-tools: Read, Edit, Bash(zest-dev:*), Task, AskUserQuestion, TodoWrite
 ---
 
 # Design: Clarify Requirements & Design Architecture
@@ -49,7 +48,7 @@ Review the codebase findings and original feature request to identify:
 - **Testing strategy**: What needs tests, testing approach
 
 **Step 5: Ask Clarifying Questions**
-**Present all questions to the user in a clear, organized list** using AskUserQuestion when multiple choice, or direct questions for open-ended queries.
+**Present all questions to the user in a clear, organized list**. Use the question tool for multiple-choice checkpoints, or ask directly for open-ended input.
 
 **Wait for answers before proceeding to architecture design.**
 
@@ -57,32 +56,33 @@ If the user says "whatever you think is best", provide your recommendation and g
 
 ## Architecture Design
 
-**Step 6: Launch Architect Agents**
-Launch 2-3 code-architect agents **in parallel** using the Task tool with different lenses:
-- **Reuse / low-risk lens**: Smallest safe change, maximum reuse of existing code
-- **Maintainability / system-design lens**: Long-term clarity, abstractions, architectural consistency
-- **Delivery pragmatism lens**: Fastest practical path with acceptable quality and validation
+**Step 6: Develop the Architecture Recommendation**
+Form the architecture recommendation yourself, using repository evidence first.
 
-Treat these agents as **research inputs**, not as user-facing option generators.
-Do not ask them to manufacture contrast or intentionally produce extreme alternatives.
+When extra design validation is useful, delegate selectively:
+- Use explorer subagents to verify existing patterns or affected modules
+- Use architect subagents to generate candidate directions or pressure-test the design
+- Use reviewer subagents for high-value critique, trade-off analysis, or synthesis feedback
 
-Each agent should provide:
-- Recommended architecture from its lens
+Treat delegated findings as **inputs**, not as user-facing option generators.
+
+The design pass should produce:
+- A recommended architecture
 - Architecture overview with components
 - Implementation approach
-- Trade-offs (pros/cons)
+- Key trade-offs
 - Files to create or modify
-- Which parts are true architectural differences vs tuning/degree differences
-- Which ideas from other likely approaches could be combined safely
+- Which differences are truly architectural vs mere tuning
+- Any ideas that can be safely combined
 
 **Step 7: Synthesize Findings & Form Opinion**
-Review all agent outputs and synthesize them into a single recommended architecture by default.
+Review all subagent outputs and synthesize them into a single recommended architecture by default.
 
 The main agent should:
 - Extract shared recommendations and constraints
 - Merge compatible strengths from different agents
 - Discard clearly inferior, redundant, or theatrical extreme proposals
-- Decide whether one subagent's proposal is already clearly correct as-is
+- Decide whether one delegated recommendation is already clearly correct as-is
 - Form a strong opinion on the best fit for this specific task and repository
 
 Consider:
@@ -107,13 +107,13 @@ Ask the user to choose only if one or more of these is true:
 
 Do **not** ask the user to choose when:
 - One direction is clearly best for the issue and repository
-- One subagent's proposal is clearly correct and the others are weaker variations
+- One delegated recommendation is clearly correct and the others are weaker variations
 - Differences are only about abstraction level, naming, file split, sequencing, or other implementation tuning
 - The alternatives are artificial extremes (for example: too minimal, too overengineered, and one obvious middle ground)
 
 If user choice is **not** needed:
 - Present one recommended architecture
-- Briefly explain what was synthesized from the subagent findings
+- Briefly explain what was synthesized from the delegated findings
 - Proceed directly to documenting the design
 
 If user choice **is** needed:

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -1,7 +1,6 @@
 ---
 description: Crystallize a discussion into a spec, then proceed step by step
 argument-hint: [optional spec-slug]
-allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
 ---
 
 # Draft: Discussion → Spec → Guided Next Steps
@@ -25,7 +24,7 @@ Review the conversation history to extract:
 - **Open questions**: Things still undecided or unclear
 - **Scope signals**: What's in vs out, even if stated informally
 
-If the conversation is too early or vague to draft a spec, use AskUserQuestion to ask:
+If the conversation is too early or vague to draft a spec, use the question tool or ask directly:
 - "What's the core thing you're trying to build?"
 - "What problem does this solve?"
 
@@ -132,14 +131,14 @@ After the spec is created and status set, present next-step options **based on t
 2. Stop here — I'll continue manually when ready
 ```
 
-Use AskUserQuestion with these options, or proceed directly if the conversation makes the answer obvious.
+Use the question tool with these options, or proceed directly if the conversation makes the answer obvious.
 
 ## Step 7: Execute Chosen Path
 
 Based on the user's choice:
 
-- **Research**: Proceed as `/research` would — clarify requirements, launch explorer agents, document findings, update status to `researched`
-- **Design**: Proceed as `/design` would — identify underspecified aspects, ask clarifying questions, launch architect agents, document chosen design, update status to `designed`
+- **Research**: Proceed as `/research` would — clarify requirements, run codebase exploration, document findings, update status to `researched`
+- **Design**: Proceed as `/design` would — identify underspecified aspects, ask clarifying questions, develop the architecture, document the chosen design, update status to `designed`
 - **Research then Design**: Run research phase fully, then run design phase
 - **Implement**: Guide user to `/implement` (do not run it inline — implementation is long-running)
 - **Stop here**: Confirm the spec is saved and guide them to the appropriate next command

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -1,6 +1,5 @@
 ---
 description: Build feature following the design
-allowed-tools: Read, Edit, Write, Bash, Task, Glob, Grep, TodoWrite
 ---
 
 # Implement: Build the Feature

--- a/plugin/commands/new.md
+++ b/plugin/commands/new.md
@@ -1,7 +1,6 @@
 ---
 description: Create a new feature spec from description
 argument-hint: <description of feature or requirement>
-allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
 ---
 
 # Create New Feature Spec
@@ -44,7 +43,7 @@ Evaluate the user's description:
   - Proceed to fill Overview section
 
 - **If vague or unclear**:
-  - Use AskUserQuestion or direct questions to clarify:
+  - Use the question tool or direct questions to clarify:
     - What specific problem needs solving?
     - What is the expected outcome or user value?
     - Are there any constraints or requirements?

--- a/plugin/commands/quick-implement.md
+++ b/plugin/commands/quick-implement.md
@@ -1,7 +1,6 @@
 ---
 description: Run all remaining workflow stages end-to-end for simple tasks with approval checkpoints
 argument-hint: <description of feature or requirement>
-allowed-tools: Read, Edit, Write, Bash, Task, Glob, Grep, TodoWrite, AskUserQuestion
 ---
 
 # Quick Implement
@@ -86,7 +85,7 @@ Present the filled Overview to the user. Identify any gaps or ambiguities:
 
 Ask the user to confirm the requirements are correct and complete before research begins.
 
-Use AskUserQuestion with options:
+Use the question tool with options:
 - **Requirements look good — start research** — proceed with the research phase
 - **Need to clarify first** — ask follow-up questions, update the Overview section, then ask again
 
@@ -98,13 +97,13 @@ Do not proceed until requirements are confirmed.
 
 **Step 5: Explore Codebase**
 
-Launch 1-2 code-explorer agents **in parallel** using the Task tool. Focus on:
+Run targeted codebase discovery. Delegate to explorer subagents when helpful, and parallelize only for independent searches. Focus on:
 - Existing patterns and conventions relevant to the feature
 - Files and modules likely to be affected
 
 **Step 6: Read Identified Files**
 
-Read the key files identified by the agents before proceeding.
+Read the key files identified by the subagents before proceeding.
 
 **Step 7: Document Research**
 
@@ -122,12 +121,14 @@ Execute: `zest-dev update active researched`
 
 ## Stage 2: Design
 
-**Step 9: Launch Architect Agent**
+**Step 9: Design a Pragmatic Solution**
 
-Launch a single code-architect agent using the Task tool. Instruct it to design a pragmatic, minimal solution that:
+Design a pragmatic, minimal solution that:
 - Reuses existing patterns and conventions
 - Minimizes new abstractions
 - Produces a clear step-by-step implementation plan
+
+If a design review would materially improve quality, ask architect or reviewer subagents to review or pressure-test the proposed direction.
 
 **Step 10: Document Design**
 
@@ -156,7 +157,7 @@ Ask the user:
 > [brief summary]
 > Proceed with implementation?
 
-Use AskUserQuestion with options:
+Use the question tool with options:
 - **Implement now** — proceed with implementation
 - **Stop here** — exit and let the user review the design before continuing manually with `/implement`
 
@@ -200,14 +201,14 @@ Execute: `zest-dev update active implemented`
 
 ## Stage 4: Final Review
 
-**Step 17: Run Code Reviewer**
+**Step 17: Run Final Review**
 
-Launch a code-reviewer agent using the Task tool to review the changes made during implementation.
+Review the changes made during implementation.
 
-Instruct the agent to:
-- Review the staged/unstaged changes for this feature
-- Check for bugs, logic errors, and security issues
-- Verify code follows project conventions
+If specialist review is warranted, delegate to reviewer subagents to review:
+- The changes for bugs, logic errors, and security issues
+- Whether the code follows project conventions
+- Whether the implementation stayed appropriately simple
 
 **Step 18: Address Critical Issues**
 

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -1,6 +1,5 @@
 ---
 description: Research feature requirements and explore codebase patterns
-allowed-tools: Read, Edit, Bash(zest-dev:*), Task, Glob, Grep, TodoWrite
 ---
 
 # Research: Understand Requirements & Explore Codebase
@@ -49,20 +48,20 @@ Use TodoWrite to create a task list tracking:
 
 ## Codebase Exploration
 
-**Step 5: Launch Explorer Agents
-Launch 2-3 code-explorer agents **in parallel** using the Task tool. Each agent should:
-- Trace through the code comprehensively and focus on getting a comprehensive understanding of abstractions, architecture and flow of control
-- Target a different aspect of the codebase
-- Include a list of 5-10 key files to read
+**Step 5: Launch Codebase Exploration**
+Delegate codebase discovery to one or more explorer subagents when that is faster than doing all search yourself. Parallelize only when different searches are clearly independent. Each exploration pass should:
+- Trace through the codebase to understand abstractions, architecture, and flow of control
+- Focus on a distinct angle
+- Return a concise list of the most important files to read next
 
-**Example agent prompts**:
+**Example exploration prompts**:
 - "Find features similar to [feature] and trace through their implementation comprehensively"
 - "Map the architecture and abstractions for [feature area], tracing through the code comprehensively"
 - "Analyze the current implementation of [existing feature/area], tracing through the code comprehensively"
 - "Identify UI patterns, testing approaches, or extension points relevant to [feature]"
 
 **Step 6: Read Identified Files**
-**IMPORTANT**: Once the agents return, read all files identified by agents to build deep understanding. Do NOT proceed to design without reading these files.
+**IMPORTANT**: Once the subagents return, read all files they identified to build deep understanding. Do NOT proceed to design without reading these files.
 
 **Step 7: Document Research Findings**
 Edit the spec file to add/update the Research section.

--- a/plugin/commands/summarize-chat.md
+++ b/plugin/commands/summarize-chat.md
@@ -1,7 +1,6 @@
 ---
 description: Capture chat conversation into a spec (for post-hoc documentation)
 argument-hint: [optional spec-slug]
-allowed-tools: Read, Write, Edit, Bash(zest-dev:*), AskUserQuestion
 ---
 
 # Summarize Conversation into Spec
@@ -32,7 +31,7 @@ Based on the conversation, determine the spec status:
 - **"designed"**: Clarified requirements, designed architecture with trade-offs
 - **"implemented"**: Actually wrote code, tested it, and reviewed quality
 
-**If status is vague or unclear**, use AskUserQuestion to ask:
+**If status is vague or unclear**, use the question tool to ask:
 - "What status should this spec be in?"
 - Options: new, researched, designed, implemented
 - Provide brief description:

--- a/plugin/commands/summarize-pr.md
+++ b/plugin/commands/summarize-pr.md
@@ -1,7 +1,6 @@
 ---
 description: Summarize a GitHub PR into a spec (for post-hoc documentation)
 argument-hint: [pr-number]
-allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(zest-dev:*), AskUserQuestion
 ---
 
 # Summarize GitHub PR into Spec

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -32,11 +32,6 @@ const EXPECTED_COMMANDS = [
   'zest-dev-summarize-pr.md',
   'zest-dev-quick-implement.md'
 ];
-const EXPECTED_AGENTS = [
-  'code-architect.md',
-  'code-explorer.md',
-  'code-reviewer.md'
-];
 const LANGUAGE_ALIGNMENT_RULE =
   'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.';
 
@@ -79,10 +74,6 @@ function readCommand(target, filename, testDir = TEST_DIR) {
   return fs.readFileSync(path.join(testDir, target, 'commands', filename), 'utf-8');
 }
 
-function readAgent(target, filename, testDir = TEST_DIR) {
-  return fs.readFileSync(path.join(testDir, target, 'agents', filename), 'utf-8');
-}
-
 function extractFrontmatter(content, filename) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   assert.ok(match, `${filename} has no frontmatter`);
@@ -120,16 +111,16 @@ test('zest-dev init integration', async (t) => {
       assert.ok(Array.isArray(result.cursor.skills), 'cursor.skills should be an array');
       assert.ok(Array.isArray(result.cursor.agents), 'cursor.agents should be an array');
       assert.ok(Array.isArray(result.opencode.agents), 'opencode.agents should be an array');
+      assert.deepEqual(result.cursor.commands, [], 'cursor.commands should be empty');
+      assert.deepEqual(result.cursor.skills, [], 'cursor.skills should be empty');
+      assert.deepEqual(result.cursor.agents, [], 'cursor.agents should be empty');
+      assert.deepEqual(result.opencode.agents, [], 'opencode.agents should be empty');
     });
 
     await t.test('directory structure', () => {
       const expectedDirs = [
-        '.cursor/commands',
-        '.cursor/skills',
-        '.cursor/agents',
         '.opencode/commands',
-        '.opencode/skills',
-        '.opencode/agents'
+        '.opencode/skills'
       ];
 
       for (const dir of expectedDirs) {
@@ -138,81 +129,67 @@ test('zest-dev init integration', async (t) => {
     });
 
     await t.test('command files', () => {
-      for (const target of ['.cursor', '.opencode']) {
-        for (const file of EXPECTED_COMMANDS) {
-          const filePath = path.join(TEST_DIR, target, 'commands', file);
-          assert.ok(fs.existsSync(filePath), `${target} command should exist: ${file}`);
-        }
+      for (const file of EXPECTED_COMMANDS) {
+        const filePath = path.join(TEST_DIR, '.opencode', 'commands', file);
+        assert.ok(fs.existsSync(filePath), `.opencode command should exist: ${file}`);
       }
+
+      assert.equal(
+        fs.existsSync(path.join(TEST_DIR, '.cursor')),
+        false,
+        '.cursor should not be created during init'
+      );
     });
 
     await t.test('command language alignment rule', () => {
-      for (const target of ['.cursor', '.opencode']) {
-        for (const file of EXPECTED_COMMANDS) {
-          const content = readCommand(target, file);
-          assert.ok(
-            content.includes(LANGUAGE_ALIGNMENT_RULE),
-            `${target}/commands/${file} should include the language alignment rule`
-          );
-        }
+      for (const file of EXPECTED_COMMANDS) {
+        const content = readCommand('.opencode', file);
+        assert.ok(
+          content.includes(LANGUAGE_ALIGNMENT_RULE),
+          `.opencode/commands/${file} should include the language alignment rule`
+        );
       }
     });
 
     await t.test('skills deployment', () => {
-      const cursorSkillPath = path.join(TEST_DIR, '.cursor/skills/zest-dev/SKILL.md');
       const opencodeSkillPath = path.join(TEST_DIR, '.opencode/skills/zest-dev/SKILL.md');
 
-      assert.ok(fs.existsSync(cursorSkillPath), 'Cursor skill file should exist');
       assert.ok(fs.existsSync(opencodeSkillPath), 'OpenCode skill file should exist');
     });
 
-    await t.test('agents deployment and model mapping', () => {
-      for (const file of EXPECTED_AGENTS) {
-        const cursorPath = path.join(TEST_DIR, '.cursor/agents', file);
-        const opencodePath = path.join(TEST_DIR, '.opencode/agents', file);
-
-        assert.ok(fs.existsSync(cursorPath), `Cursor agent should exist: ${file}`);
-        assert.ok(fs.existsSync(opencodePath), `OpenCode agent should exist: ${file}`);
-
-        const cursorFrontmatter = extractFrontmatter(readAgent('.cursor', file), `.cursor/agents/${file}`);
-        const opencodeFrontmatter = extractFrontmatter(readAgent('.opencode', file), `.opencode/agents/${file}`);
-
-        assert.equal(cursorFrontmatter.model, 'sonnet', `Cursor agent model should remain source model for ${file}`);
-        assert.equal(
-          opencodeFrontmatter.model,
-          'openai/gpt-5.3-codex',
-          `OpenCode agent model should be codex for ${file}`
-        );
-      }
+    await t.test('agents are not deployed', () => {
+      assert.equal(
+        fs.existsSync(path.join(TEST_DIR, '.opencode/agents')),
+        false,
+        '.opencode/agents should not be created during init'
+      );
     });
 
     await t.test('frontmatter transformation', () => {
-      for (const target of ['.cursor', '.opencode']) {
-        const fileLabel = `${target}/commands/zest-dev-new.md`;
-        const content = readCommand(target, 'zest-dev-new.md');
-        const frontmatter = extractFrontmatter(content, fileLabel);
+      const fileLabel = '.opencode/commands/zest-dev-new.md';
+      const content = readCommand('.opencode', 'zest-dev-new.md');
+      const frontmatter = extractFrontmatter(content, fileLabel);
 
-        assert.ok(frontmatter.description, `${fileLabel} should include description`);
-        assert.equal(
-          frontmatter['argument-hint'],
-          undefined,
-          `${fileLabel} should remove argument-hint`
-        );
-        assert.equal(
-          frontmatter['allowed-tools'],
-          undefined,
-          `${fileLabel} should remove allowed-tools`
-        );
-        assert.equal(
-          Object.keys(frontmatter).length,
-          1,
-          `${fileLabel} should only contain one frontmatter field`
-        );
-      }
+      assert.ok(frontmatter.description, `${fileLabel} should include description`);
+      assert.equal(
+        frontmatter['argument-hint'],
+        undefined,
+        `${fileLabel} should remove argument-hint`
+      );
+      assert.equal(
+        frontmatter['allowed-tools'],
+        undefined,
+        `${fileLabel} should remove allowed-tools`
+      );
+      assert.equal(
+        Object.keys(frontmatter).length,
+        1,
+        `${fileLabel} should only contain one frontmatter field`
+      );
     });
 
     await t.test('content preservation', () => {
-      const content = readCommand('.cursor', 'zest-dev-new.md');
+      const content = readCommand('.opencode', 'zest-dev-new.md');
       const match = content.match(/^---\n[\s\S]*?\n---\n\n([\s\S]*)/);
       assert.ok(match, 'should be able to extract command body');
 
@@ -226,14 +203,8 @@ test('zest-dev init integration', async (t) => {
       const secondRun = yaml.load(secondRunOutput);
       assert.equal(secondRun.ok, true, 'second init run should succeed');
 
-      const cursorCommands = fs.readdirSync(path.join(TEST_DIR, '.cursor/commands'));
       const opencodeCommands = fs.readdirSync(path.join(TEST_DIR, '.opencode/commands'));
 
-      assert.equal(
-        cursorCommands.length,
-        EXPECTED_COMMANDS.length,
-        'cursor commands count should remain unchanged'
-      );
       assert.equal(
         opencodeCommands.length,
         EXPECTED_COMMANDS.length,
@@ -494,7 +465,7 @@ test('zest-dev prompt archive integration', () => {
     assert.equal(prompt.includes('zest-dev archive active --no-merge'), false);
 
     runInit();
-    const deployedArchive = readCommand('.cursor', 'zest-dev-archive.md');
+    const deployedArchive = readCommand('.opencode', 'zest-dev-archive.md');
     assert.ok(deployedArchive.includes('zest-dev unset-active'));
     assert.equal(deployedArchive.includes('zest-dev archive active --no-merge'), false);
   } finally {
@@ -512,7 +483,7 @@ test('zest-dev prompt implement supports incremental phases', () => {
     assert.ok(prompt.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
 
     runInit();
-    const deployedImplement = readCommand('.cursor', 'zest-dev-implement.md');
+    const deployedImplement = readCommand('.opencode', 'zest-dev-implement.md');
     assert.ok(deployedImplement.includes('Step 7: Update Spec Status (Only When Fully Complete)'));
     assert.ok(deployedImplement.includes('If only part of the spec is implemented'));
     assert.ok(deployedImplement.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -165,21 +165,25 @@ test('zest-dev init integration', async (t) => {
       );
     });
 
-    await t.test('init removes stale legacy agent files but keeps agents directory', () => {
+    await t.test('init removes only known legacy agent files and keeps other agents content', () => {
       const agentsDir = path.join(TEST_DIR, '.opencode/agents');
-      const staleAgentFile = path.join(agentsDir, 'zest-dev-legacy-agent.md');
+      const staleLegacyFile = path.join(agentsDir, 'code-explorer.md');
+      const nonLegacyTopLevelFile = path.join(agentsDir, 'my-custom-agent.md');
       const nestedDir = path.join(agentsDir, 'nested-dir');
 
       fs.mkdirSync(nestedDir, { recursive: true });
-      fs.writeFileSync(staleAgentFile, '# stale agent', 'utf-8');
+      fs.writeFileSync(staleLegacyFile, '# stale legacy agent', 'utf-8');
+      fs.writeFileSync(nonLegacyTopLevelFile, '# user agent', 'utf-8');
 
-      assert.ok(fs.existsSync(staleAgentFile), 'stale legacy file should exist before init');
+      assert.ok(fs.existsSync(staleLegacyFile), 'known legacy file should exist before init');
+      assert.ok(fs.existsSync(nonLegacyTopLevelFile), 'non-legacy file should exist before init');
       assert.ok(fs.existsSync(agentsDir), 'agents directory should exist before cleanup');
 
       const rerunOutput = yaml.load(runInit());
       assert.equal(rerunOutput.ok, true, 'init rerun should succeed during upgrade cleanup');
 
-      assert.equal(fs.existsSync(staleAgentFile), false, 'stale agent file should be removed');
+      assert.equal(fs.existsSync(staleLegacyFile), false, 'known legacy file should be removed');
+      assert.ok(fs.existsSync(nonLegacyTopLevelFile), 'non-legacy top-level file should be preserved');
       assert.ok(fs.existsSync(agentsDir), 'agents directory should be kept');
       assert.ok(fs.existsSync(nestedDir), 'subdirectories under agents should be kept');
     });

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -165,6 +165,25 @@ test('zest-dev init integration', async (t) => {
       );
     });
 
+    await t.test('init removes stale legacy agent files but keeps agents directory', () => {
+      const agentsDir = path.join(TEST_DIR, '.opencode/agents');
+      const staleAgentFile = path.join(agentsDir, 'zest-dev-legacy-agent.md');
+      const nestedDir = path.join(agentsDir, 'nested-dir');
+
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(staleAgentFile, '# stale agent', 'utf-8');
+
+      assert.ok(fs.existsSync(staleAgentFile), 'stale legacy file should exist before init');
+      assert.ok(fs.existsSync(agentsDir), 'agents directory should exist before cleanup');
+
+      const rerunOutput = yaml.load(runInit());
+      assert.equal(rerunOutput.ok, true, 'init rerun should succeed during upgrade cleanup');
+
+      assert.equal(fs.existsSync(staleAgentFile), false, 'stale agent file should be removed');
+      assert.ok(fs.existsSync(agentsDir), 'agents directory should be kept');
+      assert.ok(fs.existsSync(nestedDir), 'subdirectories under agents should be kept');
+    });
+
     await t.test('frontmatter transformation', () => {
       const fileLabel = '.opencode/commands/zest-dev-new.md';
       const content = readCommand('.opencode', 'zest-dev-new.md');


### PR DESCRIPTION
## Summary
- remove Cursor and agent deployment from `zest-dev init` so plugin setup only targets `.opencode`
- generalize command prompt guidance away from Claude-specific tool and agent references to make prompts more portable in OpenCode
- update integration tests and command metadata expectations to match the simplified deployment flow