### PR TITLE
refactor Zest Dev into thick skill, thin commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This repository's custom command prompts are designed for **OpenCode / oh-my-ope
 - Do **not** hardcode specific oh-my-opencode-slim agent handles in prompts unless there is a strong reason; let the runtime choose the best matching subagent.
 - For user interaction, say **ask the user directly** or **use the question tool** rather than Claude-specific names.
 - For codebase work, describe the goal (read files, search code, inspect references, run shell commands) rather than enumerating a Claude-only tool contract.
+- When referring to a skill in prompts or command docs, refer to it by its registered skill name (for example `Zest Dev`), not by repository or deployed file paths.
 
 ### Prompt format constraints
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,7 @@ A lightweight, human-interactive development workflow for AI-assisted coding.
 
 ## Quick Start
 
-Install the CLI:
-
-```bash
-npm install -g zest-dev
-```
-
-Initialize the editor-facing commands and skills in your project:
+Assuming `zest-dev` is already installed and available in PATH, initialize the editor-facing commands and skills in your project:
 
 ```bash
 zest-dev init

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install -g zest-dev
 
 Zest Dev uses a **thick skill / thin command** model:
 - `plugin/skills/zest-dev/SKILL.md` is the workflow source of truth
+- detailed phase workflows live in `plugin/skills/zest-dev/{new,research,design,implement}.md`
 - `/zest-dev:*` commands are lightweight entrypoints and compatibility shims
 - `zest-dev` CLI manages spec lifecycle only
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ zest-dev init
 ## Usage Workflow
 
 Zest Dev uses a **thick skill / thin command** model:
-- `plugin/skills/zest-dev/SKILL.md` is the workflow source of truth
-- detailed phase workflows live in `plugin/skills/zest-dev/{new,research,design,implement}.md`
+- the `Zest Dev` skill is the workflow source of truth
+- detailed phase workflows are owned by the `Zest Dev` skill
 - `/zest-dev:*` commands are lightweight entrypoints and compatibility shims
 - `zest-dev` CLI manages spec lifecycle only
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ A lightweight, human-interactive development workflow for AI-assisted coding.
 
 ## Quick Start
 
-Install the Claude Code plugin:
+Initialize the editor-facing commands and skills in your project:
 
 ```bash
-/plugin marketplace add https://github.com/nettee/zest-dev
-/plugin install zest-dev
+zest-dev init
 ```
 
 Install the CLI:
@@ -19,19 +18,24 @@ npm install -g zest-dev
 
 ## Usage Workflow
 
+Zest Dev uses a **thick skill / thin command** model:
+- `plugin/skills/zest-dev/SKILL.md` is the workflow source of truth
+- `/zest-dev:*` commands are lightweight entrypoints and compatibility shims
+- `zest-dev` CLI manages spec lifecycle only
+
 ### Step-by-Step
 
 Work through a feature spec one phase at a time, with human review between each stage.
 
 ```bash
 /zest-dev:new "My new feature"   # Create a spec and set it as active
-/zest-dev:research            # Research requirements and explore the codebase
-/zest-dev:design              # Clarify requirements and design the architecture
-/zest-dev:implement           # Build the feature following the design
-/zest-dev:archive             # Agent-guided merge into specs/current, then unset active
+/zest-dev:research              # Research requirements and explore the codebase
+/zest-dev:design                # Clarify requirements and design the architecture
+/zest-dev:implement             # Build the feature following the design
+/zest-dev:archive               # Agent-guided merge into specs/current, then unset active
 ```
 
-Each command advances the spec to the next status: `new → researched → designed → implemented`.
+Each command routes into the main Zest Dev skill, which advances the spec through `new → researched → designed → implemented`.
 
 ### Quick Implementation
 
@@ -88,7 +92,7 @@ Valid status values: `new`, `researched`, `designed`, `implemented`
 
 ### Generate Prompts for Codex
 
-For editors like Codex that don't support project-level commands, use `zest-dev prompt` to generate the equivalent prompt text:
+For editors that don't support project-level commands, use `zest-dev prompt` to generate the equivalent thin-entry prompt text:
 
 ```bash
 codex "$(zest-dev prompt new 'some description')"
@@ -96,8 +100,13 @@ codex "$(zest-dev prompt research)"
 codex "$(zest-dev prompt design)"
 codex "$(zest-dev prompt implement)"
 codex "$(zest-dev prompt archive)"
-codex "$(zest-dev prompt summarize)"
+codex "$(zest-dev prompt draft)"
+codex "$(zest-dev prompt quick-implement 'some description')"
+codex "$(zest-dev prompt summarize-chat)"
+codex "$(zest-dev prompt summarize-pr 123)"
 ```
+
+`zest-dev prompt` supports the actual command files in `plugin/commands/`. The legacy alias `summarize` maps to `summarize-chat` for compatibility.
 
 ### Project Structure
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A lightweight, human-interactive development workflow for AI-assisted coding.
 
 ## Quick Start
 
-Initialize the editor-facing commands and skills in your project:
-
-```bash
-zest-dev init
-```
-
 Install the CLI:
 
 ```bash
 npm install -g zest-dev
+```
+
+Initialize the editor-facing commands and skills in your project:
+
+```bash
+zest-dev init
 ```
 
 ## Usage Workflow

--- a/lib/prompt-generator.js
+++ b/lib/prompt-generator.js
@@ -1,22 +1,37 @@
 const fs = require('fs');
 const path = require('path');
 
+const COMMANDS_DIR = path.join(__dirname, '..', 'plugin', 'commands');
+const COMMAND_ALIASES = {
+  summarize: 'summarize-chat'
+};
+
+function getAvailableCommands() {
+  return fs.readdirSync(COMMANDS_DIR)
+    .filter(file => file.endsWith('.md'))
+    .map(file => path.basename(file, '.md'))
+    .sort();
+}
+
+function resolveCommandName(command) {
+  return COMMAND_ALIASES[command] || command;
+}
+
 /**
  * Generate a prompt for Codex editor
- * @param {string} command - Command name (new, research, design, implement, summarize, archive)
+ * @param {string} command - Command name
  * @param {string} args - Command arguments (for 'new' command, this is the task description)
  * @returns {string} - The formatted prompt
  */
 function generatePrompt(command, args = '') {
-  const validCommands = ['new', 'research', 'design', 'implement', 'summarize', 'archive'];
+  const resolvedCommand = resolveCommandName(command);
+  const validCommands = getAvailableCommands();
 
-  if (!validCommands.includes(command)) {
+  if (!validCommands.includes(resolvedCommand)) {
     throw new Error(`Invalid command: ${command}. Must be one of: ${validCommands.join(', ')}`);
   }
 
-  // Get the plugin directory path (relative to this file)
-  const pluginDir = path.join(__dirname, '..', 'plugin');
-  const commandFile = path.join(pluginDir, 'commands', `${command}.md`);
+  const commandFile = path.join(COMMANDS_DIR, `${resolvedCommand}.md`);
 
   if (!fs.existsSync(commandFile)) {
     throw new Error(`Command file not found: ${commandFile}`);
@@ -38,5 +53,6 @@ function generatePrompt(command, args = '') {
 }
 
 module.exports = {
-  generatePrompt
+  generatePrompt,
+  getAvailableCommands
 };

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -8,8 +8,8 @@ This plugin integrates the Zest Dev methodology into command- and prompt-driven 
 
 ## Architecture
 
-- `plugin/skills/zest-dev/SKILL.md` is the canonical workflow source
-- detailed phase workflows live in `plugin/skills/zest-dev/{new,research,design,implement}.md`
+- the `Zest Dev` skill is the canonical workflow source
+- detailed phase workflows live under the `Zest Dev` skill
 - commands in `plugin/commands/` are thin entrypoints and compatibility shims
 - the `zest-dev` CLI manages spec lifecycle and prompt generation
 
@@ -37,7 +37,7 @@ All command flows keep responding in the user's language unless the user asks to
 
 ## Skills
 
-- **zest-dev** - Canonical workflow source for the New / Research / Design / Implement phases
+- **Zest Dev** - Canonical workflow source for the New / Research / Design / Implement phases
 
 ## Prerequisites
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,10 +1,16 @@
 # Zest Dev Plugin
 
-A Claude Code plugin for spec-driven development workflow.
+A plugin for Zest Dev's spec-driven development workflow.
 
 ## Overview
 
-This plugin integrates the Zest Dev methodology into Claude Code, providing a structured workflow for managing software specifications through sequential development phases.
+This plugin integrates the Zest Dev methodology into command- and prompt-driven editors, providing a structured workflow for managing software specifications through sequential development phases.
+
+## Architecture
+
+- `plugin/skills/zest-dev/SKILL.md` is the canonical workflow source
+- commands in `plugin/commands/` are thin entrypoints and compatibility shims
+- the `zest-dev` CLI manages spec lifecycle and prompt generation
 
 ## Features
 
@@ -19,18 +25,18 @@ All command flows keep responding in the user's language unless the user asks to
 
 | Command | Purpose |
 |---------|---------|
-| `/new <description>` | Create a new spec from natural language description |
-| `/draft` | Crystallize a conversation into a spec, then proceed step by step |
-| `/research` | Fill research section and advance to researched phase |
-| `/design` | Fill design section and advance to designed phase |
-| `/implement` | Fill implementation plan and advance to implemented phase |
-| `/archive` | Merge implemented active change spec knowledge into `specs/current/`, then unset active |
-| `/summarize-chat` | Capture a completed coding session into a spec (post-hoc) |
-| `/summarize-pr <pr>` | Summarize a GitHub PR into a spec (post-hoc) |
+| `/zest-dev:new <description>` | Create a new spec from natural language description |
+| `/zest-dev:draft` | Crystallize a conversation into a spec, then proceed step by step |
+| `/zest-dev:research` | Enter the Research phase via the main Zest Dev skill |
+| `/zest-dev:design` | Enter the Design phase via the main Zest Dev skill |
+| `/zest-dev:implement` | Enter the Implement phase via the main Zest Dev skill |
+| `/zest-dev:archive` | Merge implemented active change spec knowledge into `specs/current/`, then unset active |
+| `/zest-dev:summarize-chat` | Capture a completed coding session into a spec (post-hoc) |
+| `/zest-dev:summarize-pr <pr>` | Summarize a GitHub PR into a spec (post-hoc) |
 
 ## Skills
 
-- **zest-dev** - Comprehensive guide to spec-driven development principles and best practices
+- **zest-dev** - Canonical workflow source for the New / Research / Design / Implement phases
 
 ## Prerequisites
 
@@ -42,7 +48,10 @@ All command flows keep responding in the user's language unless the user asks to
 ### Local Development
 
 ```bash
-# Run Claude Code with this plugin
+# Initialize deployed OpenCode commands and skills in the current project
+zest-dev init
+
+# Or point an editor/runtime at this plugin source during development
 cc --plugin-dir /path/to/zest-dev/plugin
 ```
 
@@ -50,19 +59,23 @@ cc --plugin-dir /path/to/zest-dev/plugin
 
 ### Step-by-step (planned)
 Start from a description and work through each phase:
-1. `/new <description>` — create spec with overview
-2. `/research` — explore codebase and options
-3. `/design` — design architecture, choose approach
-4. `/implement` — build the feature
-5. `/archive` — merge into `specs/current/` and unset active change spec
+1. `/zest-dev:new <description>` — thin entry into the New phase
+2. `/zest-dev:research` — thin entry into the Research phase
+3. `/zest-dev:design` — thin entry into the Design phase
+4. `/zest-dev:implement` — thin entry into the Implement phase
+5. `/zest-dev:archive` — merge into `specs/current/` and unset active change spec
 
 ### Vibe coding first (post-hoc)
 Code first, then document what was built:
 1. Write code freely
-2. `/summarize-chat` or `/summarize-pr` — capture into a spec
+2. `/zest-dev:summarize-chat` or `/zest-dev:summarize-pr` — capture into a spec
 
 ### Discussion-driven (new)
 Chat and brainstorm first, then formalize and proceed:
 1. Have a free-form discussion about the feature
-2. `/draft` — crystallize discussion into a spec with overview
-3. Optionally continue with `/research`, `/design`, `/implement`
+2. `/zest-dev:draft` — crystallize discussion into a spec with overview
+3. Optionally continue with `/zest-dev:research`, `/zest-dev:design`, `/zest-dev:implement`
+
+## Prompt Compatibility
+
+`zest-dev prompt <command>` generates prompt text from the thin command files. It supports the real command set in `plugin/commands/`, plus a compatibility alias from `summarize` to `summarize-chat`.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,6 +9,7 @@ This plugin integrates the Zest Dev methodology into command- and prompt-driven 
 ## Architecture
 
 - `plugin/skills/zest-dev/SKILL.md` is the canonical workflow source
+- detailed phase workflows live in `plugin/skills/zest-dev/{new,research,design,implement}.md`
 - commands in `plugin/commands/` are thin entrypoints and compatibility shims
 - the `zest-dev` CLI manages spec lifecycle and prompt generation
 

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -5,17 +5,8 @@ argument-hint: [optional design focus or constraints]
 
 # Design: Clarify Requirements & Design Architecture
 
-Ultra-thin entrypoint for the Zest Dev **Design** phase.
+Run Zest Dev **Design** phase workflow.
 
-**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+**Language rule:** Respond in the user's language by default, if user's language is not English.
 
 **Arguments:** $ARGUMENTS
-
-Use the Zest Dev skill as the canonical workflow source for this phase.
-
-Bring `$ARGUMENTS` into context as optional design focus, constraints, or decision context, and let the Zest Dev skill naturally continue with the Design phase.
-
-**Important Notes**
-
-- This command is intentionally thin.
-- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -4,177 +4,36 @@ description: Clarify requirements and design architecture
 
 # Design: Clarify Requirements & Design Architecture
 
-Resolve ambiguities and design implementation approaches with trade-offs before coding.
+Thin entrypoint for the Zest Dev **Design** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
-## Clarifying Questions
+Use the Zest Dev skill as the canonical workflow source for this phase.
 
-**CRITICAL**: This is one of the most important steps. DO NOT SKIP.
+**Step 1: Enter the Zest Dev Design phase**
 
-**Step 1: Verify Active Change Spec**
-Execute: `zest-dev status`
+Treat this command as a request to run the skill's **Design** workflow.
 
-Confirm there is an active change spec set and status is "researched". If:
-- No active change spec: Guide user to set one
-- Status is "new": Suggest completing `/research` first
-- Status is "designed" or later: Confirm if user wants to update existing design
+**Step 2: Let the skill execute the phase**
 
-**Step 2: Read Active Change Spec**
-Execute: `zest-dev show active` to get the spec file path.
+Inside the skill, follow the canonical Design workflow to:
+- verify the active change spec and its readiness
+- read the active spec and relevant repository files
+- identify underspecified decisions
+- ask clarifying questions when needed
+- synthesize one recommended architecture by default
+- write the Design section and, when needed, a coarse multi-phase Plan
+- update status via `zest-dev update active designed`
 
-Read the spec file to understand:
-- Overview and problem statement
-- Research findings and recommendations
-- Any existing design content
+**Step 3: Keep design opinionated**
 
-**Step 3: Create Task List**
-Use TodoWrite to create a task list tracking:
-- Identify and ask clarifying questions
-- Launch architecture design agents
-- Synthesize recommended architecture
-- Decide whether user choice is actually needed
-- Document final design
-- Update spec status
+Design should capture the recommended approach, trade-offs, implementation steps, and edge cases.
 
-**Step 4: Identify Underspecified Aspects**
-Review the codebase findings and original feature request to identify:
-- **Edge cases**: How to handle errors, empty states, invalid input
-- **Integration points**: How components interact, API contracts
-- **Scope boundaries**: What's in scope vs out of scope
-- **Design preferences**: UI/UX choices, naming conventions, patterns to follow
-- **Backward compatibility**: Breaking changes, migration needs
-- **Performance needs**: Scalability requirements, optimization priorities
-- **Testing strategy**: What needs tests, testing approach
+**Step 4: Stop for implementation approval**
 
-**Step 5: Ask Clarifying Questions**
-**Present all questions to the user in a clear, organized list**. Use the question tool for multiple-choice checkpoints, or ask directly for open-ended input.
+After the design is documented, summarize it briefly and wait for approval before coding.
 
-**Wait for answers before proceeding to architecture design.**
+**Important Notes**
 
-If the user says "whatever you think is best", provide your recommendation and get explicit confirmation.
-
-## Architecture Design
-
-**Step 6: Develop the Architecture Recommendation**
-Form the architecture recommendation yourself, using repository evidence first.
-
-When extra design validation is useful, delegate selectively:
-- Use explorer subagents to verify existing patterns or affected modules
-- Use architect subagents to generate candidate directions or pressure-test the design
-- Use reviewer subagents for high-value critique, trade-off analysis, or synthesis feedback
-
-Treat delegated findings as **inputs**, not as user-facing option generators.
-
-The design pass should produce:
-- A recommended architecture
-- Architecture overview with components
-- Implementation approach
-- Key trade-offs
-- Files to create or modify
-- Which differences are truly architectural vs mere tuning
-- Any ideas that can be safely combined
-
-**Step 7: Synthesize Findings & Form Opinion**
-Review all subagent outputs and synthesize them into a single recommended architecture by default.
-
-The main agent should:
-- Extract shared recommendations and constraints
-- Merge compatible strengths from different agents
-- Discard clearly inferior, redundant, or theatrical extreme proposals
-- Decide whether one delegated recommendation is already clearly correct as-is
-- Form a strong opinion on the best fit for this specific task and repository
-
-Consider:
-- Is this a small fix or large feature?
-- Urgency vs quality trade-offs
-- Team context and existing patterns
-- Complexity and maintenance burden
-- Backward compatibility and migration implications
-- Whether differences are strategic or merely implementation tuning
-
-**Default rule:** the main agent should make the architectural decision and present one synthesized recommendation.
-
-**Step 8: Decide Whether User Choice Is Actually Needed**
-Only ask the user to choose when there are **2-3 genuinely viable and materially different architectural directions**.
-
-Ask the user to choose only if one or more of these is true:
-- The approaches imply different product behavior or UX semantics
-- The approaches imply different compatibility, migration, or rollout strategies
-- The approaches create meaningfully different module boundaries, contracts, or system shape
-- The approaches have materially different long-term cost profiles and there is no clear winner
-- Two or more directions are genuinely viable and depend on user/team preference rather than technical correctness
-
-Do **not** ask the user to choose when:
-- One direction is clearly best for the issue and repository
-- One delegated recommendation is clearly correct and the others are weaker variations
-- Differences are only about abstraction level, naming, file split, sequencing, or other implementation tuning
-- The alternatives are artificial extremes (for example: too minimal, too overengineered, and one obvious middle ground)
-
-If user choice is **not** needed:
-- Present one recommended architecture
-- Briefly explain what was synthesized from the delegated findings
-- Proceed directly to documenting the design
-
-If user choice **is** needed:
-- Present only the 2-3 genuinely viable directions
-- Summarize the real trade-offs briefly
-- State your recommendation with reasoning
-- Ask the user which direction they prefer
-
-Wait for user decision **only** when this decision gate determines that user input is actually needed.
-
-**Step 9: Document Design**
-Edit the spec file to add/update the Design section based on the synthesized recommendation or the user-chosen direction when a real decision fork exists.
-
-**Include:**
-- **Architecture overview**: Components, data flow, system structure
-- **Why this design**: Why this is the recommended direction, including what was synthesized or intentionally rejected
-- **Implementation steps**: Ordered sequence of what to build
-- **Pseudocode**: Logic for non-trivial algorithms or processes
-- **File structure**: Files to create or modify
-- **Interfaces/APIs**: Contracts between components
-- **Edge cases**: How to handle errors and unusual scenarios
-
-If alternatives were considered but not surfaced to the user, summarize them briefly only when helpful for future reviewers.
-
-**Format guidelines:**
-- Use visual diagrams (ASCII art, flowcharts) for architecture
-- Number implementation steps in logical order
-- Write pseudocode, NOT actual code
-- Use bullet points for file lists
-- Keep descriptions brief (1-2 lines per item)
-
-**Content principles:**
-- Prioritize brevity: Main flow and key ideas, not every detail
-- Easy to review: Structure, not implementation specifics
-- Use pseudocode: Show logic, not language syntax
-- Flowcharts: For complex processes with branches
-
-**Step 9.5: Assess Implementation Complexity & Fill Plan**
-Assess whether implementation needs to be split into multiple phases:
-
-- **Single phase** (most features): Leave the `### Plan` subsection empty.
-- **Multi-phase** (complex features): Fill `### Plan` with a coarse phase breakdown.
-
-When filling Plan, keep it high-level — name what each phase covers, not individual tasks:
-
-```
-- [ ] Phase 1: [brief description of scope]
-- [ ] Phase 2: [brief description of scope]
-```
-
-2-3 phases maximum. Do not nest sub-tasks under phases. These boxes will be checked off during the Implement stage.
-
-**Step 10: Update Spec Status**
-Execute: `zest-dev update active designed`
-
-This updates the spec status using the CLI (do not edit frontmatter manually).
-
-**Step 11: Confirm Completion**
-Mark todo items complete and inform user:
-- Design section has been completed
-- Spec status updated to "designed"
-- Clarifying questions resolved
-- Architecture approach documented
-- Guide them to use `/implement` command to build the feature
+- This command is intentionally thin.
+- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.

--- a/plugin/commands/design.md
+++ b/plugin/commands/design.md
@@ -1,39 +1,21 @@
 ---
 description: Clarify requirements and design architecture
+argument-hint: [optional design focus or constraints]
 ---
 
 # Design: Clarify Requirements & Design Architecture
 
-Thin entrypoint for the Zest Dev **Design** phase.
+Ultra-thin entrypoint for the Zest Dev **Design** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
+**Arguments:** $ARGUMENTS
+
 Use the Zest Dev skill as the canonical workflow source for this phase.
 
-**Step 1: Enter the Zest Dev Design phase**
-
-Treat this command as a request to run the skill's **Design** workflow.
-
-**Step 2: Let the skill execute the phase**
-
-Inside the skill, follow the canonical Design workflow to:
-- verify the active change spec and its readiness
-- read the active spec and relevant repository files
-- identify underspecified decisions
-- ask clarifying questions when needed
-- synthesize one recommended architecture by default
-- write the Design section and, when needed, a coarse multi-phase Plan
-- update status via `zest-dev update active designed`
-
-**Step 3: Keep design opinionated**
-
-Design should capture the recommended approach, trade-offs, implementation steps, and edge cases.
-
-**Step 4: Stop for implementation approval**
-
-After the design is documented, summarize it briefly and wait for approval before coding.
+Bring `$ARGUMENTS` into context as optional design focus, constraints, or decision context, and let the Zest Dev skill naturally continue with the Design phase.
 
 **Important Notes**
 
 - This command is intentionally thin.
-- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.
+- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -27,9 +27,14 @@ Use this command as a lightweight bridge:
 
 If the conversation already reached research or design depth, fill those sections briefly using the same canonical rules from the Zest Dev skill.
 
+Then persist the inferred status explicitly:
+- if the highest reached status is `new`, leave the status as-is
+- if the highest reached status is `researched`, fill `## Research` and run `zest-dev update active researched`
+- if the highest reached status is `designed`, fill `## Research` and `## Design`, then run `zest-dev update active designed`
+
 ## Step 2: Route into the next Zest Dev phase
 
-After the spec is created and status set, present next-step options **based on the current status**:
+After the spec is created and the inferred status is persisted, present next-step options **based on the current status**:
 
 **If status is `new`:**
 ```

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -60,7 +60,7 @@ Based on the user's choice:
 - **Research**: enter the Zest Dev skill's Research phase
 - **Design**: enter the Zest Dev skill's Design phase
 - **Research then Design**: run the skill's Research phase, then its Design phase
-- **Implement**: guide the user to `/implement` or enter the skill's Implement phase only if they explicitly want to proceed now
+- **Implement**: guide the user to `/implement` as the next explicit step instead of running implementation inline from `/draft`
 - **Stop here**: confirm the spec is saved and point to the next command
 
 ## Step 4: Confirm completion

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -83,4 +83,4 @@ Inform the user:
 
 - This command is intentionally thin.
 - Preserve open questions instead of resolving them silently.
-- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.
+- The workflow source is the `Zest Dev` skill.

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -5,109 +5,29 @@ argument-hint: [optional spec-slug]
 
 # Draft: Discussion → Spec → Guided Next Steps
 
-Synthesize the current conversation into a well-formed spec, then decide how to continue.
+Bridge entrypoint into the Zest Dev skill.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
 **Spec slug (optional):** $ARGUMENTS
 
-This command is for when you've been chatting and brainstorming with the user and want to formalize the ideas into a spec before implementation. Unlike `/new` (brief description) or `/summarize-chat` (post-hoc capture), `/draft` captures an active discussion in progress and guides the next development steps.
+This command is for when you've been chatting and brainstorming with the user and want to formalize the ideas into a spec before implementation. Unlike `/new` (brief description) or `/summarize-chat` (post-hoc capture), `/draft` captures an active discussion in progress and then routes into the appropriate Zest Dev phase.
 
 ---
 
-## Step 1: Analyze Conversation
+## Step 1: Capture the current discussion into a spec
 
-Review the conversation history to extract:
-- **Core goal**: What the user ultimately wants to build or solve
-- **Problem context**: Why this matters and what pain it addresses
-- **Ideas discussed**: Approaches, options, constraints mentioned
-- **Open questions**: Things still undecided or unclear
-- **Scope signals**: What's in vs out, even if stated informally
+Use this command as a lightweight bridge:
+- extract the core goal, context, constraints, open questions, and scope signals from the conversation
+- infer or confirm a slug from `$ARGUMENTS`
+- create the spec with `zest-dev create <slug>`
+- set it active with `zest-dev set-active <spec-id>`
+- fill `## Overview` briefly using only conversation-backed information
+- infer the highest status genuinely reached by the conversation
 
-If the conversation is too early or vague to draft a spec, use the question tool or ask directly:
-- "What's the core thing you're trying to build?"
-- "What problem does this solve?"
+If the conversation already reached research or design depth, fill those sections briefly using the same canonical rules from the Zest Dev skill.
 
-## Step 2: Infer or Confirm Spec Slug
-
-If `$ARGUMENTS` is provided, use it as the spec slug.
-
-Otherwise, infer a kebab-case slug from the main goal.
-Example: "Add webhook support for notifications" → `webhook-notifications`
-
-If unsure, confirm with the user before proceeding.
-
-## Step 3: Create Spec via CLI
-
-Execute: `zest-dev create <spec-slug>`
-
-Then set it as active: `zest-dev set-active <spec-id>`
-
-## Step 4: Fill Overview Section
-
-Read the created spec file from `specs/change/`.
-
-Write the Overview based on the conversation. **Only include sections for information that actually came up** — do not invent or assume details.
-
-**Possible sections (include only if discussed):**
-- **Problem Statement**: What problem is being solved and why it matters
-- **Goals**: What the feature should accomplish
-- **Scope**: What's included vs explicitly excluded
-- **Constraints**: Technical limitations, requirements, or dependencies
-- **Ideas & Approaches**: Options discussed (without picking one — that's for design)
-- **Open Questions**: Things not yet decided
-- **Success Criteria**: How to measure if the feature is successful
-
-**Format:**
-- Use bullet points for clarity
-- Keep descriptions brief (1-2 sentences per item)
-- Focus on "what" and "why", not "how" (implementation comes later)
-- Capture the spirit of the discussion, not a transcript
-
-**Example with discussion context:**
-
-```markdown
-## Overview
-
-### Problem Statement
-- Users lose context when switching between tasks mid-conversation
-- No way to bookmark a discussion state for later
-
-### Goals
-- Let users save and restore conversation checkpoints
-- Support tagging checkpoints for easy retrieval
-
-### Ideas & Approaches
-- Store checkpoints as local files vs remote database (not yet decided)
-- Could piggyback on existing export functionality
-
-### Open Questions
-- Should checkpoints be project-scoped or global?
-- What's the retention policy?
-
-### Constraints
-- Must not break existing conversation flow
-- No changes to backend schema in this phase
-```
-
-## Step 5: Determine Spec Status
-
-Evaluate the conversation to determine the appropriate starting status. Assess each stage in sequence:
-
-**`new`** — the default. The discussion identified the problem and goals but did not explore the codebase or settle on an architecture.
-
-**`researched`** — advance to this if the conversation included genuine codebase exploration: files were read, existing patterns were identified, and available approaches were surfaced. Casual mention of an idea does not count.
-
-**`designed`** — advance to this if the conversation went further and produced a concrete architectural decision: components, data flow, implementation steps, and key trade-offs were resolved and agreed upon.
-
-Apply the highest status the conversation genuinely reached, then execute the CLI command:
-- Status is `new`: no update needed (spec is already `new`)
-- Status is `researched`: fill the Research section from conversation context, then run `zest-dev update active researched`
-- Status is `designed`: fill both Research and Design sections from conversation context, then run `zest-dev update active designed`
-
-When filling sections from conversation context, follow the same content rules as `/research` and `/design` respectively — facts in Research, decisions and architecture in Design.
-
-## Step 6: Ask How to Proceed
+## Step 2: Route into the next Zest Dev phase
 
 After the spec is created and status set, present next-step options **based on the current status**:
 
@@ -133,17 +53,17 @@ After the spec is created and status set, present next-step options **based on t
 
 Use the question tool with these options, or proceed directly if the conversation makes the answer obvious.
 
-## Step 7: Execute Chosen Path
+## Step 3: Reuse the canonical skill workflow
 
 Based on the user's choice:
 
-- **Research**: Proceed as `/research` would — clarify requirements, run codebase exploration, document findings, update status to `researched`
-- **Design**: Proceed as `/design` would — identify underspecified aspects, ask clarifying questions, develop the architecture, document the chosen design, update status to `designed`
-- **Research then Design**: Run research phase fully, then run design phase
-- **Implement**: Guide user to `/implement` (do not run it inline — implementation is long-running)
-- **Stop here**: Confirm the spec is saved and guide them to the appropriate next command
+- **Research**: enter the Zest Dev skill's Research phase
+- **Design**: enter the Zest Dev skill's Design phase
+- **Research then Design**: run the skill's Research phase, then its Design phase
+- **Implement**: guide the user to `/implement` or enter the skill's Implement phase only if they explicitly want to proceed now
+- **Stop here**: confirm the spec is saved and point to the next command
 
-## Step 8: Confirm Completion
+## Step 4: Confirm completion
 
 Inform the user:
 - Spec id and name
@@ -156,8 +76,6 @@ Inform the user:
 
 ## Important Notes
 
-- **This is a discussion → spec bridge**: The goal is to capture what was talked about, not to start fresh
-- **Preserve open questions**: If something was undecided in conversation, record it as an open question — don't resolve it silently
-- **Don't fill in gaps**: If the user didn't discuss scope, don't invent scope
-- **Ideas ≠ Design**: Capture brainstormed approaches in "Ideas & Approaches" — leave evaluation for the design phase
-- **Lean toward asking**: When unsure whether to proceed with research or design, ask
+- This command is intentionally thin.
+- Preserve open questions instead of resolving them silently.
+- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -4,82 +4,44 @@ description: Build feature following the design
 
 # Implement: Build the Feature
 
-Implement the feature following the design and document what was built.
+Thin entrypoint for the Zest Dev **Implement** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
-**Step 1: Verify Active Change Spec**
-Execute: `zest-dev status`
+Use the Zest Dev skill as the canonical workflow source for this phase.
 
-Confirm there is an active change spec set and status is "designed". If:
-- No active change spec: Guide user to set one
-- Status is "new" or "researched": Suggest completing previous phases first
-- Status is "implemented": Confirm if user wants to continue/update implementation
+**Step 1: Enter the Zest Dev Implement phase**
 
-**Step 2: Read Active Change Spec**
-Execute: `zest-dev show active` to get the spec file path.
+Treat this command as a request to run the skill's **Implement** workflow.
 
-**IMPORTANT**: Read all research and design content before coding.
+**Step 2: Let the skill execute the phase**
 
-Do not start implementation until you have comprehensive understanding of:
-- Existing code patterns
-- Architecture and abstractions
-- Conventions and style
-- Testing approaches
+Inside the skill, follow the canonical Implement workflow to:
+- verify the active change spec with `zest-dev status`
+- read the active spec from `zest-dev show active`
+- read all relevant implementation files before coding
+- create a task list
+- get explicit user approval before writing code
+- implement according to the design and repository conventions
+- write or update tests alongside the change
+- mark completed `## Plan` items as `[x]`
+- document `### Implementation` and `### Verification` under `## Notes`
 
-**Step 3: Create Task List**
-Use TodoWrite to create a task list tracking:
-- Read all relevant files
-- Get user approval
-- Implement features following design
-- Document implementation in spec
-- Update spec status
+**Step 3: Respect incremental delivery**
 
-**Step 4: Implement Following Design**
-Once approved, implement the feature:
-- Follow the architecture designed in previous phase
-- Adhere to codebase conventions strictly
-- Write clean, well-documented code
-- Follow existing patterns discovered in research
-- Update todos as you progress
-- **After each phase/task completes, immediately mark the corresponding Plan section item as `[x]`** in the spec file
-
-**Implementation principles:**
-- **Simple and elegant**: Prioritize readable, maintainable code
-- **No over-engineering**: Only add what's needed for current requirements
-- **Follow conventions**: Match existing code style and patterns
-- **Security first**: Avoid introducing vulnerabilities
-- **Test as you go**: Write tests alongside implementation
-
-**Step 5: Verify Plan Checkboxes**
-Before moving on, confirm all completed items in the spec's Plan section are marked `[x]`. Any item left as `[ ]` must either be completed or explicitly noted as skipped with a reason.
-
-**Step 6: Document in Notes**
-Edit the spec file to fill the `### Implementation` and `### Verification` subsections under Notes.
-
-**Implementation** — what was actually built:
-- Files created or modified (with one-line description each)
-- Decisions made during coding that weren't in the design
-- Deviations from original design with rationale
-
-**Verification** — how it was validated:
-- Tests written and their results
-- Manual testing steps and outcomes
-- Any known limitations or follow-up items
-
-Keep both sections brief. Use bullet points. Skip a subsection entirely if there's nothing worth noting.
+If only part of the plan is complete, do not mark the spec `implemented` yet.
+Only when the full spec is complete, execute: `zest-dev update active implemented`
 
 **Step 7: Update Spec Status (Only When Fully Complete)**
-Support incremental delivery by phase:
-- If only part of the spec is implemented (for example, one phase), **do not** mark status as `implemented` yet.
-- Keep status at its current in-progress phase until all planned work for the spec is complete.
+
+- If only part of the spec is implemented, keep the current in-progress status.
 - Only when the full spec is complete, execute: `zest-dev update active implemented`
 
-Always update status via the CLI (do not edit frontmatter manually).
+**Step 4: Confirm result**
 
-**Step 8: Confirm Progress or Completion**
-Mark only the todo items for the work completed in this run, leaving future phases unchecked. Then inform user:
-- ✅ Implemented scope completed (phase or full spec)
-- ✅ Spec status updated appropriately (only set to `implemented` when full spec is done)
-- ✅ Relevant todo items updated for this run
-- ✅ Implementation documented
+Report implemented scope, verification, spec notes, and whether the status advanced.
+
+**Important Notes**
+
+- This command is intentionally thin.
+- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -5,17 +5,8 @@ argument-hint: [optional implementation scope or phase hint]
 
 # Implement: Build the Feature
 
-Ultra-thin entrypoint for the Zest Dev **Implement** phase.
+Run Zest Dev **Implement** phase workflow.
 
-**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+**Language rule:** Respond in the user's language by default, if user's language is not English.
 
 **Arguments:** $ARGUMENTS
-
-Use the Zest Dev skill as the canonical workflow source for this phase.
-
-Bring `$ARGUMENTS` into context as optional implementation scope, phase, or focus guidance, and let the Zest Dev skill naturally continue with the Implement phase.
-
-**Important Notes**
-
-- This command is intentionally thin.
-- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -1,47 +1,21 @@
 ---
 description: Build feature following the design
+argument-hint: [optional implementation scope or phase hint]
 ---
 
 # Implement: Build the Feature
 
-Thin entrypoint for the Zest Dev **Implement** phase.
+Ultra-thin entrypoint for the Zest Dev **Implement** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
+**Arguments:** $ARGUMENTS
+
 Use the Zest Dev skill as the canonical workflow source for this phase.
 
-**Step 1: Enter the Zest Dev Implement phase**
-
-Treat this command as a request to run the skill's **Implement** workflow.
-
-**Step 2: Let the skill execute the phase**
-
-Inside the skill, follow the canonical Implement workflow to:
-- verify the active change spec with `zest-dev status`
-- read the active spec from `zest-dev show active`
-- read all relevant implementation files before coding
-- create a task list
-- get explicit user approval before writing code
-- implement according to the design and repository conventions
-- write or update tests alongside the change
-- mark completed `## Plan` items as `[x]`
-- document `### Implementation` and `### Verification` under `## Notes`
-
-**Step 3: Respect incremental delivery**
-
-If only part of the plan is complete, do not mark the spec `implemented` yet.
-Only when the full spec is complete, execute: `zest-dev update active implemented`
-
-**Step 7: Update Spec Status (Only When Fully Complete)**
-
-- If only part of the spec is implemented, keep the current in-progress status.
-- Only when the full spec is complete, execute: `zest-dev update active implemented`
-
-**Step 4: Confirm result**
-
-Report implemented scope, verification, spec notes, and whether the status advanced.
+Bring `$ARGUMENTS` into context as optional implementation scope, phase, or focus guidance, and let the Zest Dev skill naturally continue with the Implement phase.
 
 **Important Notes**
 
 - This command is intentionally thin.
-- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.
+- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/new.md
+++ b/plugin/commands/new.md
@@ -5,7 +5,7 @@ argument-hint: <description of feature or requirement>
 
 # Create New Feature Spec
 
-Create a new feature specification from the user's description and prepare for development.
+Thin entrypoint for the Zest Dev **New** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
@@ -13,126 +13,35 @@ Create a new feature specification from the user's description and prepare for d
 
 ---
 
-**Step 1: Extract Spec Information**
+Use the Zest Dev skill as the canonical workflow source for this phase.
 
-Analyze the user's description and determine:
-- **Spec name**: Human-readable name (e.g., "User Authentication System")
-- **Spec slug**: URL-friendly identifier in kebab-case (e.g., "user-authentication-system")
+**Step 1: Enter the Zest Dev New phase**
 
-**Step 2: Create Spec via CLI**
+Treat this command as a request to run the skill's **New** workflow.
 
-Execute: `zest-dev create <spec-slug>`
+**Step 2: Pass along the user description**
 
-This will:
-- Create the spec file in `specs/change/` with a date-based id (e.g. `20260224-spec-slug`)
-- Generate frontmatter with `name` and `status`
-- Initialize empty sections
+Use the description below as the source requirement when creating the spec:
 
-**Step 3: Set as Active Change Spec**
+`$ARGUMENTS`
 
-Execute: `zest-dev set-active <spec-id>`
+**Step 3: Let the skill execute the phase**
 
-Use the `id` from the created spec's CLI output (e.g. `20260224-spec-slug`).
+Inside the skill, follow the canonical New workflow to:
+- determine name and slug
+- run `zest-dev create <slug>`
+- run `zest-dev set-active <spec-id>`
+- read the created spec file
+- fill `## Overview` using only information the user actually provided
+- ask clarification questions only if the request is too vague
 
-**Step 4: Understand the Feature**
+**Step 4: Confirm result**
 
-Read the created spec file from `specs/change/`.
-
-Evaluate the user's description:
-- **If comprehensive** (clear problem, scope, and context):
-  - Proceed to fill Overview section
-
-- **If vague or unclear**:
-  - Use the question tool or direct questions to clarify:
-    - What specific problem needs solving?
-    - What is the expected outcome or user value?
-    - Are there any constraints or requirements?
-    - What is in scope vs out of scope?
-    - Any performance, security, or compatibility requirements?
-
-**Step 5: Fill Overview Section**
-
-Edit the spec file to record what the user provided. **Only include sections for information the user actually gave — do not invent or assume.**
-
-**Possible sections (include only if user provided the information):**
-- **Problem Statement**: What problem is being solved and why it matters
-- **Goals**: What should the feature accomplish
-- **Scope**: What's included and what's explicitly excluded
-- **Constraints**: Technical limitations, requirements, or dependencies
-- **Success Criteria**: How to measure if the feature is successful
-
-**Format:**
-- Use bullet points for clarity
-- Keep descriptions brief (1-2 sentences per item)
-- Focus on "what" and "why", not "how" (implementation comes later)
-- If the user's description is a single clear statement, a plain paragraph or a few bullets under `## Overview` is sufficient — no sub-sections needed
-
-**Examples:**
-
-Minimal (user gave a brief description only):
-```markdown
-## Overview
-
-Add dark mode support to the settings page so users can switch between light and dark themes.
-```
-
-Partial (user gave goals and constraints but no success criteria):
-```markdown
-## Overview
-
-### Goals
-- Allow users to toggle between light and dark themes
-- Persist preference across sessions
-
-### Constraints
-- Must work with the existing CSS variable system
-- No changes to the backend
-```
-
-Full (user provided all details):
-```markdown
-## Overview
-
-### Problem Statement
-- Users currently cannot [problem]
-- This causes [impact] and prevents [desired outcome]
-
-### Goals
-- Enable users to [capability 1]
-- Support [use case or requirement]
-
-### Scope
-**In scope:**
-- [Feature component 1]
-
-**Out of scope:**
-- [Related feature to defer]
-
-### Constraints
-- Must maintain backward compatibility with [system/API]
-
-### Success Criteria
-- [ ] Users can successfully [action]
-```
-
-**Step 6: Confirm and Guide Next Steps**
-
-Inform the user:
-- ✅ Spec id: `<spec-id>` (e.g. `20260224-spec-slug`), name: `<spec-name>`
-- ✅ Spec file location: `specs/change/<spec-id>/spec.md`
-- ✅ Set as active change spec
-- ✅ Overview section completed
-
-**Next steps:**
-- Use `/research` command to start discovery and codebase exploration
-- Or manually explore the spec with `zest-dev show <spec-id>`
+Report the new spec id, path, active status, and the recommended next phase.
 
 ---
 
 **Important Notes**
 
-- **Record only what the user provided**: Do not add sections the user didn't mention
-- **Keep overview brief**: Focus on problem and goals, not solution
-- **Clarify early**: Better to ask questions now than assume later
-- **Use bullet points**: Makes the spec scannable and reviewable
-- **No implementation details**: Overview describes "what" and "why", not "how"
+- This command is intentionally thin.
+- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.

--- a/plugin/commands/new.md
+++ b/plugin/commands/new.md
@@ -5,21 +5,8 @@ argument-hint: <description of feature or requirement>
 
 # Create New Feature Spec
 
-Ultra-thin entrypoint for the Zest Dev **New** phase.
+Run Zest Dev **New** phase workflow.
 
-**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+**Language rule:** Respond in the user's language by default, if user's language is not English.
 
 **User's description:** $ARGUMENTS
-
----
-
-Use the Zest Dev skill as the canonical workflow source for this phase.
-
-Bring the user's description into context and let the Zest Dev skill naturally continue with the New phase.
-
----
-
-**Important Notes**
-
-- This command is intentionally thin.
-- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/new.md
+++ b/plugin/commands/new.md
@@ -5,7 +5,7 @@ argument-hint: <description of feature or requirement>
 
 # Create New Feature Spec
 
-Thin entrypoint for the Zest Dev **New** phase.
+Ultra-thin entrypoint for the Zest Dev **New** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
@@ -15,33 +15,11 @@ Thin entrypoint for the Zest Dev **New** phase.
 
 Use the Zest Dev skill as the canonical workflow source for this phase.
 
-**Step 1: Enter the Zest Dev New phase**
-
-Treat this command as a request to run the skill's **New** workflow.
-
-**Step 2: Pass along the user description**
-
-Use the description below as the source requirement when creating the spec:
-
-`$ARGUMENTS`
-
-**Step 3: Let the skill execute the phase**
-
-Inside the skill, follow the canonical New workflow to:
-- determine name and slug
-- run `zest-dev create <slug>`
-- run `zest-dev set-active <spec-id>`
-- read the created spec file
-- fill `## Overview` using only information the user actually provided
-- ask clarification questions only if the request is too vague
-
-**Step 4: Confirm result**
-
-Report the new spec id, path, active status, and the recommended next phase.
+Bring the user's description into context and let the Zest Dev skill naturally continue with the New phase.
 
 ---
 
 **Important Notes**
 
 - This command is intentionally thin.
-- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.
+- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/quick-implement.md
+++ b/plugin/commands/quick-implement.md
@@ -5,7 +5,7 @@ argument-hint: <description of feature or requirement>
 
 # Quick Implement
 
-Run through all remaining workflow stages — research, design, implement, and final review — in a single command. Suitable for straightforward, well-scoped tasks.
+Thin bridge entrypoint for running the remaining Zest Dev phases end-to-end.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
@@ -17,18 +17,14 @@ Handles two scenarios:
 
 ---
 
-## Step 0: Detect Starting Point
+## Step 0: Detect the starting point
 
 Run `zest-dev status` to check if there is an active change spec set.
 
 **If an active change spec exists:**
-- Run `zest-dev show active` to read its content and status
-- Skip ahead based on status:
-  - `new` → skip "New" and "Checkpoint 1", go directly to [Stage 1: Research](#stage-1-research)
-  - `researched` → skip to [Stage 2: Design](#stage-2-design)
-  - `designed` → skip to [Checkpoint 2: Approve Implementation](#checkpoint-2-approve-implementation)
-  - `implemented` → inform the user the spec is already fully implemented and exit
-- Create a task list covering only the remaining stages
+- Run `zest-dev show active` to read its content and status.
+- Use the current status only to determine which canonical Zest Dev phases still need to run.
+- If status is `implemented`, inform the user and stop.
 
 **If no active change spec exists:**
 - Proceed to the [New](#new) section below
@@ -39,191 +35,48 @@ Run `zest-dev status` to check if there is an active change spec set.
 
 *Only when no active change spec exists.*
 
-**Step 1: Create Spec**
-
-Analyze the user's description and determine:
-- **Spec name**: Human-readable name (e.g., "User Authentication System")
-- **Spec slug**: URL-friendly identifier in kebab-case (e.g., "user-authentication-system")
-
-Execute: `zest-dev create <spec-slug>`
-
-Then set it as active: `zest-dev set-active <spec-id>` (use the `id` from the create output, e.g. `20260224-spec-slug`)
-
-**Step 2: Fill Overview Section**
-
-Read the created spec file. Edit the Overview section with:
-- **Problem Statement**: What problem is being solved and why it matters
-- **Goals**: What the feature should accomplish
-- **Scope**: What's included and what's explicitly excluded
-- **Constraints**: Technical limitations, requirements, or dependencies
-- **Success Criteria**: How to measure if the feature is successful
-
-Keep it brief — bullet points, 1-2 sentences each.
-
-**Step 3: Create Task List**
-
-Use TodoWrite to create a task list tracking all four stages:
-- [Checkpoint] Confirm requirements with user
-- Research codebase
-- Design architecture
-- [Checkpoint] Await user approval to implement
-- Implement feature
-- Final review
+Use the Zest Dev skill's **New** phase to create the spec and fill Overview briefly.
 
 ---
 
-## Checkpoint 1: Confirm Requirements
+## Checkpoint 1: Confirm requirements
 
-*Only when a new spec was created in the [New](#new) section above.*
-
-**Step 4: Present Requirements & Ask for Approval**
-
-Present the filled Overview to the user. Identify any gaps or ambiguities:
-- Is the problem statement clear?
-- Are the goals and scope well-defined?
-- Are there constraints or unknowns that need resolving?
-
-Ask the user to confirm the requirements are correct and complete before research begins.
-
-Use the question tool with options:
-- **Requirements look good — start research** — proceed with the research phase
-- **Need to clarify first** — ask follow-up questions, update the Overview section, then ask again
-
-Do not proceed until requirements are confirmed.
+If this command created a new spec, confirm the filled Overview with the user before moving into research.
 
 ---
 
 ## Stage 1: Research
 
-**Step 5: Explore Codebase**
-
-Run targeted codebase discovery. Delegate to explorer subagents when helpful, and parallelize only for independent searches. Focus on:
-- Existing patterns and conventions relevant to the feature
-- Files and modules likely to be affected
-
-**Step 6: Read Identified Files**
-
-Read the key files identified by the subagents before proceeding.
-
-**Step 7: Document Research**
-
-Edit the spec file's Research section with findings:
-- **Existing System**: Current code and patterns relevant to this task
-- **Available Approaches**: Technical options (no ranking or recommendations)
-- **Constraints**: Hard requirements, compatibility needs
-- **Key References**: Important files (`file:line` format)
-
-**Step 8: Update Status**
-
-Execute: `zest-dev update active researched`
+Enter the Zest Dev skill's **Research** phase and let it run the canonical research workflow.
 
 ---
 
 ## Stage 2: Design
 
-**Step 9: Design a Pragmatic Solution**
-
-Design a pragmatic, minimal solution that:
-- Reuses existing patterns and conventions
-- Minimizes new abstractions
-- Produces a clear step-by-step implementation plan
-
-If a design review would materially improve quality, ask architect or reviewer subagents to review or pressure-test the proposed direction.
-
-**Step 10: Document Design**
-
-Edit the spec file's Design section with the chosen architecture:
-- Architecture overview (use ASCII diagrams or flowcharts for clarity)
-- Ordered implementation steps
-- Pseudocode for non-trivial logic
-- Files to create or modify
-- Edge cases and error handling
-
-**Step 11: Update Status**
-
-Execute: `zest-dev update active designed`
+Enter the Zest Dev skill's **Design** phase and let it run the canonical design workflow.
 
 ---
 
-## Checkpoint 2: Approve Implementation
+## Checkpoint 2: Approve implementation
 
-**Step 12: Present Design & Ask for Approval**
-
-Present a brief summary of the design (architecture overview, implementation steps, files affected).
-
-Ask the user:
-
-> Design is ready. Here's what will be implemented:
-> [brief summary]
-> Proceed with implementation?
-
-Use the question tool with options:
-- **Implement now** — proceed with implementation
-- **Stop here** — exit and let the user review the design before continuing manually with `/implement`
+After design is ready, present a brief summary and get explicit approval before entering the Implement phase.
 
 ---
 
 ## Stage 3: Implement
 
-**Step 13: Read All Relevant Files**
-
-Before writing any code, read all files identified in research and referenced in the design.
-
-**Step 14: Implement Following Design**
-
-Implement the feature:
-- Follow the architecture from the Design section
-- Match existing code conventions and patterns
-- Write tests alongside implementation
-- Update todos as you progress
-- **After each phase/task completes, immediately mark the corresponding Plan section item as `[x]`** in the spec file
-
-**Implementation principles:**
-- Simple and minimal — only what's needed for current requirements
-- Follow conventions — match existing code style
-- Security first — avoid introducing vulnerabilities
-- Test as you go
-
-**Step 15: Document Implementation**
-
-Before documenting, verify that all completed items in the spec's Plan section are marked `[x]`. Any item left as `[ ]` must either be completed or explicitly noted as skipped with a reason.
-
-Edit the spec file's Implementation section:
-- Files created or modified with descriptions
-- Testing results
-- Any deviations from the design with rationale
-
-**Step 16: Update Status**
-
-Execute: `zest-dev update active implemented`
+Enter the Zest Dev skill's **Implement** phase and let it run the canonical implementation workflow.
 
 ---
 
-## Stage 4: Final Review
+## Stage 4: Final review
 
-**Step 17: Run Final Review**
-
-Review the changes made during implementation.
-
-If specialist review is warranted, delegate to reviewer subagents to review:
-- The changes for bugs, logic errors, and security issues
-- Whether the code follows project conventions
-- Whether the implementation stayed appropriately simple
-
-**Step 18: Address Critical Issues**
-
-If the reviewer finds critical or important issues (confidence ≥ 80), fix them before marking complete.
-
-**Step 19: Confirm Completion**
-
-Mark all todo items complete and inform the user:
-- Research, design, and implementation are complete
-- Spec is documented and status updated to "implemented"
-- Any review findings addressed
+After implementation, review the result, address critical issues, and confirm what status the spec reached.
 
 ---
 
 ## Important Notes
 
-- **Simple tasks only**: For complex features with many unknowns, use the individual stage commands (`/research`, `/design`, `/implement`) for more thorough handling.
-- **Picks up from current status**: If an active change spec is already in progress, this command continues from where it left off.
+- This command is intentionally thin.
+- It reuses the Zest Dev skill's canonical phase workflows.
+- For complex work, prefer the individual stage commands.

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -5,21 +5,8 @@ argument-hint: [optional focus or scope hint]
 
 # Research: Understand Requirements & Explore Codebase
 
-Ultra-thin entrypoint for the Zest Dev **Research** phase.
+Run Zest Dev **Research** phase workflow.
 
-**Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+**Language rule:** Respond in the user's language by default, if user's language is not English.
 
 **Arguments:** $ARGUMENTS
-
----
-
-Use the Zest Dev skill as the canonical workflow source for this phase.
-
-Bring `$ARGUMENTS` into context as optional scope, context, or focus guidance, and let the Zest Dev skill naturally continue with the Research phase.
-
----
-
-## Important Notes
-
-- This command is intentionally thin.
-- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -1,42 +1,25 @@
 ---
 description: Research feature requirements and explore codebase patterns
+argument-hint: [optional focus or scope hint]
 ---
 
 # Research: Understand Requirements & Explore Codebase
 
-Thin entrypoint for the Zest Dev **Research** phase.
+Ultra-thin entrypoint for the Zest Dev **Research** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
+
+**Arguments:** $ARGUMENTS
 
 ---
 
 Use the Zest Dev skill as the canonical workflow source for this phase.
 
-**Step 1: Enter the Zest Dev Research phase**
-
-Treat this command as a request to run the skill's **Research** workflow.
-
-**Step 2: Let the skill execute the phase**
-
-Inside the skill, follow the canonical Research workflow to:
-- verify the active change spec with `zest-dev status`
-- read the active spec from `zest-dev show active`
-- clarify missing requirements when necessary
-- explore the codebase and read the identified files
-- write factual findings into `## Research`
-- update status via `zest-dev update active researched`
-
-**Step 3: Keep research factual**
-
-Document facts and available approaches, not recommendations.
-
-**Step 4: Confirm result**
-
-Report what was explored, what files were important, and how to continue into design.
+Bring `$ARGUMENTS` into context as optional scope, context, or focus guidance, and let the Zest Dev skill naturally continue with the Research phase.
 
 ---
 
 ## Important Notes
 
 - This command is intentionally thin.
-- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.
+- The workflow source lives in the Zest Dev skill.

--- a/plugin/commands/research.md
+++ b/plugin/commands/research.md
@@ -4,139 +4,39 @@ description: Research feature requirements and explore codebase patterns
 
 # Research: Understand Requirements & Explore Codebase
 
-Understand the feature requirements deeply and explore existing codebase patterns before design.
+Thin entrypoint for the Zest Dev **Research** phase.
 
 **Language rule:** Always respond in the user's language throughout the flow unless the user asks to switch languages.
 
 ---
 
-## Discovery & Verification
+Use the Zest Dev skill as the canonical workflow source for this phase.
 
-**Step 1: Verify Active Change Spec**
-Execute: `zest-dev status`
+**Step 1: Enter the Zest Dev Research phase**
 
-Confirm there is an active change spec set. If no active change spec:
-- Inform user no spec is currently active
-- Guide them to use `/new` to create a spec or `zest-dev set-active <spec-id>` to select one
+Treat this command as a request to run the skill's **Research** workflow.
 
-**Step 2: Read Active Change Spec**
-Execute: `zest-dev show active` to get the spec file path.
+**Step 2: Let the skill execute the phase**
 
-Read the spec file to understand:
-- The overview and problem statement
-- Current status (should be "new")
-- Any existing content
+Inside the skill, follow the canonical Research workflow to:
+- verify the active change spec with `zest-dev status`
+- read the active spec from `zest-dev show active`
+- clarify missing requirements when necessary
+- explore the codebase and read the identified files
+- write factual findings into `## Research`
+- update status via `zest-dev update active researched`
 
-**Step 3: Clarify Requirements**
-If the feature description is unclear or vague, ask user for:
-- What problem are they solving?
-- What should the feature do?
-- Any constraints or requirements?
-- What's in scope vs out of scope?
+**Step 3: Keep research factual**
 
-Summarize your understanding and confirm with user before proceeding.
+Document facts and available approaches, not recommendations.
 
-**Step 4: Create Task List**
-Use TodoWrite to create a task list tracking:
-- Clarify requirements
-- Launch codebase exploration
-- Read identified files
-- Document research findings
-- Update spec status
+**Step 4: Confirm result**
 
----
-
-## Codebase Exploration
-
-**Step 5: Launch Codebase Exploration**
-Delegate codebase discovery to one or more explorer subagents when that is faster than doing all search yourself. Parallelize only when different searches are clearly independent. Each exploration pass should:
-- Trace through the codebase to understand abstractions, architecture, and flow of control
-- Focus on a distinct angle
-- Return a concise list of the most important files to read next
-
-**Example exploration prompts**:
-- "Find features similar to [feature] and trace through their implementation comprehensively"
-- "Map the architecture and abstractions for [feature area], tracing through the code comprehensively"
-- "Analyze the current implementation of [existing feature/area], tracing through the code comprehensively"
-- "Identify UI patterns, testing approaches, or extension points relevant to [feature]"
-
-**Step 6: Read Identified Files**
-**IMPORTANT**: Once the subagents return, read all files they identified to build deep understanding. Do NOT proceed to design without reading these files.
-
-**Step 7: Document Research Findings**
-Edit the spec file to add/update the Research section.
-
-**Research documents FACTS, not decisions.** Leave evaluation, comparison, and selection to the design phase.
-
-**Include:**
-- **Existing System**: Current code, patterns, and infrastructure relevant to the task
-- **Available Approaches**: Technical options discovered (list them, do NOT rank or recommend)
-- **Constraints & Dependencies**: Hard requirements, compatibility needs, existing conventions
-- **Key References**: Important files discovered (use `file:line` format)
-
-**Do NOT include:**
-- Pros/cons comparisons or trade-off tables (that's design)
-- Recommendations or verdicts (that's design)
-- "Why" one approach is better than another (that's design)
-- Refactoring suggestions or improvement ideas
-
-**Format:**
-- Use bullet points for lists
-- Keep descriptions concise (1-2 sentences per item)
-- Focus on what exists and what's possible, not what should be chosen
-- State facts objectively
-
-**Content principles:**
-- Prioritize brevity: Main findings only, not exhaustive research
-- Facts only: Document what IS, not what SHOULD BE
-- Enumerate choices: List available approaches without evaluating them
-- Reference code: Point to concrete files and patterns
-
-**Example Structure:**
-```markdown
-## Research
-
-### Existing System
-- [Brief description of current state and relevant code]
-- Key files: `src/file1.js:45`, `src/file2.js:120`
-
-### Available Approaches
-- **Option A**: [What it is and how it works]
-- **Option B**: [What it is and how it works]
-- **Option C**: [What it is and how it works]
-
-### Constraints
-- [Constraint 1]: [What it means for this feature]
-- [Constraint 2]: [Hard requirement or dependency]
-
-### Key References
-- `src/file1.js:45` - [What this file does]
-- `src/file2.js:120` - [Relevant pattern found here]
-```
-
-**Step 8: Update Spec Status**
-Execute: `zest-dev update active researched`
-
-This updates the spec status using the CLI (do not edit frontmatter manually).
-
-**Step 9: Present Summary & Next Steps**
-Present summary including:
-- What was explored
-- Key patterns and systems discovered
-- Available approaches identified (without recommending one)
-- Important files and references
-
-Mark todo items complete and inform user:
-- Research phase is complete
-- Spec status updated to "researched"
-- Guide them to use `/design` command to continue to design phase
+Report what was explored, what files were important, and how to continue into design.
 
 ---
 
 ## Important Notes
 
-- **Read files identified by agents**: This is CRITICAL. Do not skip reading files.
-- **Ask clarifying questions early**: Better to ask than assume.
-- **Keep research focused**: Document findings, not exhaustive code dumps.
-- **Facts, not opinions**: Research discovers what exists and what's possible. Design evaluates and decides.
-- **Include file references**: Help future readers find relevant code.
+- This command is intentionally thin.
+- The workflow source lives in `plugin/skills/zest-dev/SKILL.md`.

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -132,19 +132,19 @@ Use when the design is ready and the user approves coding.
 ## Canonical Phase Workflow Files
 
 ### New
-- The canonical New workflow lives in `plugin/skills/zest-dev/new.md`.
+- The canonical New workflow lives in `new.md`.
 - Use it for spec creation, overview writing, and first-step guidance.
 
 ### Research
-- The canonical Research workflow lives in `plugin/skills/zest-dev/research.md`.
+- The canonical Research workflow lives in `research.md`.
 - Use it for repository discovery, factual research writing, and status advancement to `researched`.
 
 ### Design
-- The canonical Design workflow lives in `plugin/skills/zest-dev/design.md`.
+- The canonical Design workflow lives in `design.md`.
 - Use it for clarifications, architecture synthesis, plan shaping, and status advancement to `designed`.
 
 ### Implement
-- The canonical Implement workflow lives in `plugin/skills/zest-dev/implement.md`.
+- The canonical Implement workflow lives in `implement.md`.
 - Use it for approval-gated implementation, test writing, notes updates, and status advancement to `implemented` only when the full plan is complete.
 
 ## Bridge Workflows

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -18,6 +18,12 @@ This skill is the **canonical workflow source** for planned feature work:
 
 Commands should stay thin. They exist as explicit entrypoints and compatibility shims. The actual phase logic lives here.
 
+To keep this file concise, the detailed workflows live in sibling phase docs:
+- `new.md`
+- `research.md`
+- `design.md`
+- `implement.md`
+
 **Core principle:** keep workflow intelligence in the skill, keep commands lightweight.
 
 ## When This Skill Should Trigger
@@ -123,84 +129,23 @@ Use when research or direct understanding is sufficient to make an implementatio
 ### Implement phase
 Use when the design is ready and the user approves coding.
 
-## Canonical Phase Workflows
+## Canonical Phase Workflow Files
 
-### Phase: New
+### New
+- The canonical New workflow lives in `plugin/skills/zest-dev/new.md`.
+- Use it for spec creation, overview writing, and first-step guidance.
 
-1. Extract a human-readable name and kebab-case slug.
-2. Run `zest-dev create <slug>`.
-3. Set the created spec active with `zest-dev set-active <spec-id>`.
-4. Read the created spec file.
-5. Fill `## Overview` using only information the user actually provided.
-6. Ask clarifying questions only when the requirement is too vague to produce a useful overview.
-7. Confirm spec id, path, active status, and next step.
+### Research
+- The canonical Research workflow lives in `plugin/skills/zest-dev/research.md`.
+- Use it for repository discovery, factual research writing, and status advancement to `researched`.
 
-**Overview content may include:**
-- Problem Statement
-- Goals
-- Scope
-- Constraints
-- Success Criteria
+### Design
+- The canonical Design workflow lives in `plugin/skills/zest-dev/design.md`.
+- Use it for clarifications, architecture synthesis, plan shaping, and status advancement to `designed`.
 
-Do not invent missing sections.
-
-### Phase: Research
-
-1. Run `zest-dev status` and verify an active change spec exists.
-2. Run `zest-dev show active` and read the spec file.
-3. If the status is `new`, continue. If later, confirm whether the user wants to refresh research.
-4. Clarify missing requirement details if needed.
-5. Explore the codebase and locate relevant files.
-6. Read the identified files.
-7. Fill `## Research` with facts only:
-   - Existing System
-   - Available Approaches
-   - Constraints & Dependencies
-   - Key References
-8. Run `zest-dev update active researched`.
-9. Summarize findings and point to the design phase.
-
-**Research rule:** document what exists and what is possible, not what should be chosen.
-
-### Phase: Design
-
-1. Run `zest-dev status` and verify an active change spec exists.
-2. Run `zest-dev show active` and read the spec file.
-3. If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
-4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
-5. Ask the user clarifying questions when needed.
-6. Synthesize one recommended architecture by default.
-7. Fill `## Design` with:
-   - Architecture Overview
-   - Why this design
-   - Implementation Steps
-   - Pseudocode
-   - File Structure
-   - Interfaces / APIs
-   - Edge Cases
-8. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
-9. Run `zest-dev update active designed`.
-10. Present the design and stop for implementation approval.
-
-**Design rule:** this is where decisions, trade-offs, and recommendations belong.
-
-### Phase: Implement
-
-1. Run `zest-dev status` and verify an active change spec exists with status `designed`.
-2. Run `zest-dev show active` and read the full spec.
-3. Read all relevant implementation files before coding.
-4. Create a task list.
-5. Present the implementation scope and get explicit approval.
-6. Implement the feature following the design and repository conventions.
-7. Write or update tests alongside the implementation.
-8. After each completed plan phase, mark the corresponding `## Plan` checkbox as `[x]`.
-9. Fill `## Notes` with brief:
-   - `### Implementation`
-   - `### Verification`
-10. If the full spec is complete, run `zest-dev update active implemented`.
-11. If only part of the work is complete, keep the current non-final status and document what was done.
-
-**Implementation rule:** only mark the spec `implemented` when the whole plan is finished.
+### Implement
+- The canonical Implement workflow lives in `plugin/skills/zest-dev/implement.md`.
+- Use it for approval-gated implementation, test writing, notes updates, and status advancement to `implemented` only when the full plan is complete.
 
 ## Bridge Workflows
 

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -4,303 +4,278 @@ description: This skill should be used when the user asks to "create a spec", "w
 version: 0.1.0
 ---
 
-# Zest Dev: Spec-Driven Development
+# Zest Dev: Thick Skill, Thin Commands
 
-## Overview
+## Purpose
 
-Zest Dev is a lightweight, human-interactive workflow that emphasizes planning before coding through structured specification documents. The methodology guides development through sequential phases ensuring clarity before implementation.
+Zest Dev is a lightweight, human-interactive workflow for spec-driven development.
 
-**Core principle:** Plan with clarity → Implement with confidence
+This skill is the **canonical workflow source** for planned feature work:
+- `new`
+- `research`
+- `design`
+- `implement`
 
-## When to Use Specs
+Commands should stay thin. They exist as explicit entrypoints and compatibility shims. The actual phase logic lives here.
 
-**Use specs for:**
-- New features requiring research and design
-- Significant changes affecting multiple components
-- Unclear requirements or approach
-- Team collaboration and design review
+**Core principle:** keep workflow intelligence in the skill, keep commands lightweight.
 
-**Skip specs for:**
-- Trivial changes (typos, simple bug fixes)
-- Experimental prototypes
-- Well-understood, obvious tasks
+## When This Skill Should Trigger
 
-## Workflow Phases
+Use this skill when the user:
+- asks to create a spec or write a spec
+- mentions Zest Dev or spec-driven development
+- asks to enter a workflow phase such as new, research, design, or implement
+- wants to continue an active change spec
+- uses a thin command that explicitly routes into this skill
 
-Specs progress through sequential phases:
+## Shared Rules
 
+### Language
+- Always respond in the user's language unless the user asks to switch languages.
+
+### Source of truth
+- Treat this skill as the workflow source for the four core phases.
+- Treat commands as wrappers that declare intent and hand off to this skill.
+
+### CLI boundaries
+- Use `zest-dev` CLI for spec lifecycle operations.
+- Never manually create spec files.
+- Never manually edit spec frontmatter.
+- Use CLI status transitions only:
+  - `new`
+  - `researched`
+  - `designed`
+  - `implemented`
+
+### Spec writing principles
+- Prioritize brevity.
+- Prefer bullets over long prose.
+- Use pseudocode and flow descriptions instead of production code.
+- Keep Research factual.
+- Keep Design opinionated.
+- Keep Notes concise and implementation-focused.
+
+### Reading discipline
+- Before writing or deciding, read the active spec and the relevant repository files.
+- If subagents or searches identify files, read those files before continuing.
+
+### Questions and approvals
+- Ask targeted clarifying questions when requirements or architecture are underspecified.
+- Before implementation, get explicit user approval.
+- If the user says “whatever you think is best,” provide your recommendation and get confirmation when the choice is consequential.
+
+## Entry Modes
+
+### 1. Thin command entry
+
+Examples:
+- `/zest-dev:new`
+- `/zest-dev:research`
+- `/zest-dev:design`
+- `/zest-dev:implement`
+
+Interpret the command as a request to run the corresponding phase in this skill.
+
+### 2. Natural-language entry
+
+Examples:
+- “create a spec for this”
+- “research this change”
+- “design the architecture”
+- “implement the active spec”
+
+Infer the intended phase from user intent and current spec status.
+
+### 3. Bridge entry
+
+Composite commands such as `draft` and `quick-implement` should use this skill's core phases instead of re-describing thick workflows themselves.
+
+## Workflow Overview
+
+```text
+User intent or thin command
+          ↓
+  Zest Dev skill phase routing
+          ↓
+     zest-dev CLI + spec files
+          ↓
+ spec updated with brief, reviewable content
 ```
-new → researched → designed → implemented → delivered
+
+Valid progression:
+
+```text
+new → researched → designed → implemented
 ```
 
-### Phase 1: New (Creation)
+## Phase Routing
 
-Capture the initial requirement with:
-- Problem statement
-- Why it matters
-- High-level scope
-- Critical constraints
+### New phase
+Use when there is no spec yet and the user wants to formalize a requirement.
 
-Keep it brief—details come later.
+### Research phase
+Use when a spec exists and the team needs repository facts, patterns, and options.
 
-### Phase 2: Research
+### Design phase
+Use when research or direct understanding is sufficient to make an implementation plan.
 
-Gather information for informed decisions:
-- Investigate existing code/systems
-- Evaluate technical options (2-3 alternatives)
-- Document key findings
-- Recommend approach with rationale
+### Implement phase
+Use when the design is ready and the user approves coding.
 
-**Format:**
+## Canonical Phase Workflows
+
+### Phase: New
+
+1. Extract a human-readable name and kebab-case slug.
+2. Run `zest-dev create <slug>`.
+3. Set the created spec active with `zest-dev set-active <spec-id>`.
+4. Read the created spec file.
+5. Fill `## Overview` using only information the user actually provided.
+6. Ask clarifying questions only when the requirement is too vague to produce a useful overview.
+7. Confirm spec id, path, active status, and next step.
+
+**Overview content may include:**
+- Problem Statement
+- Goals
+- Scope
+- Constraints
+- Success Criteria
+
+Do not invent missing sections.
+
+### Phase: Research
+
+1. Run `zest-dev status` and verify an active change spec exists.
+2. Run `zest-dev show active` and read the spec file.
+3. If the status is `new`, continue. If later, confirm whether the user wants to refresh research.
+4. Clarify missing requirement details if needed.
+5. Explore the codebase and locate relevant files.
+6. Read the identified files.
+7. Fill `## Research` with facts only:
+   - Existing System
+   - Available Approaches
+   - Constraints & Dependencies
+   - Key References
+8. Run `zest-dev update active researched`.
+9. Summarize findings and point to the design phase.
+
+**Research rule:** document what exists and what is possible, not what should be chosen.
+
+### Phase: Design
+
+1. Run `zest-dev status` and verify an active change spec exists.
+2. Run `zest-dev show active` and read the spec file.
+3. If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
+4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
+5. Ask the user clarifying questions when needed.
+6. Synthesize one recommended architecture by default.
+7. Fill `## Design` with:
+   - Architecture Overview
+   - Why this design
+   - Implementation Steps
+   - Pseudocode
+   - File Structure
+   - Interfaces / APIs
+   - Edge Cases
+8. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
+9. Run `zest-dev update active designed`.
+10. Present the design and stop for implementation approval.
+
+**Design rule:** this is where decisions, trade-offs, and recommendations belong.
+
+### Phase: Implement
+
+1. Run `zest-dev status` and verify an active change spec exists with status `designed`.
+2. Run `zest-dev show active` and read the full spec.
+3. Read all relevant implementation files before coding.
+4. Create a task list.
+5. Present the implementation scope and get explicit approval.
+6. Implement the feature following the design and repository conventions.
+7. Write or update tests alongside the implementation.
+8. After each completed plan phase, mark the corresponding `## Plan` checkbox as `[x]`.
+9. Fill `## Notes` with brief:
+   - `### Implementation`
+   - `### Verification`
+10. If the full spec is complete, run `zest-dev update active implemented`.
+11. If only part of the work is complete, keep the current non-final status and document what was done.
+
+**Implementation rule:** only mark the spec `implemented` when the whole plan is finished.
+
+## Bridge Workflows
+
+### Draft
+- Capture a discussion into a spec.
+- Set the highest status genuinely reached by the conversation.
+- Then route the user into the next appropriate core phase from this skill.
+
+### Quick Implement
+- Create or resume the active spec.
+- Run the remaining core phases in order.
+- Keep explicit approval checkpoints before coding.
+- Reuse the canonical phase rules from this skill instead of embedding separate thick instructions.
+
+## Content Templates
+
+### Research
 ```markdown
 ## Research
 
 ### Existing System
-- [Current state]
+- ...
 
-### Options Evaluated
-1. **Option A** - [Description] (recommended)
-2. **Option B** - [Description]
+### Available Approaches
+- **Option A**: ...
+- **Option B**: ...
 
-### Recommendation
-[1-2 sentences on approach and why]
+### Constraints & Dependencies
+- ...
+
+### Key References
+- `path/to/file:line` - ...
 ```
 
-### Phase 3: Design
-
-Create implementation plan with:
-- Architecture overview (components, data flow)
-- Implementation steps (ordered sequence)
-- Pseudocode for complex logic
-- Files to create/modify
-- Edge case handling
-
-**Format:**
+### Design
 ```markdown
 ## Design
 
-### Architecture
-[Component A] → [Component B] → [Component C]
+### Architecture Overview
+[diagram]
+
+### Why this design
+- ...
 
 ### Implementation Steps
-1. **Step 1** - [Description]
-2. **Step 2** - [Description]
+1. ...
 
-### Pseudocode: [Key Algorithm]
-Function name(params):
-  Initialize state
-  Process items
-  Return result
+### Pseudocode
+Flow:
+  Step A
+  Step B
 
-### Files to Modify
-- `path/to/file.ext` - [What changes]
+### File Structure
+- `path/to/file` - ...
 ```
 
-### Phase 4: Implement
-
-Create concrete implementation plan:
-- Task checklist with checkboxes
-- Specific files to change
-- Testing approach
-- Progress tracking
-
-**Format:**
+### Notes
 ```markdown
-## Implementation
+## Notes
 
-### Tasks
-- [ ] Task 1
-- [ ] Task 2
-- [ ] Write tests
-- [ ] Deploy
+### Implementation
+- `path/to/file` - what changed
 
-### Files Modified
-- `file1.ext` - [Change description]
-- `file2.ext` - [Change description]
+### Verification
+- Tests run and results
+- Manual validation and outcomes
 ```
 
-## Content Principles
+## Guardrails
 
-### 1. Prioritize Brevity
-
-Write main flow and key ideas, not full implementation. Use bullet points over paragraphs.
-
-**Good:** Auth options: Passport.js (recommended), custom JWT, Auth0. Choosing Passport.js: battle-tested, minimal setup.
-
-**Bad:** For authentication, there are several options available. First, Passport.js which is mature... [continues for paragraphs]
-
-### 2. Easy to Review
-
-Structure for quick understanding:
-- Use clear headers
-- Put key decisions up front
-- Use tables for comparisons
-- Make it scannable in 2-3 minutes
-
-### 3. Pseudocode Over Code
-
-Show logic without implementation details:
-
-**Good:**
-```
-Load user preferences
-For each preference:
-  If enabled: Apply to session
-Return session
-```
-
-**Bad:**
-```javascript
-async function loadUserPreferences(userId) {
-  try {
-    const prefs = await db.query('SELECT...');
-    // [30 lines of implementation]
-  } catch (error) { ... }
-}
-```
-
-### 4. Use Flowcharts for Complex Logic
-
-For multi-step processes with branches:
-```
-User Request → Check Cache → Found?
-                               ↓ Yes → Return Cached
-                               ↓ No → Query DB → Cache → Return
-```
-
-## Working with Specs
-
-### CLI Commands
-
-```bash
-zest-dev create <spec-slug>     # Create new spec
-zest-dev status                 # View all specs
-zest-dev show <spec-id>         # View specific spec (e.g. 20260224-my-feature)
-zest-dev set-active <spec-id>   # Set active change spec
-zest-dev unset-active           # Unset active change spec
-```
-
-Archive is an agent workflow command (`/zest-dev:archive`) or prompt flow (`zest-dev prompt archive`), not a public CLI subcommand.
-
-**Important:** Never manually create spec files or edit frontmatter. Always use CLI.
-
-### Active Change Spec Context
-
-The active change spec is the selected in-progress change specification. Plugin commands automatically operate on the active change spec.
-
-**Workflow:**
-1. Create spec
-2. Set it as active via `zest-dev set-active <spec-id>`
-3. Work through phases with plugin commands
-4. Switch specs via `zest-dev set-active <spec-id>`
-
-## Best Practices
-
-### Do's
-
-✅ Start with clear problem statement and success criteria
-✅ Research before designing—understand options
-✅ Use pseudocode for logic—focus on algorithm, not syntax
-✅ Keep specs as living documents—update during implementation
-✅ Review design before implementing—validate approach
-
-### Don'ts
-
-❌ Don't write production code in specs—use pseudocode
-❌ Don't create exhaustive documentation—write what's needed
-❌ Don't skip phases—each builds on the previous
-❌ Don't let specs become stale—update as you learn
-❌ Don't over-engineer—solve the immediate problem
-
-## Spec Structure
-
-```markdown
----
-name: Spec Name
-status: new
-created: 2026-02-10
----
-
-## Overview
-[Problem, scope, constraints]
-
-## Research
-[Findings, options, recommendations]
-
-## Design
-[Architecture, steps, pseudocode, files]
-
-## Implementation
-[Task checklist, files, testing, progress]
-```
-
-## Choosing a Workflow
-
-There are three ways to enter the workflow depending on how you started:
-
-### Step-by-step (planned)
-You know what you want to build. Start from a description and work through each phase:
-```
-/new <description> → /research → /design → /implement
-```
-
-### Vibe coding first (post-hoc)
-You coded freely and want to document after the fact:
-```
-/summarize-chat   ← from conversation
-/summarize-pr     ← from a PR
-```
-
-### Discussion-driven (draft)
-You've been discussing or brainstorming the idea and want to formalize it before coding:
-```
-/draft → (optionally) /research → (optionally) /design → /implement
-```
-Use `/draft` when you've had a meaningful conversation about the feature and want to crystallize the ideas into a spec before deciding how to proceed. Unlike `/new` (brief description → minimal spec), `/draft` captures the full context of the discussion and then asks how you want to continue.
-
-## Adapting the Workflow
-
-The workflow is flexible:
-
-**Simple features:**
-- Minimal research (quick investigation)
-- Brief design (just key steps)
-- Fast implementation checklist
-
-**Complex features:**
-- Thorough research with options
-- Detailed design with architecture
-- Comprehensive implementation plan
-
-**Goal:** Provide enough clarity to implement confidently, not to document exhaustively.
-
-## Integration with Development
-
-Specs complement other practices:
-
-**Specs + Agile:** Spec per story, research in planning, design in refinement
-**Specs + TDD:** Design defines test cases, pseudocode becomes test scenarios
-**Specs + Code Review:** Reference spec in PR, compare to design
-**Specs + Docs:** Specs inform user docs, capture architecture decisions
-
-## Troubleshooting
-
-**Spec too long?** → Focus on main flow, cut obvious details, use bullets
-**Don't know what to research?** → Ask: What don't I understand? What are my options?
-**Design feels like code?** → Use pseudocode, show structure not implementation
-**Spec became outdated?** → Update implementation section—specs are living docs
-**Unsure which phase?** → Check status, move forward—you can return
+- Do not rely on deployed command frontmatter except `description`.
+- Do not hardcode platform-specific agent handles in command text.
+- Prefer generic role language such as explorer, architect, or reviewer subagent.
+- Keep commands small enough that future workflow changes happen primarily in this skill.
 
 ## Summary
 
-Zest Spec workflow:
-
-1. **Create** - Capture the problem
-2. **Research** - Understand options
-3. **Design** - Plan the approach
-4. **Implement** - Build with clarity
-5. **Deliver** - Ship with confidence
-
-Write specs that are **brief**, **easy to review**, and use **pseudocode**. Adapt the workflow to your needs. Keep specs as living documents that evolve with your code.
-
-**Remember:** The goal is clarity and alignment, not documentation for its own sake. Write enough to implement confidently, then build.
+Use thin commands for entry, this skill for workflow logic, the CLI for lifecycle transitions, and the spec file as the durable record.

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -1,0 +1,29 @@
+# Zest Dev Phase: Design
+
+Canonical workflow for designing an active change spec.
+
+## When to use
+- Research or direct understanding is sufficient to form an implementation plan
+- A thin `design` command routes here
+
+## Workflow
+1. Run `zest-dev status` and verify an active change spec exists.
+2. Run `zest-dev show active` and read the spec file.
+3. If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
+4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
+5. Ask the user clarifying questions when needed.
+6. Synthesize one recommended architecture by default.
+7. Fill `## Design` with:
+   - Architecture Overview
+   - Why this design
+   - Implementation Steps
+   - Pseudocode
+   - File Structure
+   - Interfaces / APIs
+   - Edge Cases
+8. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
+9. Run `zest-dev update active designed`.
+10. Present the design and stop for implementation approval.
+
+## Rule
+This is where decisions, trade-offs, and recommendations belong.

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -9,11 +9,15 @@ Canonical workflow for designing an active change spec.
 ## Workflow
 1. Run `zest-dev status` and verify an active change spec exists.
 2. Run `zest-dev show active` and read the spec file.
-3. If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
+3. Check status gating before proceeding:
+   - If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
+   - If the status is `researched`, continue.
+   - If the status is `designed` or `implemented`, confirm that the user wants to revise the existing design before continuing.
 4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
 5. Ask the user clarifying questions when needed.
-6. Synthesize one recommended architecture by default.
-7. Fill `## Design` with:
+6. Wait for answers before finalizing the architecture when the open questions are consequential.
+7. Synthesize one recommended architecture by default.
+8. Fill `## Design` with:
    - Architecture Overview
    - Why this design
    - Implementation Steps
@@ -21,9 +25,9 @@ Canonical workflow for designing an active change spec.
    - File Structure
    - Interfaces / APIs
    - Edge Cases
-8. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
-9. Run `zest-dev update active designed`.
-10. Present the design and stop for implementation approval.
+9. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
+10. Run `zest-dev update active designed`.
+11. Present the design and stop for implementation approval.
 
 ## Rule
 This is where decisions, trade-offs, and recommendations belong.

--- a/plugin/skills/zest-dev/implement.md
+++ b/plugin/skills/zest-dev/implement.md
@@ -1,0 +1,25 @@
+# Zest Dev Phase: Implement
+
+Canonical workflow for implementing an active change spec.
+
+## When to use
+- The design is ready and the user approves coding
+- A thin `implement` command routes here
+
+## Workflow
+1. Run `zest-dev status` and verify an active change spec exists with status `designed`.
+2. Run `zest-dev show active` and read the full spec.
+3. Read all relevant implementation files before coding.
+4. Create a task list.
+5. Present the implementation scope and get explicit approval.
+6. Implement the feature following the design and repository conventions.
+7. Write or update tests alongside the implementation.
+8. After each completed plan phase, mark the corresponding `## Plan` checkbox as `[x]`.
+9. Fill `## Notes` with brief:
+   - `### Implementation`
+   - `### Verification`
+10. If the full spec is complete, run `zest-dev update active implemented`.
+11. If only part of the work is complete, keep the current non-final status and document what was done.
+
+## Rule
+Only mark the spec `implemented` when the whole plan is finished.

--- a/plugin/skills/zest-dev/new.md
+++ b/plugin/skills/zest-dev/new.md
@@ -1,0 +1,26 @@
+# Zest Dev Phase: New
+
+Canonical workflow for creating a new change spec.
+
+## When to use
+- No active spec exists yet
+- The user wants to formalize a new requirement
+- A thin `new` command routes here
+
+## Workflow
+1. Extract a human-readable name and kebab-case slug.
+2. Run `zest-dev create <slug>`.
+3. Set the created spec active with `zest-dev set-active <spec-id>`.
+4. Read the created spec file.
+5. Fill `## Overview` using only information the user actually provided.
+6. Ask clarifying questions only when the requirement is too vague to produce a useful overview.
+7. Confirm spec id, path, active status, and next step.
+
+## Overview content may include
+- Problem Statement
+- Goals
+- Scope
+- Constraints
+- Success Criteria
+
+Do not invent missing sections.

--- a/plugin/skills/zest-dev/research.md
+++ b/plugin/skills/zest-dev/research.md
@@ -19,8 +19,9 @@ Canonical workflow for researching an active change spec.
    - Available Approaches
    - Constraints & Dependencies
    - Key References
-9. Run `zest-dev update active researched`.
-10. Summarize findings and point to the design phase.
+9. If the current status is `new`, run `zest-dev update active researched`.
+10. If this is a refresh for a later-phase spec, keep the current status and do not downgrade it.
+11. Summarize findings and point to the design phase.
 
 ## Rule
 Document what exists and what is possible, not what should be chosen.

--- a/plugin/skills/zest-dev/research.md
+++ b/plugin/skills/zest-dev/research.md
@@ -1,0 +1,25 @@
+# Zest Dev Phase: Research
+
+Canonical workflow for researching an active change spec.
+
+## When to use
+- An active spec exists and the team needs repository facts, patterns, and options
+- A thin `research` command routes here
+
+## Workflow
+1. Run `zest-dev status` and verify an active change spec exists.
+2. Run `zest-dev show active` and read the spec file.
+3. If the status is `new`, continue. If later, confirm whether the user wants to refresh research.
+4. Clarify missing requirement details if needed.
+5. Explore the codebase and locate relevant files.
+6. Read the identified files.
+7. Fill `## Research` with facts only:
+   - Existing System
+   - Available Approaches
+   - Constraints & Dependencies
+   - Key References
+8. Run `zest-dev update active researched`.
+9. Summarize findings and point to the design phase.
+
+## Rule
+Document what exists and what is possible, not what should be chosen.

--- a/plugin/skills/zest-dev/research.md
+++ b/plugin/skills/zest-dev/research.md
@@ -11,15 +11,16 @@ Canonical workflow for researching an active change spec.
 2. Run `zest-dev show active` and read the spec file.
 3. If the status is `new`, continue. If later, confirm whether the user wants to refresh research.
 4. Clarify missing requirement details if needed.
-5. Explore the codebase and locate relevant files.
-6. Read the identified files.
-7. Fill `## Research` with facts only:
+5. Summarize your understanding of the request and confirm it with the user before deeper exploration when the requirements are still ambiguous.
+6. Explore the codebase and locate relevant files.
+7. Read the identified files.
+8. Fill `## Research` with facts only:
    - Existing System
    - Available Approaches
    - Constraints & Dependencies
    - Key References
-8. Run `zest-dev update active researched`.
-9. Summarize findings and point to the design phase.
+9. Run `zest-dev update active researched`.
+10. Summarize findings and point to the design phase.
 
 ## Rule
 Document what exists and what is possible, not what should be chosen.

--- a/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
+++ b/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260421-thick-skill-thin-command-workflow
 name: Thick Skill Thin Command Workflow
-status: researched
+status: designed
 created: '2026-04-21'
 ---
 
@@ -66,12 +66,134 @@ created: '2026-04-21'
 
 ## Design
 
-<!-- Technical approach, architecture decisions -->
+### Architecture Overview
+
+```text
+自然语言 / /zest-dev:* / zest-dev prompt <command>
+                    │
+                    ▼
+          plugin/commands/*.md（薄入口）
+                    │
+                    ▼
+        plugin/skills/zest-dev/SKILL.md
+        ├─ Phase: New
+        ├─ Phase: Research
+        ├─ Phase: Design
+        └─ Phase: Implement
+                    │
+                    ▼
+              zest-dev CLI
+      (status/show/create/set-active/update/init)
+                    │
+                    ▼
+              specs/change/*
+```
+
+### Why this design
+- 以 `plugin/skills/zest-dev/SKILL.md` 作为核心 workflow 的唯一真源，收敛 `new / research / design / implement` 的阶段逻辑，减少当前 command 间的重复与漂移。
+- `plugin/commands/new.md`、`plugin/commands/research.md`、`plugin/commands/design.md`、`plugin/commands/implement.md` 退化为薄入口，保留 command 兼容性，但不再承载完整流程。
+- `zest-dev` CLI 继续只负责 spec 生命周期、prompt 兼容层和部署，不把 workflow 细节下沉到 CLI 中，保持与 `lib/spec-manager.js` 的状态机边界一致。
+- 自然语言直触发主要依赖 skill 的 description 与 phase 路由说明，符合部署后 command frontmatter 只保留 `description` 的约束。
+
+### Component Responsibilities
+- **CLI (`bin/zest-dev.js`, `lib/spec-manager.js`)**
+  - 负责 spec 的创建、读取、active 切换、状态更新、plugin 部署、prompt 输出。
+  - 不负责阶段内的 agent 编排、澄清问题模板或 spec 内容写作策略。
+- **Thin commands (`plugin/commands/{new,research,design,implement}.md`)**
+  - 负责显式入口、阶段名称、参数透传和“进入 Zest Dev skill 对应 phase”的最小提示。
+  - 不再包含完整步骤、重复规则和大段 workflow 说明。
+- **Main skill (`plugin/skills/zest-dev/SKILL.md`)**
+  - 负责自然语言触发、phase 路由、共享规则和四个核心阶段的完整 canonical workflow。
+  - 统一语言规则、active spec 校验、何时提问、何时调用 CLI、各阶段写回 spec 的要求。
+- **Specs (`specs/change/*/spec.md`)**
+  - 负责承载 Overview / Research / Design / Plan / Notes，记录状态和设计结果。
+  - 不承载 command 或 skill 的执行说明文本。
+- **Deployer (`lib/plugin-deployer.js`)**
+  - 继续负责把 source plugin 部署到 `.opencode/commands/` 与 `.opencode/skills/`。
+  - 不承担 workflow 编排，仅做最小转换与复制。
+- **Tests (`test/test-integration.js`)**
+  - 负责锁定 command 兼容性、prompt 输出可用性、技能部署结果，以及“command 变薄 / skill 成为真源”的结构约束。
+
+### Implementation Steps
+1. **把 skill 升级为真源**
+   - 重写 `plugin/skills/zest-dev/SKILL.md`，加入 phase 路由和四个核心阶段的完整流程定义。
+   - 将通用规则（语言、状态校验、CLI-only frontmatter 更新、facts vs decisions）收敛到 skill 的共享部分。
+2. **把核心 command 压薄**
+   - 重写 `plugin/commands/new.md`、`research.md`、`design.md`、`implement.md` 为轻量入口。
+   - 每个 command 只保留阶段目的、参数位和“调用主 skill 对应 phase”的说明。
+3. **补齐 prompt 兼容层**
+   - 调整 `lib/prompt-generator.js`，使其定位为“薄入口 prompt 生成器”，同时处理当前 command 枚举与仓库实际文件集合不一致的问题。
+   - 保持 `zest-dev prompt <command>` 仍可作为兼容入口使用。
+4. **清理组合型入口的依赖关系**
+   - 更新 `plugin/commands/draft.md` 与 `quick-implement.md` 等组合入口，使其复用新的主 skill phase，而不是继续内嵌旧的厚流程。
+5. **更新文档与测试**
+   - 更新 `plugin/README.md` 与 `README.md`，明确“skill 是 workflow 真源，command 是兼容入口”。
+   - 更新 `test/test-integration.js`，验证核心 command 仍部署、prompt 仍可用、skill 部署存在，以及 command 内容不再承载厚流程。
+
+### Pseudocode
+```text
+When request arrives:
+  If user uses /zest-dev:new|research|design|implement:
+    Load thin command prompt
+    Command tells agent to enter Zest Dev skill phase
+
+  Else if user uses natural language matching Zest Dev:
+    Trigger Zest Dev skill directly
+
+Inside Zest Dev skill:
+  Detect target phase from command context or user intent
+  Verify active spec and required status for that phase
+  Ask clarifying questions when required
+  Read spec and relevant codebase context
+  Execute phase-specific workflow
+  Use zest-dev CLI for spec creation / status transitions
+  Write results back into spec sections
+  Return next-step guidance
+```
+
+### File Structure
+- `plugin/skills/zest-dev/SKILL.md` - 核心 workflow 真源，承载 phase 路由与四个核心阶段逻辑。
+- `plugin/commands/new.md` - new 阶段的薄入口。
+- `plugin/commands/research.md` - research 阶段的薄入口。
+- `plugin/commands/design.md` - design 阶段的薄入口。
+- `plugin/commands/implement.md` - implement 阶段的薄入口。
+- `plugin/commands/draft.md` - 组合入口，改为桥接到主 skill phase。
+- `plugin/commands/quick-implement.md` - 组合入口，改为串联主 skill phase。
+- `lib/prompt-generator.js` - prompt 兼容层，输出薄 command prompt。
+- `plugin/README.md` - plugin 层工作流说明与入口说明。
+- `README.md` - 仓库对外使用说明。
+- `test/test-integration.js` - command/skill 部署、prompt 输出与架构约束测试。
+
+### Interfaces / APIs
+- **CLI → Skill / Command**
+  - `zest-dev status`
+  - `zest-dev show <spec-id|active>`
+  - `zest-dev create <slug>`
+  - `zest-dev set-active <spec-id>`
+  - `zest-dev update <spec-id|active> <status>`
+  - `zest-dev prompt <command> [args...]`
+- **Command → Skill**
+  - command prompt 不再直接描述完整工作流，而是声明当前 phase，并要求进入 Zest Dev skill 的对应 phase。
+- **Skill → Spec**
+  - 通过 CLI 更新 status；通过编辑 spec 正文填充 Overview / Research / Design / Notes。
+
+### Edge Cases
+- **没有 active spec**：`research / design / implement` phase 必须先中止并引导用户创建或设置 active spec。
+- **status 不匹配**：主 skill 必须按阶段校验 `new / researched / designed` 前置状态，避免绕过既有状态机约束。
+- **自然语言触发不精确**：skill description 需要覆盖 phase 触发词和“create spec / research phase / design architecture / implement feature”等意图，降低误触发或漏触发概率。
+- **prompt 兼容入口枚举漂移**：`lib/prompt-generator.js` 的命令集合需要与实际 command 文件集合保持一致，避免迁移后出现入口存在但 prompt 不支持的情况。
+- **部署后 frontmatter 被裁剪**：不能依赖 deployed command 的 `argument-hint` 或其他 frontmatter 字段，相关上下文必须写进正文或 skill 中。
+- **一次性迁移的回归面**：`draft`、`quick-implement` 等组合入口如果仍内嵌旧逻辑，会与主 skill 真源产生再次漂移，需同轮对齐。
+
+### Alternatives Considered
+- 保持“厚 command、薄 skill”：会继续把 workflow 真源放在多个 command 文件中，不能解决漂移问题。
+- 为每个 phase 单独拆分 skill：会重复共享规则，并增加 phase 间一致性维护成本。
+- 把更多 workflow 下沉到 CLI：会把 AI workflow 与本地状态机耦合，削弱自然语言直触发能力。
 
 ## Plan
 
-<!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
-     Decided during Design. Checked off during Implement. -->
+- [ ] Phase 1: 将核心 workflow 真源迁移到 `plugin/skills/zest-dev/SKILL.md`，并压薄 `new/research/design/implement` commands。
+- [ ] Phase 2: 对齐 prompt 兼容层、组合入口、文档与集成测试，确保一次性迁移后的行为一致性。
 
 ## Notes
 

--- a/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
+++ b/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
@@ -1,8 +1,8 @@
 ---
-id: "20260421-thick-skill-thin-command-workflow"
-name: "Thick Skill Thin Command Workflow"
-status: new
-created: "2026-04-21"
+id: 20260421-thick-skill-thin-command-workflow
+name: Thick Skill Thin Command Workflow
+status: researched
+created: '2026-04-21'
 ---
 
 ## Overview
@@ -27,7 +27,42 @@ created: "2026-04-21"
 
 ## Research
 
-<!-- What have we found out? What are the alternatives considered? -->
+### Existing System
+- `zest-dev` CLI 负责 spec 生命周期与 prompt 生成：`status/show/create/set-active/update/create-branch/init/prompt` 都在同一入口实现。关键入口见 `bin/zest-dev.js:97-246`。
+- spec 状态由 `lib/spec-manager.js:11-17` 和 `lib/spec-manager.js:319-369` 管理，当前只支持 `new → researched → designed → implemented` 的前进式流转，active spec 通过 `specs/change/active` symlink 表示，见 `lib/spec-manager.js:70-72`、`lib/spec-manager.js:236-265`。
+- command workflow 以 `plugin/commands/*.md` 的 markdown prompt 形式存在，`/new`、`/research`、`/design`、`/implement`、`/draft`、`/summarize-*` 等流程都通过文档步骤定义，见 `plugin/commands/new.md:1-138`、`plugin/commands/research.md:1-142`、`plugin/commands/design.md:1-180`、`plugin/commands/implement.md:1-85`、`plugin/commands/draft.md:1-163`。
+- `zest-dev prompt <command>` 会读取 `plugin/commands/<command>.md`，去掉 frontmatter，并替换 `$ARGUMENTS`，把 command 文档转成自然语言 prompt 文本，见 `bin/zest-dev.js:230-244` 与 `lib/prompt-generator.js:10-37`。
+- 部署时，command 会被复制到 `.opencode/commands/` 并统一加上 `zest-dev-` 前缀；skill 会整目录复制到 `.opencode/skills/`。部署逻辑在 `lib/plugin-deployer.js:122-173`、`lib/plugin-deployer.js:179-223`。
+- 已部署 command 的 frontmatter 会被裁剪为仅保留 `description`，其余如 `argument-hint` 不会进入部署产物，见 `lib/plugin-deployer.js:30-42`。
+- `plugin/skills/zest-dev/SKILL.md:1-306` 当前主要承担方法论说明和触发描述；`plugin/skills/debug-mode/SKILL.md:1-280` 展示了 skill 目录可同时包含 `SKILL.md` 与辅助脚本（如 `server.js`）的结构。
+- 仓库文档要求 prompt 以能力/角色描述为主，避免绑定 Claude 特有工具或固定 agent 名称，并明确部署后的 OpenCode command 只保留 `description` frontmatter，见 `AGENTS.md:7-24`。
+
+### Available Approaches
+- **Command markdown 入口**：继续以 `plugin/commands/*.md` 定义具体 workflow 步骤，再由部署产物和 `/command` 入口触发，见 `plugin/commands/research.md:1-142`。
+- **CLI prompt 生成入口**：通过 `zest-dev prompt <command>` 读取 command markdown，并将其作为普通 prompt 提供给编辑器或代理，见 `bin/zest-dev.js:230-244`、`lib/prompt-generator.js:10-37`。
+- **Skill 触发入口**：通过 `SKILL.md` 的 description 和正文方法论，让自然语言或特定短语直接触发 workflow/skill，见 `plugin/skills/zest-dev/SKILL.md:1-306`、`plugin/skills/debug-mode/SKILL.md:1-7`。
+
+### Constraints & Dependencies
+- command 与 skill 当前都依赖 `zest-dev` CLI 和 `specs/change/` 目录来读取 active spec、创建 spec、推进状态，见 `plugin/README.md:35-39`、`lib/spec-manager.js:153-180`。
+- 现有命令式 workflow 明确约束各阶段顺序：`new → researched → designed → implemented`，而 `updateSpecStatus` 禁止回退状态，见 `lib/spec-manager.js:321-349`。
+- 部署到 OpenCode 后，command 文档不能依赖 `allowed-tools`、`argument-hint` 等前端作者字段；相关信息需要通过正文表达，见 `AGENTS.md:19-24`、`lib/plugin-deployer.js:35-42`。
+- prompt 编写规范要求使用通用的“explorer/architect/reviewer subagent”等角色语言，而非硬编码某个平台专属 agent 或工具名，见 `AGENTS.md:11-17`。
+- 当前 `generatePrompt` 只接受固定 command 名称集合 `new/research/design/implement/summarize/archive`，说明 CLI prompt 入口本身有一层枚举式约束，见 `lib/prompt-generator.js:10-15`。
+
+### Key References
+- `bin/zest-dev.js:102-244` - CLI 对 spec 管理、plugin 部署和 prompt 生成的统一入口。
+- `lib/spec-manager.js:99-131` - project status 与 active change spec 的解析逻辑。
+- `lib/spec-manager.js:236-369` - active spec 设置和前进式状态迁移规则。
+- `lib/prompt-generator.js:10-37` - 读取 command markdown、剥离 frontmatter、替换 `$ARGUMENTS` 的逻辑。
+- `lib/plugin-deployer.js:35-42` - command 部署时仅保留 `description` frontmatter。
+- `lib/plugin-deployer.js:122-173` - command 与 skill 的部署方式。
+- `plugin/commands/new.md:16-138` - 从用户描述创建 spec 并写入 Overview 的现有流程。
+- `plugin/commands/research.md:51-142` - 当前 research 阶段对探索、阅读、写回 spec 的要求。
+- `plugin/commands/design.md:57-180` - 当前 design 阶段对澄清、架构综合与状态更新的定义。
+- `plugin/commands/implement.md:38-85` - 当前 implement 阶段对按设计实现、记录 Notes、更新状态的定义。
+- `plugin/commands/draft.md:93-145` - 对话到 spec，再选择后续 workflow 的桥接模式。
+- `plugin/skills/zest-dev/SKILL.md:237-259` - skill 中已定义的 workflow 入口模型：step-by-step、vibe coding、discussion-driven。
+- `AGENTS.md:11-24` - command prompt 的可移植性约束与通用角色写法规范。
 
 ## Design
 

--- a/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
+++ b/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260421-thick-skill-thin-command-workflow
 name: Thick Skill Thin Command Workflow
-status: designed
+status: implemented
 created: '2026-04-21'
 ---
 
@@ -192,8 +192,8 @@ Inside Zest Dev skill:
 
 ## Plan
 
-- [ ] Phase 1: 将核心 workflow 真源迁移到 `plugin/skills/zest-dev/SKILL.md`，并压薄 `new/research/design/implement` commands。
-- [ ] Phase 2: 对齐 prompt 兼容层、组合入口、文档与集成测试，确保一次性迁移后的行为一致性。
+- [x] Phase 1: 将核心 workflow 真源迁移到 `plugin/skills/zest-dev/SKILL.md`，并压薄 `new/research/design/implement` commands。
+- [x] Phase 2: 对齐 prompt 兼容层、组合入口、文档与集成测试，确保一次性迁移后的行为一致性。
 
 ## Notes
 
@@ -201,8 +201,16 @@ Inside Zest Dev skill:
 
 ### Implementation
 
-<!-- Files created/modified, decisions made during coding, deviations from design -->
+- `plugin/skills/zest-dev/SKILL.md` - 重写为四个核心 phase 的 canonical workflow 真源，并收敛共享规则、phase 路由与 bridge workflow 说明。
+- `plugin/commands/{new,research,design,implement}.md` - 压薄为进入主 skill 对应 phase 的轻入口，保留最小上下文与关键约束。
+- `plugin/commands/{draft,quick-implement}.md` - 改为 bridge 入口，复用主 skill phase，而不是继续内嵌完整厚流程。
+- `lib/prompt-generator.js` - 改为从 `plugin/commands/` 实际文件集合动态派生可用 command，并保留 `summarize -> summarize-chat` 兼容别名。
+- `README.md`、`plugin/README.md` - 更新为 thick skill / thin command 架构说明，并对齐 prompt 与命令使用方式。
+- `test/test-integration.js` - 增加 skill 真源、thin command、实际 prompt command 集合与 summarize alias 的集成测试。
+- 编码时额外决定：为避免已有 `zest-dev prompt summarize` 用法回归，保留兼容 alias，而不是完全移除旧入口名。
 
 ### Verification
 
-<!-- How the feature was verified: tests written, manual testing steps, results -->
+- 运行 `pnpm install` 以安装仓库依赖。
+- 运行 `pnpm test:local`，33 个集成测试全部通过。
+- 手动验证 `zest-dev status` 与 `zest-dev show active`，确认 active spec 读取正常；并验证实现过程中已将 `Plan` 两个 phase 都标记为 `[x]`。

--- a/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
+++ b/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
@@ -1,0 +1,51 @@
+---
+id: "20260421-thick-skill-thin-command-workflow"
+name: "Thick Skill Thin Command Workflow"
+status: new
+created: "2026-04-21"
+---
+
+## Overview
+
+### Problem Statement
+- 当前工作流能力分散在 command 中，导致维护成本偏高，且不同入口之间的行为容易不一致。
+- 需要将更多工作流能力沉淀到 skill 中，让命令触发和自然语言 prompt 的使用体验更统一。
+
+### Goals
+- 将 research、design、implement 等流程收敛到 skill 内部，由 skill 负责主要逻辑与编排。
+- 让 command 仅作为轻量触发入口，尽量减少 command 中的流程逻辑。
+- 支持用户不依赖专门 command，仅通过简单 prompt 也能触发对应的 skill/workflow。
+
+### Scope
+**In scope:**
+- 设计兼容 command 和自由 prompt 的 skill 触发机制。
+- 明确 command 与 skill 的职责边界。
+- 评估现有 command 中哪些流程适合优先迁移到 skill。
+
+### Constraints
+- 需要保证 prompt 直触发时的稳定性和可预测性。
+
+## Research
+
+<!-- What have we found out? What are the alternatives considered? -->
+
+## Design
+
+<!-- Technical approach, architecture decisions -->
+
+## Plan
+
+<!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
+     Decided during Design. Checked off during Implement. -->
+
+## Notes
+
+<!-- Optional sections — add what's relevant. -->
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->

--- a/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
+++ b/specs/change/20260421-thick-skill-thin-command-workflow/spec.md
@@ -202,7 +202,10 @@ Inside Zest Dev skill:
 ### Implementation
 
 - `plugin/skills/zest-dev/SKILL.md` - 重写为四个核心 phase 的 canonical workflow 真源，并收敛共享规则、phase 路由与 bridge workflow 说明。
+- `plugin/skills/zest-dev/{new,research,design,implement}.md` - 将四个核心 phase 的详细 workflow 从 `SKILL.md` 中拆出，改为按 phase 分文件维护。
 - `plugin/commands/{new,research,design,implement}.md` - 压薄为进入主 skill 对应 phase 的轻入口，保留最小上下文与关键约束。
+- `plugin/commands/{new,research,design,implement}.md` - 进一步压薄为只声明 phase 入口，并引用 skill 共享规则文件与对应 phase 文件。
+- `plugin/commands/{new,research,design,implement}.md` - 四个核心入口统一补上 `$ARGUMENTS` 透传，允许 phase-specific 的 scope / focus / constraint hint 继续传给 skill。
 - `plugin/commands/{draft,quick-implement}.md` - 改为 bridge 入口，复用主 skill phase，而不是继续内嵌完整厚流程。
 - `lib/prompt-generator.js` - 改为从 `plugin/commands/` 实际文件集合动态派生可用 command，并保留 `summarize -> summarize-chat` 兼容别名。
 - `README.md`、`plugin/README.md` - 更新为 thick skill / thin command 架构说明，并对齐 prompt 与命令使用方式。
@@ -213,4 +216,6 @@ Inside Zest Dev skill:
 
 - 运行 `pnpm install` 以安装仓库依赖。
 - 运行 `pnpm test:local`，33 个集成测试全部通过。
+- 验证部署后的 skill 目录包含 `SKILL.md` 和四个 phase 文件，确认拆分后的 skill 结构会被 `zest-dev init` 一并复制。
+- 验证四个核心 command 的部署产物都保留 `$ARGUMENTS` 占位符，并继续引用对应 phase skill 文件。
 - 手动验证 `zest-dev status` 与 `zest-dev show active`，确认 active spec 读取正常；并验证实现过程中已将 `Plan` 两个 phase 都标记为 `[x]`。

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -40,6 +40,7 @@ const THIN_COMMANDS = [
   'zest-dev-draft.md',
   'zest-dev-quick-implement.md'
 ];
+const SKILL_PHASE_FILES = ['new.md', 'research.md', 'design.md', 'implement.md'];
 const LANGUAGE_ALIGNMENT_RULE =
   'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.';
 
@@ -167,6 +168,11 @@ test('zest-dev init integration', async (t) => {
       const skillContent = fs.readFileSync(opencodeSkillPath, 'utf-8');
       assert.ok(skillContent.includes('This skill is the **canonical workflow source**'));
       assert.ok(skillContent.includes('Commands should stay thin'));
+
+      for (const file of SKILL_PHASE_FILES) {
+        const filePath = path.join(TEST_DIR, '.opencode/skills/zest-dev', file);
+        assert.ok(fs.existsSync(filePath), `skill phase file should exist: ${file}`);
+      }
     });
 
     await t.test('agents are not deployed', () => {
@@ -224,13 +230,22 @@ test('zest-dev init integration', async (t) => {
     });
 
     await t.test('content preservation', () => {
-      const content = readCommand('.opencode', 'zest-dev-new.md');
-      const match = content.match(/^---\n[\s\S]*?\n---\n\n([\s\S]*)/);
-      assert.ok(match, 'should be able to extract command body');
+      const coreCommands = [
+        ['zest-dev-new.md', 'Zest Dev skill'],
+        ['zest-dev-research.md', 'Zest Dev skill'],
+        ['zest-dev-design.md', 'Zest Dev skill'],
+        ['zest-dev-implement.md', 'Zest Dev skill']
+      ];
 
-      const bodyContent = match[1];
-      assert.ok(bodyContent.includes('$ARGUMENTS'), 'command body should keep $ARGUMENTS placeholder');
-      assert.ok(bodyContent.includes('Step 1'), 'command body should keep step structure');
+      for (const [file, phaseRef] of coreCommands) {
+        const content = readCommand('.opencode', file);
+        const match = content.match(/^---\n[\s\S]*?\n---\n\n([\s\S]*)/);
+        assert.ok(match, `should be able to extract command body: ${file}`);
+
+        const bodyContent = match[1];
+        assert.ok(bodyContent.includes('$ARGUMENTS'), `${file} should keep $ARGUMENTS placeholder`);
+        assert.ok(bodyContent.includes(phaseRef), `${file} should preserve skill reference`);
+      }
     });
 
     await t.test('core workflow commands are thin entrypoints', () => {
@@ -239,8 +254,15 @@ test('zest-dev init integration', async (t) => {
         assert.ok(content.includes('This command is intentionally thin.'), `${file} should declare thin entrypoint behavior`);
       }
 
+      const newContent = readCommand('.opencode', 'zest-dev-new.md');
+      assert.ok(newContent.includes('let the Zest Dev skill naturally continue with the New phase.'));
+      assert.equal(newContent.includes('**Step 1:'), false, 'new command should not re-describe phase steps');
+      assert.equal(newContent.includes('Treat this command as a request'), false, 'new command should avoid request/run phrasing');
+
       const implementContent = readCommand('.opencode', 'zest-dev-implement.md');
-      assert.ok(implementContent.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
+      assert.ok(implementContent.includes('let the Zest Dev skill naturally continue with the Implement phase.'));
+      assert.equal(implementContent.includes('**Step 1:'), false, 'implement command should not re-describe phase steps');
+      assert.equal(implementContent.includes('Treat this command as a request'), false, 'implement command should avoid request/run phrasing');
     });
 
     await t.test('idempotency', () => {
@@ -542,15 +564,15 @@ test('zest-dev prompt implement supports incremental phases', () => {
 
   try {
     const prompt = runCommand('prompt implement');
-    assert.ok(prompt.includes('Step 7: Update Spec Status (Only When Fully Complete)'));
-    assert.ok(prompt.includes('If only part of the spec is implemented'));
-    assert.ok(prompt.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
+    assert.ok(prompt.includes('let the Zest Dev skill naturally continue with the Implement phase.'));
+    assert.equal(prompt.includes('**Step 1:'), false);
+    assert.equal(prompt.includes('Treat this command as a request'), false);
 
     runInit();
     const deployedImplement = readCommand('.opencode', 'zest-dev-implement.md');
-    assert.ok(deployedImplement.includes('Step 7: Update Spec Status (Only When Fully Complete)'));
-    assert.ok(deployedImplement.includes('If only part of the spec is implemented'));
-    assert.ok(deployedImplement.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
+    assert.ok(deployedImplement.includes('let the Zest Dev skill naturally continue with the Implement phase.'));
+    assert.equal(deployedImplement.includes('**Step 1:'), false);
+    assert.equal(deployedImplement.includes('Treat this command as a request'), false);
   } finally {
     cleanup();
   }

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -175,6 +175,18 @@ test('zest-dev init integration', async (t) => {
         const filePath = path.join(TEST_DIR, '.opencode/skills/zest-dev', file);
         assert.ok(fs.existsSync(filePath), `skill phase file should exist: ${file}`);
       }
+
+      const researchPhase = fs.readFileSync(path.join(TEST_DIR, '.opencode/skills/zest-dev/research.md'), 'utf-8');
+      assert.ok(
+        researchPhase.includes('Summarize your understanding of the request and confirm it with the user'),
+        'research phase should preserve the confirmation checkpoint before deeper exploration'
+      );
+
+      const designPhase = fs.readFileSync(path.join(TEST_DIR, '.opencode/skills/zest-dev/design.md'), 'utf-8');
+      assert.ok(
+        designPhase.includes('If the status is `designed` or `implemented`, confirm that the user wants to revise the existing design before continuing.'),
+        'design phase should preserve confirmation when revising an existing design'
+      );
     });
 
     await t.test('agents are not deployed', () => {
@@ -544,6 +556,7 @@ test('zest-dev prompt supports actual command set and summarize alias', () => {
 
     const draftPrompt = runCommand('prompt draft');
     assert.ok(draftPrompt.includes('Bridge entrypoint into the Zest Dev skill.'));
+    assert.ok(draftPrompt.includes('guide the user to `/implement` as the next explicit step'));
 
     const summarizeAliasPrompt = runCommand('prompt summarize');
     const summarizeChatPrompt = runCommand('prompt summarize-chat');

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -32,6 +32,14 @@ const EXPECTED_COMMANDS = [
   'zest-dev-summarize-pr.md',
   'zest-dev-quick-implement.md'
 ];
+const THIN_COMMANDS = [
+  'zest-dev-new.md',
+  'zest-dev-research.md',
+  'zest-dev-design.md',
+  'zest-dev-implement.md',
+  'zest-dev-draft.md',
+  'zest-dev-quick-implement.md'
+];
 const LANGUAGE_ALIGNMENT_RULE =
   'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.';
 
@@ -155,6 +163,10 @@ test('zest-dev init integration', async (t) => {
       const opencodeSkillPath = path.join(TEST_DIR, '.opencode/skills/zest-dev/SKILL.md');
 
       assert.ok(fs.existsSync(opencodeSkillPath), 'OpenCode skill file should exist');
+
+      const skillContent = fs.readFileSync(opencodeSkillPath, 'utf-8');
+      assert.ok(skillContent.includes('This skill is the **canonical workflow source**'));
+      assert.ok(skillContent.includes('Commands should stay thin'));
     });
 
     await t.test('agents are not deployed', () => {
@@ -219,6 +231,16 @@ test('zest-dev init integration', async (t) => {
       const bodyContent = match[1];
       assert.ok(bodyContent.includes('$ARGUMENTS'), 'command body should keep $ARGUMENTS placeholder');
       assert.ok(bodyContent.includes('Step 1'), 'command body should keep step structure');
+    });
+
+    await t.test('core workflow commands are thin entrypoints', () => {
+      for (const file of THIN_COMMANDS) {
+        const content = readCommand('.opencode', file);
+        assert.ok(content.includes('This command is intentionally thin.'), `${file} should declare thin entrypoint behavior`);
+      }
+
+      const implementContent = readCommand('.opencode', 'zest-dev-implement.md');
+      assert.ok(implementContent.includes('Only when the full spec is complete, execute: `zest-dev update active implemented`'));
     });
 
     await t.test('idempotency', () => {
@@ -491,6 +513,25 @@ test('zest-dev prompt archive integration', () => {
     const deployedArchive = readCommand('.opencode', 'zest-dev-archive.md');
     assert.ok(deployedArchive.includes('zest-dev unset-active'));
     assert.equal(deployedArchive.includes('zest-dev archive active --no-merge'), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('zest-dev prompt supports actual command set and summarize alias', () => {
+  setup();
+
+  try {
+    const quickPrompt = runCommand('prompt quick-implement test feature');
+    assert.ok(quickPrompt.includes('Thin bridge entrypoint'));
+    assert.ok(quickPrompt.includes('test feature'));
+
+    const draftPrompt = runCommand('prompt draft');
+    assert.ok(draftPrompt.includes('Bridge entrypoint into the Zest Dev skill.'));
+
+    const summarizeAliasPrompt = runCommand('prompt summarize');
+    const summarizeChatPrompt = runCommand('prompt summarize-chat');
+    assert.equal(summarizeAliasPrompt, summarizeChatPrompt);
   } finally {
     cleanup();
   }

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -269,6 +269,11 @@ test('zest-dev init integration', async (t) => {
       const implementContent = readCommand('.opencode', 'zest-dev-implement.md');
       assert.ok(implementContent.includes('Run Zest Dev **Implement** phase workflow.'));
       assert.equal(implementContent.includes('Treat this command as a request'), false, 'implement command should avoid request/run phrasing');
+
+      const draftContent = readCommand('.opencode', 'zest-dev-draft.md');
+      assert.ok(draftContent.includes('run `zest-dev update active researched`'));
+      assert.ok(draftContent.includes('run `zest-dev update active designed`'));
+      assert.ok(draftContent.includes('the inferred status is persisted'));
     });
 
     await t.test('idempotency', () => {
@@ -557,6 +562,8 @@ test('zest-dev prompt supports actual command set and summarize alias', () => {
     const draftPrompt = runCommand('prompt draft');
     assert.ok(draftPrompt.includes('Bridge entrypoint into the Zest Dev skill.'));
     assert.ok(draftPrompt.includes('guide the user to `/implement` as the next explicit step'));
+    assert.ok(draftPrompt.includes('run `zest-dev update active researched`'));
+    assert.ok(draftPrompt.includes('run `zest-dev update active designed`'));
 
     const summarizeAliasPrompt = runCommand('prompt summarize');
     const summarizeChatPrompt = runCommand('prompt summarize-chat');

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -41,8 +41,10 @@ const THIN_COMMANDS = [
   'zest-dev-quick-implement.md'
 ];
 const SKILL_PHASE_FILES = ['new.md', 'research.md', 'design.md', 'implement.md'];
-const LANGUAGE_ALIGNMENT_RULE =
-  'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.';
+const LANGUAGE_ALIGNMENT_RULES = [
+  'Respond in the user\'s language by default, if user\'s language is not English.',
+  'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.'
+];
 
 function cleanup(testDir = TEST_DIR) {
   if (fs.existsSync(testDir)) {
@@ -154,8 +156,8 @@ test('zest-dev init integration', async (t) => {
       for (const file of EXPECTED_COMMANDS) {
         const content = readCommand('.opencode', file);
         assert.ok(
-          content.includes(LANGUAGE_ALIGNMENT_RULE),
-          `.opencode/commands/${file} should include the language alignment rule`
+          LANGUAGE_ALIGNMENT_RULES.some(rule => content.includes(rule)),
+          `.opencode/commands/${file} should include a supported language alignment rule`
         );
       }
     });
@@ -230,38 +232,30 @@ test('zest-dev init integration', async (t) => {
     });
 
     await t.test('content preservation', () => {
-      const coreCommands = [
-        ['zest-dev-new.md', 'Zest Dev skill'],
-        ['zest-dev-research.md', 'Zest Dev skill'],
-        ['zest-dev-design.md', 'Zest Dev skill'],
-        ['zest-dev-implement.md', 'Zest Dev skill']
-      ];
+      const coreCommands = ['zest-dev-new.md', 'zest-dev-research.md', 'zest-dev-design.md', 'zest-dev-implement.md'];
 
-      for (const [file, phaseRef] of coreCommands) {
+      for (const file of coreCommands) {
         const content = readCommand('.opencode', file);
         const match = content.match(/^---\n[\s\S]*?\n---\n\n([\s\S]*)/);
         assert.ok(match, `should be able to extract command body: ${file}`);
 
         const bodyContent = match[1];
         assert.ok(bodyContent.includes('$ARGUMENTS'), `${file} should keep $ARGUMENTS placeholder`);
-        assert.ok(bodyContent.includes(phaseRef), `${file} should preserve skill reference`);
       }
     });
 
     await t.test('core workflow commands are thin entrypoints', () => {
       for (const file of THIN_COMMANDS) {
         const content = readCommand('.opencode', file);
-        assert.ok(content.includes('This command is intentionally thin.'), `${file} should declare thin entrypoint behavior`);
+        assert.equal(content.includes('**Step 1:'), false, `${file} should not re-describe phase steps`);
       }
 
       const newContent = readCommand('.opencode', 'zest-dev-new.md');
-      assert.ok(newContent.includes('let the Zest Dev skill naturally continue with the New phase.'));
-      assert.equal(newContent.includes('**Step 1:'), false, 'new command should not re-describe phase steps');
+      assert.ok(newContent.includes('Run Zest Dev **New** phase workflow.'));
       assert.equal(newContent.includes('Treat this command as a request'), false, 'new command should avoid request/run phrasing');
 
       const implementContent = readCommand('.opencode', 'zest-dev-implement.md');
-      assert.ok(implementContent.includes('let the Zest Dev skill naturally continue with the Implement phase.'));
-      assert.equal(implementContent.includes('**Step 1:'), false, 'implement command should not re-describe phase steps');
+      assert.ok(implementContent.includes('Run Zest Dev **Implement** phase workflow.'));
       assert.equal(implementContent.includes('Treat this command as a request'), false, 'implement command should avoid request/run phrasing');
     });
 
@@ -564,13 +558,13 @@ test('zest-dev prompt implement supports incremental phases', () => {
 
   try {
     const prompt = runCommand('prompt implement');
-    assert.ok(prompt.includes('let the Zest Dev skill naturally continue with the Implement phase.'));
+    assert.ok(prompt.includes('Run Zest Dev **Implement** phase workflow.'));
     assert.equal(prompt.includes('**Step 1:'), false);
     assert.equal(prompt.includes('Treat this command as a request'), false);
 
     runInit();
     const deployedImplement = readCommand('.opencode', 'zest-dev-implement.md');
-    assert.ok(deployedImplement.includes('let the Zest Dev skill naturally continue with the Implement phase.'));
+    assert.ok(deployedImplement.includes('Run Zest Dev **Implement** phase workflow.'));
     assert.equal(deployedImplement.includes('**Step 1:'), false);
     assert.equal(deployedImplement.includes('Treat this command as a request'), false);
   } finally {


### PR DESCRIPTION
## Summary
- move the canonical New / Research / Design / Implement workflow logic into the Zest Dev skill and split phase-specific details into separate skill docs
- shrink the core command prompts down to thin phase entrypoints while keeping draft and quick-implement aligned with the shared skill workflow
- update prompt generation, docs, and integration tests to cover the new command/skill structure and command compatibility