### PR TITLE
improve Zest Dev workflow prompt consistency

### DIFF
--- a/.zest-dev/template/spec.md
+++ b/.zest-dev/template/spec.md
@@ -15,12 +15,14 @@ created: "{date}"
 
 ## Design
 
-<!-- Technical approach, architecture decisions -->
+<!-- Technical approach, architecture decisions, and test strategy. Each design decision should cite a fact source. -->
 
 ## Plan
 
 <!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
-     Decided during Design. Checked off during Implement. -->
+     Decided during Design. Checked off during Implement.
+     Each phase should include both implementation and validation; do not create a testing-only phase.
+     Each phase should be small enough to finish implementation + verification in one coding session. -->
 
 ## Notes
 

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -15,24 +15,23 @@ created: "{date}"
 
 ## Design
 
-<!-- Technical approach, architecture decisions -->
+<!-- Technical approach, architecture decisions, and test strategy. Each design decision should cite a fact source. -->
 
 ## Plan
 
-<!-- Break down implementation and verification into steps -->
-
-- [ ] Phase 1: Implement the first part of the feature
-  - [ ] Task 1
-  - [ ] Task 2
-  - [ ] Task 3
-- [ ] Phase 2: Implement the second part of the feature
-  - [ ] Task 1
-  - [ ] Task 2
-  - [ ] Task 3
-- [ ] Phase 3: Test and verify
-  - [ ] Test criteria 1
-  - [ ] Test criteria 2
+<!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
+     Decided during Design. Checked off during Implement.
+     Each phase should include both implementation and validation; do not create a testing-only phase.
+     Each phase should be small enough to finish implementation + verification in one coding session. -->
 
 ## Notes
 
-<!-- Optional: Alternatives considered, open questions, etc. -->
+<!-- Optional sections — add what's relevant. -->
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -26,6 +26,8 @@ Use this command as a lightweight bridge:
 - infer the highest status genuinely reached by the conversation
 
 If the conversation already reached research or design depth, fill those sections briefly using the same canonical rules from the Zest Dev skill.
+- `## Research`: facts only, and every finding must include a fact source.
+- `## Design`: list design decisions with fact sources and include the matching test strategy.
 
 Then persist the inferred status explicitly:
 - if the highest reached status is `new`, leave the status as-is

--- a/plugin/commands/summarize-chat.md
+++ b/plugin/commands/summarize-chat.md
@@ -66,32 +66,21 @@ Fill sections based on the status:
 - **Success Criteria**: How to measure success
 
 **If status is "researched" or later - Fill Research section:**
-- **Existing Systems**: Code, patterns, or infrastructure explored
-- **Options Evaluated**: 2-3 alternatives with trade-offs (use table)
-- **Recommended Approach**: Chosen direction with rationale
-- **Key Findings**: Insights discovered during exploration
-- **File References**: Important files found (use `file:line` format)
+- Follow the canonical Research rules from the Zest Dev skill
+- Facts only; do not backfill design recommendations into Research
+- Every finding must include a fact source from code, database artifacts, or documentation
+- Reuse sources already present in the conversation/worklog when possible
 
 **If status is "designed" or later - Fill Design section:**
-- **Chosen Approach**: Brief description of architecture and why
-- **Architecture**: Visual diagram of components and data flow
-- **Implementation Steps**: Numbered sequence of what to build
-- **Pseudocode**: Logic for non-trivial algorithms
-- **Files to Modify**: List of files with descriptions
-- **Edge Cases**: How to handle errors and unusual scenarios
-- **Design Decisions**: Key decisions with rationale
+- Follow the canonical Design rules from the Zest Dev skill
+- List all meaningful design decisions and attach fact sources
+- Include the matching test strategy alongside the implementation design
+- If a `## Plan` phase breakdown is added, each phase must include implementation + validation; do not create a testing-only phase
 
-**If status is "implemented" - Fill Implementation section:**
-- **Tasks**: Checklist with completed tasks marked `[x]`
-- **Files Modified**: All created/modified files with descriptions and line counts
-- **Testing**: What tests were written and their status
-- **Design Changes**: Any deviations from original design with rationale
-- **Summary**:
-  - What was built
-  - Key decisions made
-  - Files modified (with totals)
-  - Testing status
-  - Current status and next steps
+**If status is "implemented" - Fill Notes section:**
+- `### Implementation`: What was built, files changed, and design deviations
+- `### Verification`: Tests written/run, results, manual validation, and relevant fix-and-rerun notes
+- Only treat work as implemented when the relevant tests were actually run and passed
 
 **Step 5: Update Spec Status**
 
@@ -129,6 +118,7 @@ Inform the user:
 - **File references**: Link to relevant files, don't paste full code
 - **Rationale**: Always include "why" for key decisions
 - **Challenges**: Document what was hard and how it was solved
+- **Source discipline**: Research findings and design decisions need fact sources
 
 **Example Scenario:**
 

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -167,17 +167,19 @@ Use when the design is ready and the user approves coding.
 ## Research
 
 ### Existing System
-- ...
+- ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
 
 ### Available Approaches
-- **Option A**: ...
-- **Option B**: ...
+- **Option A**: ... Source: `path/to/file:line`
+- **Option B**: ... Source: `docs/path.md#section`
 
 ### Constraints & Dependencies
-- ...
+- ... Source: `path/to/file:line`
 
 ### Key References
 - `path/to/file:line` - ...
+
+Every research finding must include a fact source from code, database artifacts, or documentation.
 ```
 
 ### Design
@@ -187,11 +189,17 @@ Use when the design is ready and the user approves coding.
 ### Architecture Overview
 [diagram]
 
+### Design Decisions
+- Decision: ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
+
 ### Why this design
 - ...
 
 ### Implementation Steps
 1. ...
+
+### Test Strategy
+- Phase/area: ... Validation: ... Source: `path/to/file:line`
 
 ### Pseudocode
 Flow:
@@ -201,6 +209,10 @@ Flow:
 ### File Structure
 - `path/to/file` - ...
 ```
+
+List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
+
+If `## Plan` is used, each phase must include its own implementation and validation. Do not create a testing-only phase. Each phase should be small enough for one coding agent session to implement and verify.
 
 ### Notes
 ```markdown

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -16,16 +16,26 @@ Canonical workflow for designing an active change spec.
 4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
 5. Ask the user clarifying questions when needed.
 6. Wait for answers before finalizing the architecture when the open questions are consequential.
-7. Synthesize one recommended architecture by default.
+7. Synthesize one recommended architecture by default, including the matching test strategy.
 8. Fill `## Design` with:
    - Architecture Overview
+   - Design Decisions
    - Why this design
    - Implementation Steps
+   - Test Strategy
    - Pseudocode
    - File Structure
    - Interfaces / APIs
    - Edge Cases
+   - List all design decisions.
+   - Every design decision must cite its fact source inline or immediately adjacent to it.
+   - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.
+   - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
 9. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
+   - Do not create a dedicated testing/verification phase.
+   - Each phase must include both implementation work and its own testing/verification.
+   - A phase is complete only when its relevant tests pass.
+   - Size each phase so a coding agent can implement and validate it within a single session.
 10. Run `zest-dev update active designed`.
 11. Present the design and stop for implementation approval.
 

--- a/plugin/skills/zest-dev/implement.md
+++ b/plugin/skills/zest-dev/implement.md
@@ -13,13 +13,14 @@ Canonical workflow for implementing an active change spec.
 4. Create a task list.
 5. Present the implementation scope and get explicit approval.
 6. Implement the feature following the design and repository conventions.
-7. Write or update tests alongside the implementation.
-8. After each completed plan phase, mark the corresponding `## Plan` checkbox as `[x]`.
-9. Fill `## Notes` with brief:
-   - `### Implementation`
-   - `### Verification`
-10. If the full spec is complete, run `zest-dev update active implemented`.
-11. If only part of the work is complete, keep the current non-final status and document what was done.
+7. Write or update tests alongside the implementation, not afterward.
+8. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
+9. After each completed plan phase, mark the corresponding `## Plan` checkbox as `[x]` only when that phase's implementation and validation are both complete.
+10. Fill `## Notes` with brief:
+    - `### Implementation`
+    - `### Verification`
+11. If the full spec is complete, run `zest-dev update active implemented`.
+12. If only part of the work is complete, keep the current non-final status and document what was done.
 
 ## Rule
 Only mark the spec `implemented` when the whole plan is finished.

--- a/plugin/skills/zest-dev/research.md
+++ b/plugin/skills/zest-dev/research.md
@@ -19,6 +19,8 @@ Canonical workflow for researching an active change spec.
    - Available Approaches
    - Constraints & Dependencies
    - Key References
+   - Every finding must cite its fact source inline or immediately adjacent to it.
+   - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
 9. If the current status is `new`, run `zest-dev update active researched`.
 10. If this is a refresh for a later-phase spec, keep the current status and do not downgrade it.
 11. Summarize findings and point to the design phase.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -317,6 +317,13 @@ test('zest-dev create integration', async (t) => {
       assert.equal(frontmatter.status, 'new');
       assert.equal(typeof frontmatter.created, 'string');
       assert.ok(content.includes('## Overview'), 'should use packaged default template');
+      assert.ok(
+        content.includes('do not create a testing-only phase'),
+        'packaged default template should forbid testing-only phases'
+      );
+      assert.ok(content.includes('### Implementation'), 'packaged default template should include Implementation notes section');
+      assert.ok(content.includes('### Verification'), 'packaged default template should include Verification notes section');
+      assert.equal(content.includes('Phase 3: Test and verify'), false);
       assert.equal(content.includes('{name}'), false);
       assert.equal(content.includes('{date}'), false);
     });


### PR DESCRIPTION
## Summary
- require factual sources for research findings and design decisions across the core Zest Dev workflows and related bridge commands
- add integrated test-strategy guidance to design prompts and require plan phases to include both implementation and validation
- tighten implement guidance so testing happens during implementation and phases only complete once relevant tests pass