### PR TITLE
[codex] support Codex-target plugin deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 specs/change/active
 
 # Generated plugin deployment directories
+.agents/**/zest-dev/
+.agents/**/zest-dev*.md
 .cursor/**/zest-dev/
 .cursor/**/zest-dev*.md
 .cursor/**/debug-mode/
@@ -10,6 +12,7 @@ specs/change/active
 .opencode/**/zest-dev*.md
 .opencode/**/debug-mode/
 .opencode/agents
+.codex/agents
 
 # Logs
 logs

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -216,10 +216,11 @@ program
 // zest-dev init
 program
   .command('init')
-  .description('Initialize plugin deployment to .opencode directories')
-  .action(() => {
+  .description('Initialize plugin deployment for a target ecosystem')
+  .option('-t, --target <target>', 'Deployment target (opencode|codex)', 'opencode')
+  .action((options) => {
     try {
-      const result = deployPlugin();
+      const result = deployPlugin(options.target);
       console.log(yaml.dump(result));
     } catch (error) {
       console.error('Error:', error.message);

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -253,7 +253,7 @@ function deployCodexSubagents() {
     const tomlContent = [
       `name = "${frontmatter.name || agentName}"`,
       `description = ${toTomlMultiline(frontmatter.description || '')}`,
-      `prompt = ${toTomlMultiline(content)}`,
+      `developer_instructions = ${toTomlMultiline(content)}`,
       ''
     ].join('\n');
 

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -69,6 +69,21 @@ function ensureDirectories() {
 }
 
 /**
+ * Create target directories for Codex deployment
+ */
+function ensureCodexDirectories() {
+  const dirs = [
+    '.codex/agents',
+    '.agents/skills/zest-dev'
+  ];
+
+  dirs.forEach(dir => {
+    const fullPath = path.join(process.cwd(), dir);
+    fs.mkdirSync(fullPath, { recursive: true });
+  });
+}
+
+/**
  * Remove legacy deployed agent files without deleting directories
  *
  * Legacy installs may have written files into .opencode/agents.
@@ -173,10 +188,88 @@ function deploySkills() {
 }
 
 /**
+ * Deploy command markdown files for Codex skill layout
+ * @returns {string[]} Deployed file lists
+ */
+function deployCodexCommandPrompts() {
+  const sourceDir = path.join(__dirname, '../plugin/commands');
+  const commandFiles = fs.readdirSync(sourceDir)
+    .filter(f => f.endsWith('.md'))
+    .sort();
+
+  const codexCommandsDir = path.join(process.cwd(), '.agents/skills/zest-dev/commands');
+  fs.mkdirSync(codexCommandsDir, { recursive: true });
+
+  const result = [];
+  commandFiles.forEach(filename => {
+    const sourcePath = path.join(sourceDir, filename);
+    const { frontmatter, content } = parseMarkdownWithFrontmatter(sourcePath);
+    const transformedFrontmatter = transformFrontmatter(frontmatter);
+    const prefixedFilename = `zest-dev-${filename}`;
+
+    const targetPath = path.join(codexCommandsDir, prefixedFilename);
+    writeMarkdownWithFrontmatter(targetPath, transformedFrontmatter, content);
+    result.push(`commands/${prefixedFilename}`);
+  });
+
+  return result;
+}
+
+/**
+ * Deploy skills for Codex layout
+ * @returns {string[]} Deployed files/dirs
+ */
+function deployCodexSkills() {
+  const sourceDir = path.join(__dirname, '../plugin/skills/zest-dev');
+  const targetDir = path.join(process.cwd(), '.agents/skills/zest-dev');
+  fs.mkdirSync(targetDir, { recursive: true });
+  copyDirectoryRecursive(sourceDir, targetDir);
+
+  const entries = fs.readdirSync(targetDir, { withFileTypes: true })
+    .map(entry => entry.isDirectory() ? `${entry.name}/` : entry.name)
+    .sort();
+
+  return entries;
+}
+
+function toTomlMultiline(value) {
+  return `"""${value.replace(/"""/g, '\\"\\"\\"')}"""`;
+}
+
+/**
+ * Deploy exactly three codex subagent TOML files
+ * @returns {string[]} deployed agent filenames
+ */
+function deployCodexSubagents() {
+  const sourceDir = path.join(__dirname, '../plugin/agents');
+  const targetDir = path.join(process.cwd(), '.codex/agents');
+  const expectedAgents = ['code-architect', 'code-explorer', 'code-reviewer'];
+  const deployed = [];
+
+  expectedAgents.forEach(agentName => {
+    const sourcePath = path.join(sourceDir, `${agentName}.md`);
+    const { frontmatter, content } = parseMarkdownWithFrontmatter(sourcePath);
+
+    const tomlContent = [
+      `name = "${frontmatter.name || agentName}"`,
+      `description = ${toTomlMultiline(frontmatter.description || '')}`,
+      `prompt = ${toTomlMultiline(content)}`,
+      ''
+    ].join('\n');
+
+    const targetFilename = `${agentName}.toml`;
+    fs.writeFileSync(path.join(targetDir, targetFilename), tomlContent, 'utf-8');
+    deployed.push(targetFilename);
+  });
+
+  return deployed;
+}
+
+/**
  * Main deployment function
  * @returns {Object} Deployment result with status and deployed files
  */
-function deployPlugin() {
+function deployPlugin(target = 'opencode') {
   try {
     // 1. Verify plugin directory exists
     const pluginDir = path.join(__dirname, '../plugin');
@@ -184,32 +277,61 @@ function deployPlugin() {
       throw new Error('Plugin directory not found. Make sure you are in the zest-dev project root.');
     }
 
-    // 2. Create target directories
-    ensureDirectories();
+    if (target === 'opencode') {
+      ensureDirectories();
+      cleanupLegacyAgentFiles();
+      const commandsResult = deployCommands();
+      const skillsResult = deploySkills();
 
-    // 2.5. Clean stale legacy agent files (do not remove directories)
-    cleanupLegacyAgentFiles();
+      return {
+        ok: true,
+        target,
+        cursor: {
+          commands: [],
+          skills: [],
+          agents: []
+        },
+        opencode: {
+          commands: commandsResult,
+          skills: skillsResult,
+          agents: []
+        },
+        codex: {
+          commands: [],
+          skills: [],
+          agents: []
+        }
+      };
+    }
 
-    // 3. Deploy commands
-    const commandsResult = deployCommands();
+    if (target === 'codex') {
+      ensureCodexDirectories();
+      const codexCommands = deployCodexCommandPrompts();
+      const codexSkills = deployCodexSkills();
+      const codexAgents = deployCodexSubagents();
 
-    // 4. Deploy skills
-    const skillsResult = deploySkills();
+      return {
+        ok: true,
+        target,
+        cursor: {
+          commands: [],
+          skills: [],
+          agents: []
+        },
+        opencode: {
+          commands: [],
+          skills: [],
+          agents: []
+        },
+        codex: {
+          commands: codexCommands,
+          skills: codexSkills,
+          agents: codexAgents
+        }
+      };
+    }
 
-    // 5. Return result grouped by target
-    return {
-      ok: true,
-      cursor: {
-        commands: [],
-        skills: [],
-        agents: []
-      },
-      opencode: {
-        commands: commandsResult,
-        skills: skillsResult,
-        agents: []
-      }
-    };
+    throw new Error(`Invalid target: ${target}. Expected one of: opencode, codex`);
   } catch (error) {
     // Wrap low-level errors with context
     if (error.code === 'EACCES') {

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -41,6 +41,7 @@ const THIN_COMMANDS = [
   'zest-dev-quick-implement.md'
 ];
 const SKILL_PHASE_FILES = ['new.md', 'research.md', 'design.md', 'implement.md'];
+const CODEX_SUBAGENTS = ['code-architect.toml', 'code-explorer.toml', 'code-reviewer.toml'];
 const LANGUAGE_ALIGNMENT_RULES = [
   'Respond in the user\'s language by default, if user\'s language is not English.',
   'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.'
@@ -71,6 +72,26 @@ function runCommand(command, cwd = TEST_DIR) {
 
 function runInit(cwd = TEST_DIR) {
   return runCommand('init', cwd);
+}
+
+function runInitWithTarget(target, cwd = TEST_DIR) {
+  return runCommand(`init -t ${target}`, cwd);
+}
+
+function runCommandExpectFailure(command, cwd = TEST_DIR) {
+  try {
+    execSync(`${CLI_COMMAND} ${command}`, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: 'pipe'
+    });
+    return { failed: false, output: '' };
+  } catch (error) {
+    return {
+      failed: true,
+      output: [error.stdout, error.stderr, error.message].filter(Boolean).join('\n')
+    };
+  }
 }
 
 function runCreate(slug, cwd = TEST_DIR) {
@@ -112,13 +133,15 @@ test('zest-dev init integration', async (t) => {
   try {
     const firstRunOutput = runInit();
 
-    await t.test('output format', () => {
+    await t.test('default target output format (opencode)', () => {
       const result = yaml.load(firstRunOutput);
 
       assert.equal(result.ok, true, 'output should include ok: true');
-      assert.ok(result.cursor && result.opencode, 'output should group by cursor/opencode');
+      assert.equal(result.target, 'opencode', 'default init target should be opencode');
+      assert.ok(result.cursor && result.opencode && result.codex, 'output should include grouped targets');
       assert.ok(Array.isArray(result.cursor.commands), 'cursor.commands should be an array');
       assert.ok(Array.isArray(result.opencode.commands), 'opencode.commands should be an array');
+      assert.ok(Array.isArray(result.codex.commands), 'codex.commands should be an array');
       assert.ok(Array.isArray(result.cursor.skills), 'cursor.skills should be an array');
       assert.ok(Array.isArray(result.cursor.agents), 'cursor.agents should be an array');
       assert.ok(Array.isArray(result.opencode.agents), 'opencode.agents should be an array');
@@ -126,6 +149,9 @@ test('zest-dev init integration', async (t) => {
       assert.deepEqual(result.cursor.skills, [], 'cursor.skills should be empty');
       assert.deepEqual(result.cursor.agents, [], 'cursor.agents should be empty');
       assert.deepEqual(result.opencode.agents, [], 'opencode.agents should be empty');
+      assert.deepEqual(result.codex.commands, [], 'codex.commands should be empty for opencode target');
+      assert.deepEqual(result.codex.skills, [], 'codex.skills should be empty for opencode target');
+      assert.deepEqual(result.codex.agents, [], 'codex.agents should be empty for opencode target');
     });
 
     await t.test('directory structure', () => {
@@ -287,6 +313,51 @@ test('zest-dev init integration', async (t) => {
         opencodeCommands.length,
         EXPECTED_COMMANDS.length,
         'opencode commands count should remain unchanged'
+      );
+    });
+
+    await t.test('codex target deploys codex-specific layout with exactly three subagents', () => {
+      const codexOutput = yaml.load(runInitWithTarget('codex'));
+      assert.equal(codexOutput.ok, true);
+      assert.equal(codexOutput.target, 'codex');
+      assert.deepEqual(codexOutput.opencode.commands, [], 'opencode commands should be empty for codex target');
+      assert.equal(fs.existsSync(path.join(TEST_DIR, '.opencode', 'commands', EXPECTED_COMMANDS[0])), true, 'existing opencode files are preserved from previous init');
+
+      const codexAgentsDir = path.join(TEST_DIR, '.codex/agents');
+      const codexSkillRoot = path.join(TEST_DIR, '.agents/skills/zest-dev');
+      const codexCommandsDir = path.join(codexSkillRoot, 'commands');
+
+      assert.ok(fs.existsSync(codexAgentsDir), '.codex/agents should exist');
+      assert.ok(fs.existsSync(codexSkillRoot), '.agents/skills/zest-dev should exist');
+      assert.ok(fs.existsSync(codexCommandsDir), '.agents/skills/zest-dev/commands should exist');
+      assert.equal(fs.existsSync(path.join(TEST_DIR, 'AGENTS.md')), false, 'AGENTS.md should not be generated for codex target');
+
+      const subagents = fs.readdirSync(codexAgentsDir).sort();
+      assert.deepEqual(subagents, CODEX_SUBAGENTS, 'codex should deploy exactly three subagent toml files');
+
+      for (const subagent of CODEX_SUBAGENTS) {
+        const content = fs.readFileSync(path.join(codexAgentsDir, subagent), 'utf-8');
+        assert.ok(content.includes('name = '), `${subagent} should contain name field`);
+        assert.ok(content.includes('prompt = '), `${subagent} should contain prompt field`);
+      }
+
+      const codexCommandFile = path.join(codexCommandsDir, 'zest-dev-new.md');
+      assert.ok(fs.existsSync(codexCommandFile), 'codex command prompt should be deployed');
+      const opencodeCommandFile = path.join(TEST_DIR, '.opencode/commands/zest-dev-new.md');
+      assert.ok(fs.existsSync(opencodeCommandFile), 'opencode command should be deployed');
+      assert.notEqual(
+        codexCommandFile,
+        opencodeCommandFile,
+        'codex and opencode command outputs should differ by target path'
+      );
+    });
+
+    await t.test('invalid target fails with clear error', () => {
+      const failed = runCommandExpectFailure('init --target invalid');
+      assert.equal(failed.failed, true, 'init with invalid target should fail');
+      assert.ok(
+        failed.output.includes('Invalid target: invalid. Expected one of: opencode, codex'),
+        'error should clearly describe valid targets'
       );
     });
   } finally {

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -338,7 +338,7 @@ test('zest-dev init integration', async (t) => {
       for (const subagent of CODEX_SUBAGENTS) {
         const content = fs.readFileSync(path.join(codexAgentsDir, subagent), 'utf-8');
         assert.ok(content.includes('name = '), `${subagent} should contain name field`);
-        assert.ok(content.includes('prompt = '), `${subagent} should contain prompt field`);
+        assert.ok(content.includes('developer_instructions = '), `${subagent} should contain developer_instructions field`);
       }
 
       const codexCommandFile = path.join(codexCommandsDir, 'zest-dev-new.md');


### PR DESCRIPTION
## What changed
- add `zest-dev init --target <target>` and keep `opencode` as the default target
- add Codex-specific deployment paths for commands, skills, and exactly three subagent TOML files
- extend integration tests to cover Codex target output and invalid target handling
- ignore generated Codex agent artifacts in `.gitignore`

## Why
The project already distinguishes OpenCode-specific deployment behavior, but it did not provide a first-class deployment target for Codex. This change adds that target without changing the existing default flow.

## Impact
Users can now initialize plugin deployment for either OpenCode or Codex from the same CLI entrypoint.

## Validation
- reviewed diff against `main`
- branch pushed successfully to GitHub
- tests not run in this session