### PR TITLE
improve phase-based plan guidance for Zest Dev specs

### DIFF
--- a/.zest-dev/template/spec.md
+++ b/.zest-dev/template/spec.md
@@ -21,6 +21,17 @@ created: "{date}"
 
 <!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
      Decided during Design. Checked off during Implement.
+     Keep this section compact and phase-based.
+     Use markdown checkboxes for all phase items, for example:
+     - [ ] Phase 1: Foo
+       - [ ] Implement: Foo
+       - [ ] Verify: Foo
+     - [ ] Phase 2: Bar
+       - [ ] Implement: Bar
+       - [ ] Verify: Bar
+     - [ ] Phase 3: Baz
+       - [ ] Implement: Baz
+       - [ ] Verify: Baz
      Use a capability-based phase breakdown with reviewable, meaningful increments.
      Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
      Each implementation phase must include implementation + immediate testing/verification.

--- a/.zest-dev/template/spec.md
+++ b/.zest-dev/template/spec.md
@@ -21,8 +21,13 @@ created: "{date}"
 
 <!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
      Decided during Design. Checked off during Implement.
-     Each phase should include both implementation and validation; do not create a testing-only phase.
-     Each phase should be small enough to finish implementation + verification in one coding session. -->
+     Use a capability-based phase breakdown with reviewable, meaningful increments.
+     Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
+     Each implementation phase must include implementation + immediate testing/verification.
+     The final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
+     A phase is complete only when relevant tests pass.
+     Size phases so one coding agent can implement + validate in a single session.
+     Write each phase to clearly state both implementation scope and verification approach. -->
 
 ## Notes
 

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -21,6 +21,17 @@ created: "{date}"
 
 <!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
      Decided during Design. Checked off during Implement.
+     Keep this section compact and phase-based.
+     Use markdown checkboxes for all phase items, for example:
+     - [ ] Phase 1: Foo
+       - [ ] Implement: Foo
+       - [ ] Verify: Foo
+     - [ ] Phase 2: Bar
+       - [ ] Implement: Bar
+       - [ ] Verify: Bar
+     - [ ] Phase 3: Baz
+       - [ ] Implement: Baz
+       - [ ] Verify: Baz
      Use a capability-based phase breakdown with reviewable, meaningful increments.
      Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
      Each implementation phase must include implementation + immediate testing/verification.

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -21,8 +21,13 @@ created: "{date}"
 
 <!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
      Decided during Design. Checked off during Implement.
-     Each phase should include both implementation and validation; do not create a testing-only phase.
-     Each phase should be small enough to finish implementation + verification in one coding session. -->
+     Use a capability-based phase breakdown with reviewable, meaningful increments.
+     Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
+     Each implementation phase must include implementation + immediate testing/verification.
+     The final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
+     A phase is complete only when relevant tests pass.
+     Size phases so one coding agent can implement + validate in a single session.
+     Write each phase to clearly state both implementation scope and verification approach. -->
 
 ## Notes
 

--- a/plugin/commands/summarize-chat.md
+++ b/plugin/commands/summarize-chat.md
@@ -75,7 +75,7 @@ Fill sections based on the status:
 - Follow the canonical Design rules from the Zest Dev skill
 - List all meaningful design decisions and attach fact sources
 - Include the matching test strategy alongside the implementation design
-- If a `## Plan` phase breakdown is added, each phase must include implementation + validation; do not create a testing-only phase
+- If a `## Plan` phase breakdown is added, use capability-based phases that deliver meaningful, reviewable increments; each implementation phase must include implementation + immediate verification, the final phase may focus on overall testing/verification and coverage improvements, and each phase is complete only when relevant tests pass
 
 **If status is "implemented" - Fill Notes section:**
 - `### Implementation`: What was built, files changed, and design deviations

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -212,7 +212,18 @@ Flow:
 
 List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
 
-If `## Plan` is used, use a capability-based breakdown with meaningful, easy-to-review increments. Good boundaries usually align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone. Each implementation phase must include implementation + immediate testing/verification; the final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements. A phase is complete only when its relevant tests pass. Size each phase for one coding-agent session, and write each phase to clearly state both implementation scope and verification approach.
+If `## Plan` is used, keep it compact and phase-based with markdown checkboxes. Example:
+- [ ] Phase 1: Foo
+  - [ ] Implement: Foo
+  - [ ] Verify: Foo
+- [ ] Phase 2: Bar
+  - [ ] Implement: Bar
+  - [ ] Verify: Bar
+- [ ] Phase 3: Baz
+  - [ ] Implement: Baz
+  - [ ] Verify: Baz
+
+Use a capability-based breakdown with meaningful, easy-to-review increments. Good boundaries usually align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone. Each implementation phase must include implementation + immediate testing/verification; the final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements. A phase is complete only when its relevant tests pass. Size each phase for one coding-agent session, and write each phase to clearly state both implementation scope and verification approach.
 
 ### Notes
 ```markdown

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -212,7 +212,7 @@ Flow:
 
 List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
 
-If `## Plan` is used, each phase must include its own implementation and validation. Do not create a testing-only phase. Each phase should be small enough for one coding agent session to implement and verify.
+If `## Plan` is used, use a capability-based breakdown with meaningful, easy-to-review increments. Good boundaries usually align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone. Each implementation phase must include implementation + immediate testing/verification; the final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements. A phase is complete only when its relevant tests pass. Size each phase for one coding-agent session, and write each phase to clearly state both implementation scope and verification approach.
 
 ### Notes
 ```markdown

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -33,6 +33,18 @@ Canonical workflow for designing an active change spec.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
 9. Fill `## Plan` only when implementation should be split into phases.
    - Use a capability-based phase breakdown.
+   - Keep the plan compact and phase-based.
+   - Use markdown checkboxes for every phase and sub-item.
+   - Format as a short checklist, for example:
+     - [ ] Phase 1: Foo
+       - [ ] Implement: Foo
+       - [ ] Verify: Foo
+     - [ ] Phase 2: Bar
+       - [ ] Implement: Bar
+       - [ ] Verify: Bar
+     - [ ] Phase 3: Baz
+       - [ ] Implement: Baz
+       - [ ] Verify: Baz
    - Prefer phases that each deliver one meaningful increment and remain easy to review.
    - Good phase boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
    - Each implementation phase must include both implementation work and its own immediate testing/verification.

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -31,11 +31,15 @@ Canonical workflow for designing an active change spec.
    - Every design decision must cite its fact source inline or immediately adjacent to it.
    - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
-9. Fill `## Plan` only when implementation should be split into 2-3 coarse phases.
-   - Do not create a dedicated testing/verification phase.
-   - Each phase must include both implementation work and its own testing/verification.
+9. Fill `## Plan` only when implementation should be split into phases.
+   - Use a capability-based phase breakdown.
+   - Prefer phases that each deliver one meaningful increment and remain easy to review.
+   - Good phase boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
+   - Each implementation phase must include both implementation work and its own immediate testing/verification.
+   - The final phase may focus on overall testing/verification, edge-case validation, regression coverage, and test coverage improvements.
    - A phase is complete only when its relevant tests pass.
    - Size each phase so a coding agent can implement and validate it within a single session.
+   - Write each phase so its wording clearly states the implementation content and the verification approach.
 10. Run `zest-dev update active designed`.
 11. Present the design and stop for implementation approval.
 

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -389,8 +389,8 @@ test('zest-dev create integration', async (t) => {
       assert.equal(typeof frontmatter.created, 'string');
       assert.ok(content.includes('## Overview'), 'should use packaged default template');
       assert.ok(
-        content.includes('do not create a testing-only phase'),
-        'packaged default template should forbid testing-only phases'
+        content.includes('Use markdown checkboxes for all phase items'),
+        'packaged default template should include phase checkbox guidance'
       );
       assert.ok(content.includes('### Implementation'), 'packaged default template should include Implementation notes section');
       assert.ok(content.includes('### Verification'), 'packaged default template should include Verification notes section');


### PR DESCRIPTION
## Summary
- expand the spec template guidance for `## Plan` with checkbox-based, phase-oriented examples
- align summarize-chat and Zest Dev skill docs around capability-based phases, immediate verification, and test-complete phase exit criteria
- clarify that the final phase can focus on broader verification, regression coverage, and coverage improvements