### PR TITLE
Update Plan template to use numbered substeps

### DIFF
--- a/.zest-dev/template/spec.md
+++ b/.zest-dev/template/spec.md
@@ -19,26 +19,30 @@ created: "{date}"
 
 ## Plan
 
-<!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
+<!-- Optional: Step breakdown for complex features that need multiple implementation steps.
      Decided during Design. Checked off during Implement.
-     Keep this section compact and phase-based.
-     Use markdown checkboxes for all phase items, for example:
-     - [ ] Phase 1: Foo
-       - [ ] Implement: Foo
-       - [ ] Verify: Foo
-     - [ ] Phase 2: Bar
-       - [ ] Implement: Bar
-       - [ ] Verify: Bar
-     - [ ] Phase 3: Baz
-       - [ ] Implement: Baz
-       - [ ] Verify: Baz
-     Use a capability-based phase breakdown with reviewable, meaningful increments.
+     Keep this section compact and step-based.
+     Use markdown checkboxes for all step and substep items, for example:
+     - [ ] Step 1: Foo
+       - [ ] Substep 1.1 Implement: Foo foundation
+       - [ ] Substep 1.2 Implement: Foo integration
+       - [ ] Substep 1.3 Implement: Foo edge handling
+       - [ ] Substep 1.4 Verify: Foo automated coverage
+       - [ ] Substep 1.5 Verify: Foo manual workflow
+     - [ ] Step 2: Bar
+       - [ ] Substep 2.1 Implement: Bar
+       - [ ] Substep 2.2 Verify: Bar
+     - [ ] Step 3: Baz
+       - [ ] Substep 3.1 Implement: Baz
+       - [ ] Substep 3.2 Verify: Baz
+     Use a capability-based step breakdown with reviewable, meaningful increments.
      Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
-     Each implementation phase must include implementation + immediate testing/verification.
-     The final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
-     A phase is complete only when relevant tests pass.
-     Size phases so one coding agent can implement + validate in a single session.
-     Write each phase to clearly state both implementation scope and verification approach. -->
+     Each step must include small, independent substeps for implementation and immediate testing/verification.
+     Within each step, list implementation substeps before verification substeps.
+     The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
+     A step is complete only when relevant tests pass.
+     Size steps so one coding agent can implement + validate in a single session.
+     Write each substep as one small, independent task. -->
 
 ## Notes
 

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -19,26 +19,30 @@ created: "{date}"
 
 ## Plan
 
-<!-- Optional: Phase breakdown for complex features that need multiple implementation phases.
+<!-- Optional: Step breakdown for complex features that need multiple implementation steps.
      Decided during Design. Checked off during Implement.
-     Keep this section compact and phase-based.
-     Use markdown checkboxes for all phase items, for example:
-     - [ ] Phase 1: Foo
-       - [ ] Implement: Foo
-       - [ ] Verify: Foo
-     - [ ] Phase 2: Bar
-       - [ ] Implement: Bar
-       - [ ] Verify: Bar
-     - [ ] Phase 3: Baz
-       - [ ] Implement: Baz
-       - [ ] Verify: Baz
-     Use a capability-based phase breakdown with reviewable, meaningful increments.
+     Keep this section compact and step-based.
+     Use markdown checkboxes for all step and substep items, for example:
+     - [ ] Step 1: Foo
+       - [ ] Substep 1.1 Implement: Foo foundation
+       - [ ] Substep 1.2 Implement: Foo integration
+       - [ ] Substep 1.3 Implement: Foo edge handling
+       - [ ] Substep 1.4 Verify: Foo automated coverage
+       - [ ] Substep 1.5 Verify: Foo manual workflow
+     - [ ] Step 2: Bar
+       - [ ] Substep 2.1 Implement: Bar
+       - [ ] Substep 2.2 Verify: Bar
+     - [ ] Step 3: Baz
+       - [ ] Substep 3.1 Implement: Baz
+       - [ ] Substep 3.2 Verify: Baz
+     Use a capability-based step breakdown with reviewable, meaningful increments.
      Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
-     Each implementation phase must include implementation + immediate testing/verification.
-     The final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
-     A phase is complete only when relevant tests pass.
-     Size phases so one coding agent can implement + validate in a single session.
-     Write each phase to clearly state both implementation scope and verification approach. -->
+     Each step must include small, independent substeps for implementation and immediate testing/verification.
+     Within each step, list implementation substeps before verification substeps.
+     The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
+     A step is complete only when relevant tests pass.
+     Size steps so one coding agent can implement + validate in a single session.
+     Write each substep as one small, independent task. -->
 
 ## Notes
 

--- a/plugin/commands/summarize-chat.md
+++ b/plugin/commands/summarize-chat.md
@@ -75,7 +75,7 @@ Fill sections based on the status:
 - Follow the canonical Design rules from the Zest Dev skill
 - List all meaningful design decisions and attach fact sources
 - Include the matching test strategy alongside the implementation design
-- If a `## Plan` phase breakdown is added, use capability-based phases that deliver meaningful, reviewable increments; each implementation phase must include implementation + immediate verification, the final phase may focus on overall testing/verification and coverage improvements, and each phase is complete only when relevant tests pass
+- If a `## Plan` step breakdown is added, use capability-based steps that deliver meaningful, reviewable increments; each step must include small, independent substeps for implementation and immediate verification; list implementation substeps before verification substeps; the final step may focus on overall testing/verification and coverage improvements; each step is complete only when relevant tests pass
 
 **If status is "implemented" - Fill Notes section:**
 - `### Implementation`: What was built, files changed, and design deviations

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -214,18 +214,21 @@ Flow:
 
 List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
 
-If `## Plan` is used, keep it compact and phase-based with markdown checkboxes. Example:
-- [ ] Phase 1: Foo
-  - [ ] Implement: Foo
-  - [ ] Verify: Foo
-- [ ] Phase 2: Bar
-  - [ ] Implement: Bar
-  - [ ] Verify: Bar
-- [ ] Phase 3: Baz
-  - [ ] Implement: Baz
-  - [ ] Verify: Baz
+If `## Plan` is used, keep it compact and step-based with markdown checkboxes. Example:
+- [ ] Step 1: Foo
+  - [ ] Substep 1.1 Implement: Foo foundation
+  - [ ] Substep 1.2 Implement: Foo integration
+  - [ ] Substep 1.3 Implement: Foo edge handling
+  - [ ] Substep 1.4 Verify: Foo automated coverage
+  - [ ] Substep 1.5 Verify: Foo manual workflow
+- [ ] Step 2: Bar
+  - [ ] Substep 2.1 Implement: Bar
+  - [ ] Substep 2.2 Verify: Bar
+- [ ] Step 3: Baz
+  - [ ] Substep 3.1 Implement: Baz
+  - [ ] Substep 3.2 Verify: Baz
 
-Use a capability-based breakdown with meaningful, easy-to-review increments. Good boundaries usually align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone. Each implementation phase must include implementation + immediate testing/verification; the final phase may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements. A phase is complete only when its relevant tests pass. Size each phase for one coding-agent session, and write each phase to clearly state both implementation scope and verification approach.
+Use a capability-based breakdown with meaningful, easy-to-review increments. Good step boundaries usually align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone. Each step must include small, independent substeps for implementation and immediate testing/verification. Within each step, list implementation substeps before verification substeps. The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements. A step is complete only when its relevant tests pass. Size each step for one coding-agent session, and write each substep as one small, independent task.
 
 ### Notes
 ```markdown

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -32,27 +32,31 @@ Canonical workflow for designing an active change spec.
    - Every design decision must cite its fact source inline or immediately adjacent to it.
    - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
-9. Fill `## Plan` only when implementation should be split into phases.
-   - Use a capability-based phase breakdown.
-   - Keep the plan compact and phase-based.
-   - Use markdown checkboxes for every phase and sub-item.
+9. Fill `## Plan` only when implementation should be split into steps.
+   - Use a capability-based step breakdown.
+   - Keep the plan compact and step-based.
+   - Use markdown checkboxes for every step and substep.
    - Format as a short checklist, for example:
-     - [ ] Phase 1: Foo
-       - [ ] Implement: Foo
-       - [ ] Verify: Foo
-     - [ ] Phase 2: Bar
-       - [ ] Implement: Bar
-       - [ ] Verify: Bar
-     - [ ] Phase 3: Baz
-       - [ ] Implement: Baz
-       - [ ] Verify: Baz
-   - Prefer phases that each deliver one meaningful increment and remain easy to review.
-   - Good phase boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
-   - Each implementation phase must include both implementation work and its own immediate testing/verification.
-   - The final phase may focus on overall testing/verification, edge-case validation, regression coverage, and test coverage improvements.
-   - A phase is complete only when its relevant tests pass.
-   - Size each phase so a coding agent can implement and validate it within a single session.
-   - Write each phase so its wording clearly states the implementation content and the verification approach.
+      - [ ] Step 1: Foo
+        - [ ] Substep 1.1 Implement: Foo foundation
+        - [ ] Substep 1.2 Implement: Foo integration
+        - [ ] Substep 1.3 Implement: Foo edge handling
+        - [ ] Substep 1.4 Verify: Foo automated coverage
+        - [ ] Substep 1.5 Verify: Foo manual workflow
+      - [ ] Step 2: Bar
+        - [ ] Substep 2.1 Implement: Bar
+        - [ ] Substep 2.2 Verify: Bar
+      - [ ] Step 3: Baz
+        - [ ] Substep 3.1 Implement: Baz
+        - [ ] Substep 3.2 Verify: Baz
+   - Prefer steps that each deliver one meaningful increment and remain easy to review.
+   - Good step boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
+   - Each step must include small, independent substeps for implementation work and immediate testing/verification.
+   - Within each step, list implementation substeps before verification substeps.
+   - The final step may focus on overall testing/verification, edge-case validation, regression coverage, and test coverage improvements.
+   - A step is complete only when its relevant tests pass.
+   - Size each step so a coding agent can implement and validate it within a single session.
+   - Write each substep as one small, independent task.
 10. Run `zest-dev update active designed`.
 11. Present the design and stop.
 

--- a/plugin/skills/zest-dev/implement.md
+++ b/plugin/skills/zest-dev/implement.md
@@ -14,7 +14,7 @@ Canonical workflow for implementing an active change spec.
 5. Implement the feature following the design and repository conventions.
 6. Write or update tests alongside the implementation, not afterward.
 7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
-8. After each completed plan phase, mark the corresponding `## Plan` checkbox as `[x]` only when that phase's implementation and validation are both complete.
+8. After each completed plan step or substep, mark the corresponding `## Plan` checkbox as `[x]` only when that item is complete and relevant tests pass.
 9. Fill `## Notes` with brief:
     - `### Implementation`
     - `### Verification`

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -389,9 +389,10 @@ test('zest-dev create integration', async (t) => {
       assert.equal(typeof frontmatter.created, 'string');
       assert.ok(content.includes('## Overview'), 'should use packaged default template');
       assert.ok(
-        content.includes('Use markdown checkboxes for all phase items'),
-        'packaged default template should include phase checkbox guidance'
+        content.includes('Use markdown checkboxes for all step and substep items'),
+        'packaged default template should include step and substep checkbox guidance'
       );
+      assert.ok(content.includes('Substep 1.1 Implement'), 'packaged default template should include substep example');
       assert.ok(content.includes('### Implementation'), 'packaged default template should include Implementation notes section');
       assert.ok(content.includes('### Verification'), 'packaged default template should include Verification notes section');
       assert.equal(content.includes('Phase 3: Test and verify'), false);


### PR DESCRIPTION
## Summary
- Rename Plan breakdown terminology from phases to steps across Zest Dev templates and guidance.
- Update Plan examples to use `Step` plus numbered `Substep` checkboxes.
- Clarify that each step lists implementation substeps before verification substeps.

## Verification
- Ran `git diff --check`.