### PR TITLE
Clarify Zest Dev spec evidence guidance

### DIFF
--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -192,14 +192,14 @@ Keep sources compact: use the smallest useful line/range, merge same-file citati
 
 Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
 
+### Change Scope
+- Area: ... Impact: ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
+
 ### Design Decisions
 - Decision: ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
 
 ### Why this design
 - ...
-
-### Implementation Steps
-1. ...
 
 ### Test Strategy
 - Phase/area: ... Validation: ... Source: `path/to/file:line`
@@ -212,6 +212,8 @@ Flow:
 ### File Structure
 - `path/to/file` - ...
 ```
+
+Use `### Change Scope` to describe affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, and rollout impact. Execution sequencing belongs in `## Plan`.
 
 List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
 

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -180,6 +180,7 @@ Use when the design is ready for coding.
 - `path/to/file:line` - ...
 
 Every research finding must include a fact source from code, database artifacts, or documentation.
+Keep sources compact: use the smallest useful line/range, merge same-file citations like `src/media.ts:770-811,829,855,877-890`, and move long evidence lists to Key References.
 ```
 
 ### Design

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -20,14 +20,16 @@ Canonical workflow for designing an active change spec.
 8. Fill `## Design` with:
    - Architecture Overview
    - Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
+   - Change Scope
    - Design Decisions
    - Why this design
-   - Implementation Steps
    - Test Strategy
    - Pseudocode
    - File Structure
    - Interfaces / APIs
    - Edge Cases
+   - Use Change Scope to describe affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, and rollout impact.
+   - Put execution sequencing in `## Plan`.
    - List all design decisions.
    - Every design decision must cite its fact source inline or immediately adjacent to it.
    - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.

--- a/plugin/skills/zest-dev/research.md
+++ b/plugin/skills/zest-dev/research.md
@@ -21,6 +21,9 @@ Canonical workflow for researching an active change spec.
    - Key References
    - Every finding must cite its fact source inline or immediately adjacent to it.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
+   - Keep sources compact: cite the smallest useful evidence, usually 1 representative line or short range per finding.
+   - Merge same-file citations into ranges or grouped refs: `src/media.ts:770-811,829,855,877-890`.
+   - Move long evidence lists to `Key References`; keep inline `Source:` entries short.
 9. If the current status is `new`, run `zest-dev update active researched`.
 10. If this is a refresh for a later-phase spec, keep the current status and do not downgrade it.
 11. Summarize findings and point to the design phase.


### PR DESCRIPTION
## Summary
- Add compact source citation guidance for Zest Dev research findings.
- Replace design-phase implementation steps with change scope guidance and keep execution sequencing in the plan.

## Testing
- Not run; documentation-only prompt updates.