### PR TITLE
Support global init targets

### DIFF
--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -216,11 +216,19 @@ program
 // zest-dev init
 program
   .command('init')
-  .description('Initialize plugin deployment for a target ecosystem')
-  .option('-t, --target <target>', 'Deployment target (opencode|codex)', 'opencode')
+  .description('Initialize plugin deployment for OpenCode and/or Codex')
+  .option('--global', 'Deploy to global user locations (default)')
+  .option('--local', 'Deploy to the current project directory')
+  .option('-t, --target <target>', 'Deployment target (all|opencode|codex)')
   .action((options) => {
     try {
-      const result = deployPlugin(options.target);
+      if (options.global && options.local) {
+        throw new Error('Cannot specify both --global and --local');
+      }
+
+      const scope = options.local ? 'local' : 'global';
+      const target = options.target || (scope === 'local' ? 'opencode' : 'all');
+      const result = deployPlugin({ scope, target });
       console.log(yaml.dump(result));
     } catch (error) {
       console.error('Error:', error.message);

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -16,17 +16,39 @@ const {
   updateSpecStatus,
   createBranchFromActiveChangeSpec
 } = require('../lib/spec-manager');
-const { deployPlugin, getTargetPaths } = require('../lib/plugin-deployer');
+const { deployPlugin } = require('../lib/plugin-deployer');
 const { generatePrompt } = require('../lib/prompt-generator');
 
 const program = new Command();
 
+function getOptionalGlobalOpenCodeCommandDir() {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  if (xdgConfigHome) {
+    return path.isAbsolute(xdgConfigHome)
+      ? path.join(xdgConfigHome, 'opencode', 'commands')
+      : null;
+  }
+
+  const homeDir = process.env.HOME || process.env.USERPROFILE;
+  if (!homeDir || !path.isAbsolute(homeDir)) {
+    return null;
+  }
+
+  return path.join(homeDir, '.config', 'opencode', 'commands');
+}
+
 function getDeployedCommandDirs() {
-  return [
+  const dirs = [
     path.join(process.cwd(), '.cursor/commands'),
-    path.join(process.cwd(), '.opencode/commands'),
-    getTargetPaths('global').opencode.commandsDir
+    path.join(process.cwd(), '.opencode/commands')
   ];
+
+  const globalOpenCodeCommandDir = getOptionalGlobalOpenCodeCommandDir();
+  if (globalOpenCodeCommandDir) {
+    dirs.push(globalOpenCodeCommandDir);
+  }
+
+  return dirs;
 }
 
 function isFzfAvailable() {

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -16,14 +16,18 @@ const {
   updateSpecStatus,
   createBranchFromActiveChangeSpec
 } = require('../lib/spec-manager');
-const { deployPlugin } = require('../lib/plugin-deployer');
+const { deployPlugin, getTargetPaths } = require('../lib/plugin-deployer');
 const { generatePrompt } = require('../lib/prompt-generator');
 
 const program = new Command();
-const DEPLOYED_COMMAND_DIRS = [
-  path.join(process.cwd(), '.cursor/commands'),
-  path.join(process.cwd(), '.opencode/commands')
-];
+
+function getDeployedCommandDirs() {
+  return [
+    path.join(process.cwd(), '.cursor/commands'),
+    path.join(process.cwd(), '.opencode/commands'),
+    getTargetPaths('global').opencode.commandsDir
+  ];
+}
 
 function isFzfAvailable() {
   const result = spawnSync('fzf', ['--version'], { stdio: 'ignore' });
@@ -84,7 +88,7 @@ async function selectSpecInteractively(specs) {
 }
 
 function hasDeployedCommandMarkdowns() {
-  return DEPLOYED_COMMAND_DIRS.some(dirPath => {
+  return getDeployedCommandDirs().some(dirPath => {
     if (!fs.existsSync(dirPath)) {
       return false;
     }

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -373,6 +373,5 @@ function deployPlugin(options = {}) {
 }
 
 module.exports = {
-  deployPlugin,
-  getTargetPaths
+  deployPlugin
 };

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -373,5 +373,6 @@ function deployPlugin(options = {}) {
 }
 
 module.exports = {
-  deployPlugin
+  deployPlugin,
+  getTargetPaths
 };

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -98,43 +98,83 @@ function getTargetPaths(scope) {
   if (scope === 'local') {
     const baseDir = process.cwd();
     return {
-      opencode: {
-        baseDir,
-        commandsDir: path.join(baseDir, '.opencode/commands'),
-        skillsDir: path.join(baseDir, '.opencode/skills'),
-        legacyAgentsDir: path.join(baseDir, '.opencode/agents')
-      },
-      codex: {
-        baseDir,
-        commandsDir: null,
-        skillsDir: path.join(baseDir, '.agents/skills/zest-dev'),
-        agentsDir: path.join(baseDir, '.codex/agents')
-      }
+      baseDir,
+      opencode: getLocalOpenCodePaths(baseDir),
+      codex: getLocalCodexPaths(baseDir)
     };
   }
 
+  return {
+    opencode: getGlobalOpenCodePaths,
+    codex: getGlobalCodexPaths
+  };
+}
+
+function getLocalOpenCodePaths(baseDir = process.cwd()) {
+  return {
+    baseDir,
+    commandsDir: path.join(baseDir, '.opencode/commands'),
+    skillsDir: path.join(baseDir, '.opencode/skills'),
+    legacyAgentsDir: path.join(baseDir, '.opencode/agents')
+  };
+}
+
+function getLocalCodexPaths(baseDir = process.cwd()) {
+  return {
+    baseDir,
+    commandsDir: null,
+    skillsDir: path.join(baseDir, '.agents/skills/zest-dev'),
+    agentsDir: path.join(baseDir, '.codex/agents')
+  };
+}
+
+function getGlobalOpenCodePaths() {
+  const openCodeBaseDir = getGlobalOpenCodeBaseDir();
+
+  return {
+    baseDir: openCodeBaseDir,
+    commandsDir: path.join(openCodeBaseDir, 'commands'),
+    skillsDir: path.join(openCodeBaseDir, 'skills'),
+    legacyAgentsDir: path.join(openCodeBaseDir, 'agents')
+  };
+}
+
+function getGlobalCodexPaths() {
   const homeDir = getHomeDirectory();
   if (!homeDir) {
     throw new Error('HOME is not set');
   }
   assertAbsolutePath('HOME', homeDir);
 
-  const openCodeBaseDir = getGlobalOpenCodeBaseDir();
-
   return {
-    opencode: {
-      baseDir: openCodeBaseDir,
-      commandsDir: path.join(openCodeBaseDir, 'commands'),
-      skillsDir: path.join(openCodeBaseDir, 'skills'),
-      legacyAgentsDir: path.join(openCodeBaseDir, 'agents')
-    },
-    codex: {
-      baseDir: homeDir,
-      commandsDir: null,
-      skillsDir: path.join(homeDir, '.agents/skills/zest-dev'),
-      agentsDir: path.join(homeDir, '.codex/agents')
-    }
+    baseDir: homeDir,
+    commandsDir: null,
+    skillsDir: path.join(homeDir, '.agents/skills/zest-dev'),
+    agentsDir: path.join(homeDir, '.codex/agents')
   };
+}
+
+function resolveTargetPaths(scope, target) {
+  const targetPathResolvers = getTargetPaths(scope);
+  if (typeof targetPathResolvers.opencode !== 'function' && typeof targetPathResolvers.codex !== 'function') {
+    return targetPathResolvers;
+  }
+
+  const paths = {};
+
+  if (target === 'all' || target === 'opencode') {
+    paths.opencode = typeof targetPathResolvers.opencode === 'function'
+      ? targetPathResolvers.opencode()
+      : targetPathResolvers.opencode;
+  }
+
+  if (target === 'all' || target === 'codex') {
+    paths.codex = typeof targetPathResolvers.codex === 'function'
+      ? targetPathResolvers.codex()
+      : targetPathResolvers.codex;
+  }
+
+  return paths;
 }
 
 function ensureDirectories(dirs) {
@@ -338,13 +378,13 @@ function deployPlugin(options = {}) {
       throw new Error(`Invalid scope: ${scope}. Expected one of: ${VALID_SCOPES.join(', ')}`);
     }
 
-    const targetPaths = getTargetPaths(scope);
+    const targetPaths = resolveTargetPaths(scope, target);
     const result = {
       ok: true,
       scope,
       target,
-      opencode: createEmptyTargetResult(targetPaths.opencode.baseDir),
-      codex: createEmptyTargetResult(targetPaths.codex.baseDir)
+      opencode: createEmptyTargetResult(targetPaths.opencode ? targetPaths.opencode.baseDir : null),
+      codex: createEmptyTargetResult(targetPaths.codex ? targetPaths.codex.baseDir : null)
     };
 
     if (target === 'all' || target === 'opencode') {

--- a/lib/plugin-deployer.js
+++ b/lib/plugin-deployer.js
@@ -2,6 +2,14 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
+const VALID_TARGETS = ['all', 'opencode', 'codex'];
+const VALID_SCOPES = ['global', 'local'];
+const LEGACY_OPENCODE_AGENT_FILENAMES = new Set([
+  'code-architect.md',
+  'code-explorer.md',
+  'code-reviewer.md'
+]);
+
 /**
  * Parse markdown file with frontmatter
  * @param {string} filePath - Path to markdown file
@@ -56,30 +64,82 @@ function writeMarkdownWithFrontmatter(targetPath, frontmatter, content) {
 /**
  * Create target directories if they don't exist
  */
-function ensureDirectories() {
-  const dirs = [
-    '.opencode/commands',
-    '.opencode/skills'
-  ];
-
-  dirs.forEach(dir => {
-    const fullPath = path.join(process.cwd(), dir);
-    fs.mkdirSync(fullPath, { recursive: true });
-  });
+function getHomeDirectory() {
+  return process.env.HOME || process.env.USERPROFILE;
 }
 
-/**
- * Create target directories for Codex deployment
- */
-function ensureCodexDirectories() {
-  const dirs = [
-    '.codex/agents',
-    '.agents/skills/zest-dev'
-  ];
+function assertAbsolutePath(name, value) {
+  if (!path.isAbsolute(value)) {
+    throw new Error(`${name} must be an absolute path: ${value}`);
+  }
+}
 
+function getGlobalOpenCodeBaseDir() {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  if (xdgConfigHome) {
+    assertAbsolutePath('XDG_CONFIG_HOME', xdgConfigHome);
+    return path.join(xdgConfigHome, 'opencode');
+  }
+
+  const homeDir = getHomeDirectory();
+  if (!homeDir) {
+    throw new Error('HOME is not set');
+  }
+  assertAbsolutePath('HOME', homeDir);
+
+  return path.join(homeDir, '.config', 'opencode');
+}
+
+function getTargetPaths(scope) {
+  if (!VALID_SCOPES.includes(scope)) {
+    throw new Error(`Invalid scope: ${scope}. Expected one of: ${VALID_SCOPES.join(', ')}`);
+  }
+
+  if (scope === 'local') {
+    const baseDir = process.cwd();
+    return {
+      opencode: {
+        baseDir,
+        commandsDir: path.join(baseDir, '.opencode/commands'),
+        skillsDir: path.join(baseDir, '.opencode/skills'),
+        legacyAgentsDir: path.join(baseDir, '.opencode/agents')
+      },
+      codex: {
+        baseDir,
+        commandsDir: null,
+        skillsDir: path.join(baseDir, '.agents/skills/zest-dev'),
+        agentsDir: path.join(baseDir, '.codex/agents')
+      }
+    };
+  }
+
+  const homeDir = getHomeDirectory();
+  if (!homeDir) {
+    throw new Error('HOME is not set');
+  }
+  assertAbsolutePath('HOME', homeDir);
+
+  const openCodeBaseDir = getGlobalOpenCodeBaseDir();
+
+  return {
+    opencode: {
+      baseDir: openCodeBaseDir,
+      commandsDir: path.join(openCodeBaseDir, 'commands'),
+      skillsDir: path.join(openCodeBaseDir, 'skills'),
+      legacyAgentsDir: path.join(openCodeBaseDir, 'agents')
+    },
+    codex: {
+      baseDir: homeDir,
+      commandsDir: null,
+      skillsDir: path.join(homeDir, '.agents/skills/zest-dev'),
+      agentsDir: path.join(homeDir, '.codex/agents')
+    }
+  };
+}
+
+function ensureDirectories(dirs) {
   dirs.forEach(dir => {
-    const fullPath = path.join(process.cwd(), dir);
-    fs.mkdirSync(fullPath, { recursive: true });
+    fs.mkdirSync(dir, { recursive: true });
   });
 }
 
@@ -89,24 +149,35 @@ function ensureCodexDirectories() {
  * Legacy installs may have written files into .opencode/agents.
  * We no longer deploy agents, but should clean stale files on init.
  */
-function cleanupLegacyAgentFiles() {
-  const agentsDir = path.join(process.cwd(), '.opencode/agents');
-  const legacyAgentFilenames = new Set([
-    'code-architect.md',
-    'code-explorer.md',
-    'code-reviewer.md'
-  ]);
-
+function cleanupLegacyAgentFiles(agentsDir) {
   if (!fs.existsSync(agentsDir)) {
     return;
   }
 
   const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
   entries.forEach(entry => {
-    if (entry.isFile() && legacyAgentFilenames.has(entry.name)) {
+    if (entry.isFile() && LEGACY_OPENCODE_AGENT_FILENAMES.has(entry.name)) {
       fs.unlinkSync(path.join(agentsDir, entry.name));
     }
   });
+}
+
+function cleanupLegacyCodexCommandPrompts(skillDir) {
+  const commandsDir = path.join(skillDir, 'commands');
+  if (!fs.existsSync(commandsDir)) {
+    return;
+  }
+
+  const entries = fs.readdirSync(commandsDir, { withFileTypes: true });
+  entries.forEach(entry => {
+    if (entry.isFile() && /^zest-dev-.*\.md$/.test(entry.name)) {
+      fs.unlinkSync(path.join(commandsDir, entry.name));
+    }
+  });
+
+  if (fs.readdirSync(commandsDir).length === 0) {
+    fs.rmdirSync(commandsDir);
+  }
 }
 
 /**
@@ -134,7 +205,7 @@ function copyDirectoryRecursive(source, target) {
  * Deploy command files to OpenCode directory
  * @returns {string[]} Deployed file lists
  */
-function deployCommands() {
+function deployCommands(commandsDir) {
   const sourceDir = path.join(__dirname, '../plugin/commands');
   const commandFiles = fs.readdirSync(sourceDir)
     .filter(f => f.endsWith('.md'))
@@ -153,8 +224,8 @@ function deployCommands() {
     const prefixedFilename = `zest-dev-${filename}`;
 
     // Deploy to OpenCode
-    const opencodePath = path.join(process.cwd(), '.opencode/commands', prefixedFilename);
-    writeMarkdownWithFrontmatter(opencodePath, transformedFrontmatter, content);
+    const targetPath = path.join(commandsDir, prefixedFilename);
+    writeMarkdownWithFrontmatter(targetPath, transformedFrontmatter, content);
     result.push(prefixedFilename);
   });
 
@@ -165,7 +236,7 @@ function deployCommands() {
  * Deploy skill files to OpenCode directory
  * @returns {string[]} Deployed directory lists
  */
-function deploySkills() {
+function deploySkills(skillsRootDir) {
   const skillsDir = path.join(__dirname, '../plugin/skills');
   const skillDirs = fs.readdirSync(skillsDir, { withFileTypes: true })
     .filter(entry => entry.isDirectory())
@@ -178,7 +249,7 @@ function deploySkills() {
     const sourceDir = path.join(skillsDir, skillName);
 
     // Copy to OpenCode
-    const opencodeTarget = path.join(process.cwd(), '.opencode/skills', skillName);
+    const opencodeTarget = path.join(skillsRootDir, skillName);
     fs.mkdirSync(opencodeTarget, { recursive: true });
     copyDirectoryRecursive(sourceDir, opencodeTarget);
     result.push(skillName + '/');
@@ -188,41 +259,13 @@ function deploySkills() {
 }
 
 /**
- * Deploy command markdown files for Codex skill layout
- * @returns {string[]} Deployed file lists
- */
-function deployCodexCommandPrompts() {
-  const sourceDir = path.join(__dirname, '../plugin/commands');
-  const commandFiles = fs.readdirSync(sourceDir)
-    .filter(f => f.endsWith('.md'))
-    .sort();
-
-  const codexCommandsDir = path.join(process.cwd(), '.agents/skills/zest-dev/commands');
-  fs.mkdirSync(codexCommandsDir, { recursive: true });
-
-  const result = [];
-  commandFiles.forEach(filename => {
-    const sourcePath = path.join(sourceDir, filename);
-    const { frontmatter, content } = parseMarkdownWithFrontmatter(sourcePath);
-    const transformedFrontmatter = transformFrontmatter(frontmatter);
-    const prefixedFilename = `zest-dev-${filename}`;
-
-    const targetPath = path.join(codexCommandsDir, prefixedFilename);
-    writeMarkdownWithFrontmatter(targetPath, transformedFrontmatter, content);
-    result.push(`commands/${prefixedFilename}`);
-  });
-
-  return result;
-}
-
-/**
  * Deploy skills for Codex layout
  * @returns {string[]} Deployed files/dirs
  */
-function deployCodexSkills() {
+function deployCodexSkills(targetDir) {
   const sourceDir = path.join(__dirname, '../plugin/skills/zest-dev');
-  const targetDir = path.join(process.cwd(), '.agents/skills/zest-dev');
   fs.mkdirSync(targetDir, { recursive: true });
+  cleanupLegacyCodexCommandPrompts(targetDir);
   copyDirectoryRecursive(sourceDir, targetDir);
 
   const entries = fs.readdirSync(targetDir, { withFileTypes: true })
@@ -240,9 +283,8 @@ function toTomlMultiline(value) {
  * Deploy exactly three codex subagent TOML files
  * @returns {string[]} deployed agent filenames
  */
-function deployCodexSubagents() {
+function deployCodexSubagents(targetDir) {
   const sourceDir = path.join(__dirname, '../plugin/agents');
-  const targetDir = path.join(process.cwd(), '.codex/agents');
   const expectedAgents = ['code-architect', 'code-explorer', 'code-reviewer'];
   const deployed = [];
 
@@ -269,71 +311,57 @@ function deployCodexSubagents() {
  * Main deployment function
  * @returns {Object} Deployment result with status and deployed files
  */
-function deployPlugin(target = 'opencode') {
+function createEmptyTargetResult(baseDir) {
+  return {
+    commands: [],
+    skills: [],
+    agents: [],
+    baseDir
+  };
+}
+
+function deployPlugin(options = {}) {
   try {
-    // 1. Verify plugin directory exists
     const pluginDir = path.join(__dirname, '../plugin');
     if (!fs.existsSync(pluginDir)) {
       throw new Error('Plugin directory not found. Make sure you are in the zest-dev project root.');
     }
 
-    if (target === 'opencode') {
-      ensureDirectories();
-      cleanupLegacyAgentFiles();
-      const commandsResult = deployCommands();
-      const skillsResult = deploySkills();
+    const scope = options.scope || 'global';
+    const target = options.target || (scope === 'local' ? 'opencode' : 'all');
 
-      return {
-        ok: true,
-        target,
-        cursor: {
-          commands: [],
-          skills: [],
-          agents: []
-        },
-        opencode: {
-          commands: commandsResult,
-          skills: skillsResult,
-          agents: []
-        },
-        codex: {
-          commands: [],
-          skills: [],
-          agents: []
-        }
-      };
+    if (!VALID_TARGETS.includes(target)) {
+      throw new Error(`Invalid target: ${target}. Expected one of: ${VALID_TARGETS.join(', ')}`);
     }
 
-    if (target === 'codex') {
-      ensureCodexDirectories();
-      const codexCommands = deployCodexCommandPrompts();
-      const codexSkills = deployCodexSkills();
-      const codexAgents = deployCodexSubagents();
-
-      return {
-        ok: true,
-        target,
-        cursor: {
-          commands: [],
-          skills: [],
-          agents: []
-        },
-        opencode: {
-          commands: [],
-          skills: [],
-          agents: []
-        },
-        codex: {
-          commands: codexCommands,
-          skills: codexSkills,
-          agents: codexAgents
-        }
-      };
+    if (!VALID_SCOPES.includes(scope)) {
+      throw new Error(`Invalid scope: ${scope}. Expected one of: ${VALID_SCOPES.join(', ')}`);
     }
 
-    throw new Error(`Invalid target: ${target}. Expected one of: opencode, codex`);
+    const targetPaths = getTargetPaths(scope);
+    const result = {
+      ok: true,
+      scope,
+      target,
+      opencode: createEmptyTargetResult(targetPaths.opencode.baseDir),
+      codex: createEmptyTargetResult(targetPaths.codex.baseDir)
+    };
+
+    if (target === 'all' || target === 'opencode') {
+      ensureDirectories([targetPaths.opencode.commandsDir, targetPaths.opencode.skillsDir]);
+      cleanupLegacyAgentFiles(targetPaths.opencode.legacyAgentsDir);
+      result.opencode.commands = deployCommands(targetPaths.opencode.commandsDir);
+      result.opencode.skills = deploySkills(targetPaths.opencode.skillsDir);
+    }
+
+    if (target === 'all' || target === 'codex') {
+      ensureDirectories([targetPaths.codex.skillsDir, targetPaths.codex.agentsDir]);
+      result.codex.skills = deployCodexSkills(targetPaths.codex.skillsDir);
+      result.codex.agents = deployCodexSubagents(targetPaths.codex.agentsDir);
+    }
+
+    return result;
   } catch (error) {
-    // Wrap low-level errors with context
     if (error.code === 'EACCES') {
       throw new Error(`Permission denied: ${error.path}`);
     } else if (error.code === 'ENOENT' && error.path) {

--- a/specs/change/20260509-global-init-targets/spec.md
+++ b/specs/change/20260509-global-init-targets/spec.md
@@ -1,0 +1,238 @@
+---
+id: 20260509-global-init-targets
+name: Global Init Targets
+status: designed
+created: '2026-05-09'
+---
+
+## Overview
+
+### Problem Statement
+
+`zest-dev init` 当前在当前目录初始化 OpenCode command/skill 文件和 Codex skill/subagent 文件。期望调整为默认在全局位置创建 OpenCode 与 Codex 文件；Claude Code 通过 plugin 机制处理，退出本次 CLI init 范围。
+
+### Goals
+
+- 默认行为等价于 `zest-dev init --global`。
+- `--target` 默认值随 scope 变化：global scope 默认 `all`，local scope 默认 `opencode`。
+- 支持为 OpenCode 创建全局 command 和 skill 文件。
+- 支持为 Codex 创建全局 skill 和 subagent 文件。
+- 保留原来的当前目录初始化能力，通过 `--local` 参数显式启用。
+- 让用户能够清楚地区分全局初始化和本地初始化。
+
+### Scope
+
+- 更新 `zest-dev init` 的默认目标位置。
+- 增加或完善 `--global` 与 `--local` 参数行为。
+- 覆盖相关 CLI 帮助文案、部署路径逻辑和测试。
+
+### Success Criteria
+
+- 执行 `zest-dev init` 时会创建 OpenCode 全局 command/skill 文件和 Codex 全局 skill/subagent 文件。
+- 执行 `zest-dev init --global` 与默认行为一致。
+- 执行 `zest-dev init --local` 时保留原来的当前目录初始化行为。
+- 未传 `--target` 时，`zest-dev init` 与 `zest-dev init --global` 使用 `--target all`；`zest-dev init --local` 使用 `--target opencode`。
+- OpenCode 和 Codex 的目标文件均按对应平台规则生成。
+- Claude Code 相关安装由 plugin 机制承接。
+
+## Research
+
+### Existing System
+
+- `zest-dev init` 目前只有 `--target <target>` 参数，默认值是 `opencode`，入口调用 `deployPlugin(options.target)`。Source: `bin/zest-dev.js:216-224`
+- OpenCode 当前本地部署会创建 `.opencode/commands` 和 `.opencode/skills`。Source: `lib/plugin-deployer.js:59-68`
+- OpenCode command 从 `plugin/commands/*.md` 读取，写入当前目录 `.opencode/commands/zest-dev-<filename>`，并只保留 `description` frontmatter。Source: `lib/plugin-deployer.js:137-158`, `lib/plugin-deployer.js:35-41`
+- OpenCode skill 从 `plugin/skills/*` 复制到当前目录 `.opencode/skills/<skillName>`。Source: `lib/plugin-deployer.js:168-185`
+- Codex 当前本地部署会创建 `.codex/agents` 和 `.agents/skills/zest-dev`。Source: `lib/plugin-deployer.js:74-83`
+- Codex 当前把 command markdown 作为 skill 内的 prompt 文件写到 `.agents/skills/zest-dev/commands/zest-dev-*.md`；新设计会移除 Codex command prompt 部署。Source: `lib/plugin-deployer.js:194-215`
+- Codex 当前只复制 `plugin/skills/zest-dev` 到 `.agents/skills/zest-dev`，并生成三个 `.codex/agents/*.toml` 子代理文件。Source: `lib/plugin-deployer.js:222-232`, `lib/plugin-deployer.js:243-265`
+- 当前 `deployPlugin` 只接受 `opencode` 和 `codex` 两个 target；无全局目录逻辑。Source: `lib/plugin-deployer.js:272-334`
+- 集成测试当前断言默认 target 是 `opencode`，默认初始化写入本地 `.opencode` 目录。Source: `test/test-integration.js:130-166`
+- 集成测试覆盖 OpenCode command、skill、frontmatter 转换、幂等性、Codex target 布局和非法 target 错误。Source: `test/test-integration.js:168-362`
+- 包发布内容包含 `bin/`、`lib/` 和 `plugin/`，CLI bin 是 `./bin/zest-dev.js`。Source: `package.json:19-29`
+
+### Platform Global Locations
+
+- Claude Code 全局 command 路径是 `~/.claude/commands/*.md`，项目 command 路径是 `.claude/commands/*.md`；全局 skill 路径是 `~/.claude/skills/<name>/SKILL.md`，项目 skill 路径是 `.claude/skills/<name>/SKILL.md`。Source: https://code.claude.com/docs/en/claude-directory, https://docs.claude.com/en/docs/claude-code/slash-commands
+- Claude Code 文档说明 custom commands 已并入 skills 体系，但 command 文件路径仍被记录为项目和全局可用位置。Source: https://docs.claude.com/en/docs/claude-code/slash-commands
+- Claude Code 还支持 plugin 机制；本次 `zest-dev init` 设计范围聚焦 OpenCode 和 Codex，Claude Code 安装交给 plugin 路线。Source: `plugin/.claude-plugin/plugin.json:1-10`, https://docs.claude.com/en/docs/claude-code/slash-commands
+- Codex CLI slash commands 文档列出内置 slash commands；未给出自定义 slash command 文件路径。Codex 扩展点是 skills。Source: https://developers.openai.com/codex/cli/slash-commands, https://developers.openai.com/codex/skills
+- Codex 全局 skill 可放在 `~/.agents/skills/` 或 `~/.codex/skills/`，仓库 skill 放在 `.agents/skills/<name>/`，系统级 skill 放在 `/etc/codex/skills`。Source: https://developers.openai.com/codex/skills, https://developers.openai.com/codex/concepts/customization
+- Codex 全局 instructions 路径是 `~/.codex/AGENTS.md`，仓库 instructions 路径是 `AGENTS.md`。Source: https://developers.openai.com/codex/guides/agents-md
+- OpenCode 全局 command 路径是 `~/.config/opencode/commands/*.md`，项目 command 路径是 `.opencode/commands/*.md`。Source: https://opencode.ai/docs/commands/
+- OpenCode 全局 skill 路径是 `~/.config/opencode/skills/<name>/SKILL.md`，项目 skill 路径是 `.opencode/skills/<name>/SKILL.md`。Source: https://opencode.ai/docs/commands/, https://github.com/alvinunreal/oh-my-opencode-slim/blob/master/docs/quick-reference.md
+
+### Codex CLI vs Desktop/App vs IDE Extension
+
+- Codex CLI、IDE extension 和 Codex app 共享配置层：用户级 `~/.codex/config.toml`、项目级 `.codex/config.toml`，并按 flags/config/profile/project/user/system/defaults 优先级合并。Source: https://developers.openai.com/codex/local-config
+- Codex skills 文档标明 skills 可用于 CLI、IDE extension 和 Codex app；仓库 skill 路径是 `.agents/skills/<name>/SKILL.md`，用户级路径是 `~/.agents/skills/` 或 `~/.codex/skills/`。Source: https://developers.openai.com/codex/skills
+- Codex agents/subagents 也有共享位置：全局 instructions 是 `~/.codex/AGENTS.md`，全局 subagents 是 `~/.codex/agents/*.toml`；仓库位置是 `AGENTS.md` 和 `.codex/agents/*.toml`。Source: https://developers.openai.com/codex/concepts/customization, https://developers.openai.com/codex/subagents
+- Codex CLI 提供完整命令行 flags、TUI、`codex exec`、`codex features` 和 CLI slash command 列表。Source: https://developers.openai.com/codex/cli/reference, https://developers.openai.com/codex/cli/slash-commands
+- Codex app/桌面端侧重 GUI 功能，包括 skills sidebar、automations、worktrees、Git UI、原生沙箱和 app command 子集；它使用同一套 Codex skills，而不是独立的 command 文件目录。Source: https://developers.openai.com/codex/app/features, https://developers.openai.com/codex/app/commands, https://developers.openai.com/codex/app/settings
+- Codex IDE extension 侧重编辑器集成，包括 auto-context、图片拖放、审批 UI 和 IDE command 子集；文档说明它共享 CLI 配置。Source: https://developers.openai.com/codex/ide/features, https://developers.openai.com/codex/ide/settings
+- Codex 文档未给 CLI、app 或 IDE extension 提供类似 Claude/OpenCode 的自定义 `commands/` 目录；跨形态可复用的扩展点是 skills，slash commands 是内置命令集合。Source: https://developers.openai.com/codex/cli/slash-commands, https://developers.openai.com/codex/app/commands, https://developers.openai.com/codex/skills
+
+### Available Approaches
+
+- Add scope selection (`global` default, `local` opt-in) separately from ecosystem selection (`opencode`, `codex`) so current `--target` behavior can evolve without mixing path scope and platform. Source: `bin/zest-dev.js:216-224`, `lib/plugin-deployer.js:272-334`
+- Preserve existing local layouts behind `--local`: OpenCode remains `.opencode/commands` and `.opencode/skills`; Codex remains `.agents/skills/zest-dev` plus `.codex/agents/*.toml`, with command prompt deployment removed. Source: `lib/plugin-deployer.js:59-83`, `lib/plugin-deployer.js:194-265`
+- Implement global OpenCode by reusing current OpenCode command/skill transforms with base directories under `~/.config/opencode`. Source: `lib/plugin-deployer.js:137-185`, https://opencode.ai/docs/commands/
+- Implement global Codex as skill deployment under a documented global skill root such as `~/.agents/skills/zest-dev` or `~/.codex/skills/zest-dev`, plus subagents under `~/.codex/agents`; command prompt files are removed from Codex output because Codex has no documented custom command file directory. Source: `lib/plugin-deployer.js:194-265`, https://developers.openai.com/codex/skills
+- Treat Codex CLI、desktop/app 和 IDE extension as one Codex platform for Zest Dev global skill deployment because documented skills/config locations are shared across variants. Source: https://developers.openai.com/codex/local-config, https://developers.openai.com/codex/skills
+
+### Constraints & Dependencies
+
+- Global writes target user home/config directories and may fail on permission errors; existing deployer already surfaces `EACCES` as `Permission denied: <path>`. Source: `lib/plugin-deployer.js:335-343`
+- Tests currently run in temporary project directories and assume all init outputs live under the test cwd; global-path tests need path injection or HOME/config-directory isolation to avoid modifying a real user environment. Source: `test/test-integration.js:21-79`, `test/test-integration.js:130-366`
+- Current status hint only scans local deployed command dirs via `DEPLOYED_COMMAND_DIRS`; global init may require either expanded hint logic or unchanged local-only hint semantics. Source: `bin/zest-dev.js:86-94`, `bin/zest-dev.js:107-113`
+- `plugin/skills` currently includes `zest-dev` and `debug-mode`; Codex local deployment copies only `zest-dev`, while OpenCode copies all skill dirs. Source: `lib/plugin-deployer.js:168-185`, `lib/plugin-deployer.js:222-232`
+- Current result object has grouped `cursor`, `opencode`, and `codex` fields even though `cursor` is unused; the output schema can drop unused `cursor` and report only supported `opencode`/`codex` targets. Source: `lib/plugin-deployer.js:286-330`, `test/test-integration.js:136-155`
+- Codex docs mention both `~/.agents/skills/` and `~/.codex/skills/` as user/global skill roots, so the design phase needs to choose one canonical install root or support both explicitly. Source: https://developers.openai.com/codex/skills, https://developers.openai.com/codex/concepts/customization
+
+### Key References
+
+- `bin/zest-dev.js:216-224` - current init command entry and default target.
+- `lib/plugin-deployer.js:59-334` - directory creation, command/skill deployment, Codex subagent generation, valid targets.
+- `test/test-integration.js:130-366` - current init integration coverage.
+- https://code.claude.com/docs/en/claude-directory - Claude Code project/global directory table.
+- https://docs.claude.com/en/docs/claude-code/slash-commands - Claude Code commands and skills location docs.
+- https://developers.openai.com/codex/skills - Codex skill scopes and locations.
+- https://developers.openai.com/codex/local-config - shared Codex CLI/IDE/app configuration layers.
+- https://developers.openai.com/codex/app/features - Codex app/desktop capabilities.
+- https://developers.openai.com/codex/ide/features - Codex IDE extension capabilities.
+- https://developers.openai.com/codex/cli/slash-commands - Codex built-in slash command reference.
+- https://opencode.ai/docs/commands/ - OpenCode command and skill locations.
+
+## Design
+
+### Architecture Overview
+
+```mermaid
+flowchart TD
+  CLI[zest-dev init] --> Parse[Parse scope + target]
+  Parse --> Scope{scope}
+  Scope -->|global default| GlobalTargets[OpenCode + Codex by default]
+  Scope -->|local| LocalTargets[target default opencode]
+  GlobalTargets --> CodexGlobal[Codex global skill + subagents]
+  GlobalTargets --> OpenCodeGlobal[OpenCode global deploy]
+  LocalTargets --> OpenCodeLocal[existing .opencode deploy]
+  LocalTargets --> CodexLocal[Codex local skill + subagents]
+  CodexGlobal --> Result
+  OpenCodeGlobal --> Result
+  OpenCodeLocal --> Result
+  CodexLocal --> Result
+```
+
+### Change Scope
+
+- CLI: add `--global` and `--local` scope flags; keep `--target <target>` and expand valid targets to `all|opencode|codex`. Source: `bin/zest-dev.js:216-224`, `lib/plugin-deployer.js:272-334`
+- Deployment core: refactor current hardcoded cwd-relative deploy functions into reusable target-root functions for local and global paths. Source: `lib/plugin-deployer.js:59-185`, `lib/plugin-deployer.js:194-265`
+- OpenCode output: local remains `.opencode/commands` and `.opencode/skills`; global writes `~/.config/opencode/commands` and `~/.config/opencode/skills`. Source: `lib/plugin-deployer.js:59-68`, https://opencode.ai/docs/commands/
+- Codex output: local writes `.agents/skills/zest-dev` and `.codex/agents`; global writes `~/.agents/skills/zest-dev` and `~/.codex/agents`; Codex command prompt files are removed from both scopes. Source: `lib/plugin-deployer.js:74-83`, `lib/plugin-deployer.js:194-265`, https://developers.openai.com/codex/skills, https://developers.openai.com/codex/subagents
+- Tests: update integration tests so global writes are isolated under a fake HOME/config directory, while `--local` keeps current cwd-based assertions. Source: `test/test-integration.js:21-79`, `test/test-integration.js:130-366`
+
+### Design Decisions
+
+- Default `zest-dev init` uses `scope=global` and `target=all`, so one command installs Zest Dev for OpenCode and Codex. Source: `specs/change/20260509-global-init-targets/spec.md:16-34`, `bin/zest-dev.js:216-224`
+- `zest-dev init --global` is an explicit alias for the default global install. Source: `specs/change/20260509-global-init-targets/spec.md:16-31`
+- `zest-dev init --local` switches to cwd-relative install and preserves the existing local default target as OpenCode for compatibility with current tests and behavior. Source: `test/test-integration.js:136-166`, `lib/plugin-deployer.js:280-305`
+- `--target` has scope-aware defaults: global scope defaults to `all`, local scope defaults to `opencode`; explicit targets remain available through `--target all`, `--target opencode`, and `--target codex`. Source: `lib/plugin-deployer.js:280-334`, `test/test-integration.js:136-166`
+- OpenCode deployment reuses the existing command frontmatter transform and skill directory copy behavior. Source: `lib/plugin-deployer.js:35-41`, `lib/plugin-deployer.js:137-185`
+- Claude Code deployment is handled through the plugin route and stays outside `zest-dev init`. Source: `plugin/.claude-plugin/plugin.json:1-10`, https://docs.claude.com/en/docs/claude-code/slash-commands
+- Codex deployment installs only the Zest Dev skill and subagents; command markdown files are excluded because Codex documents skills across variants and built-in slash commands separately. Source: `lib/plugin-deployer.js:194-265`, https://developers.openai.com/codex/skills, https://developers.openai.com/codex/cli/slash-commands, https://developers.openai.com/codex/app/commands
+- Codex global skill canonical root is `~/.agents/skills/zest-dev`, because the current local repository root is `.agents/skills/zest-dev` and Codex docs list `~/.agents/skills/` as a user/global skill location. Source: `lib/plugin-deployer.js:194-232`, https://developers.openai.com/codex/skills
+- Codex subagents are deployed globally to `~/.codex/agents/*.toml`, matching current local `.codex/agents/*.toml` generation and Codex subagent docs. Source: `lib/plugin-deployer.js:243-265`, https://developers.openai.com/codex/concepts/customization, https://developers.openai.com/codex/subagents
+- Result YAML should include `ok`, `scope`, `target`, and grouped `codex`/`opencode` entries, each with `commands`, `skills`, `agents`, and `baseDir` fields; Codex `commands` remains an empty array. Source: `lib/plugin-deployer.js:286-330`, `test/test-integration.js:136-155`
+- Invalid scope/target combinations should fail with clear errors before writing files. Source: `lib/plugin-deployer.js:334-343`
+
+### Why this design
+
+- It matches the requested user-facing default: global install is the default flow and local install becomes opt-in.
+- It keeps ecosystem selection separate from path scope, which makes the CLI easier to extend and keeps `--local --target codex` understandable.
+- It preserves existing local behavior behind `--local`, reducing migration risk for existing users and tests.
+- It treats Codex CLI, app, and IDE extension as one platform because the documented skills/config locations are shared.
+- It uses the documented Codex skills mechanism for cross-variant availability.
+- It leaves Claude Code installation to the existing plugin artifact path.
+
+### Test Strategy
+
+- CLI parsing: assert `init`, `init --global`, `init --local`, `init --target <target>`, invalid target, and conflicting scope flags. Source: `bin/zest-dev.js:216-224`
+- Global default: run with isolated HOME/config env and assert Codex skill/subagents and OpenCode command/skill files are created. Source: `test/test-integration.js:21-79`
+- Local compatibility: run `init --local` and assert the existing `.opencode` default behavior remains. Source: `test/test-integration.js:130-166`
+- Target-specific paths: assert `--global --target codex` and `--global --target opencode` create only their target outputs. Source: `lib/plugin-deployer.js:280-334`
+- Artifact content: assert OpenCode command files preserve `$ARGUMENTS`, frontmatter transform stays stable where required, Codex has no command files, and skill phase files are copied. Source: `test/test-integration.js:249-303`
+- Idempotency: run global and local init twice and assert stable file counts. Source: `test/test-integration.js:305-317`
+
+### Pseudocode
+
+Flow:
+  Parse `init` options.
+  Set `scope = global` unless `--local` is present.
+  Set `target = all` for global default; set `target = opencode` for local default.
+  Resolve target list from `all|opencode|codex`.
+  For each target:
+    Resolve base directories from scope and target.
+    Ensure directories exist.
+    Deploy OpenCode command files for OpenCode target.
+    Deploy skill files to platform skill directories.
+    Deploy Codex subagents for Codex target.
+  Return grouped YAML result.
+
+### File Structure
+
+- `bin/zest-dev.js` - CLI flags, target/scope option passing, help text.
+- `lib/plugin-deployer.js` - path resolution, target deploy functions, result schema, validation errors.
+- `test/test-integration.js` - global/local/target integration coverage with isolated environment.
+- `plugin/commands/*` - shared command source files.
+- `plugin/skills/*` - shared skill source directories.
+
+### Interfaces / APIs
+
+- `zest-dev init` → global install for OpenCode and Codex.
+- `zest-dev init` → equivalent to `zest-dev init --global --target all`.
+- `zest-dev init --global` → equivalent to `zest-dev init --global --target all`.
+- `zest-dev init --local` → equivalent to `zest-dev init --local --target opencode`.
+- `zest-dev init --target all|opencode|codex` → target selection.
+- `zest-dev init --local --target codex` → current Codex local layout.
+- `zest-dev init --local --target all` → local install for OpenCode and Codex.
+
+### Edge Cases
+
+- Passing both `--global` and `--local` fails before file writes.
+- Invalid `--target` fails before file writes.
+- Permission errors in global directories surface as `Permission denied: <path>`.
+- Missing packaged `plugin/` files fail immediately with the existing plugin directory error.
+- Existing non-Zest Dev files in target directories are preserved; init only writes Zest Dev OpenCode command/skill artifacts and Codex skill/subagent artifacts.
+
+## Plan
+
+- [ ] Step 1: Refactor deployer around scope and target roots
+  - [ ] Substep 1.1 Implement: Add scope/target validation and path resolution helpers.
+  - [ ] Substep 1.2 Implement: Parameterize existing OpenCode and Codex deploy functions by base directory.
+  - [ ] Substep 1.3 Implement: Remove Codex command prompt deployment and keep Codex skill/subagent deployment.
+  - [ ] Substep 1.4 Verify: Run focused init tests for path resolution and invalid options.
+- [ ] Step 2: Update CLI behavior and result schema
+  - [ ] Substep 2.1 Implement: Add `--global`, `--local`, expanded `--target`, and help text.
+  - [ ] Substep 2.2 Implement: Return `scope`, `target`, and grouped `codex/opencode` deployment metadata.
+  - [ ] Substep 2.3 Verify: Assert default `init` equals `init --global` behavior.
+- [ ] Step 3: Add global and local integration coverage
+  - [ ] Substep 3.1 Implement: Isolate HOME/config roots in tests for global installs.
+  - [ ] Substep 3.2 Implement: Add assertions for Codex and OpenCode global outputs.
+  - [ ] Substep 3.3 Implement: Update local compatibility tests to use `init --local`.
+  - [ ] Substep 3.4 Verify: Run `pnpm test:local`.
+- [ ] Step 4: Stabilize package behavior
+  - [ ] Substep 4.1 Verify: Run `pnpm test:package`.
+  - [ ] Substep 4.2 Verify: Manually inspect generated YAML for default, target-specific, and local commands.
+  - [ ] Substep 4.3 Implement: Update docs/help text if test output reveals confusing command usage.
+
+## Notes
+
+<!-- Optional sections — add what's relevant. -->
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->

--- a/specs/change/20260509-global-init-targets/spec.md
+++ b/specs/change/20260509-global-init-targets/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260509-global-init-targets
 name: Global Init Targets
-status: designed
+status: implemented
 created: '2026-05-09'
 ---
 
@@ -206,33 +206,35 @@ Flow:
 
 ## Plan
 
-- [ ] Step 1: Refactor deployer around scope and target roots
-  - [ ] Substep 1.1 Implement: Add scope/target validation and path resolution helpers.
-  - [ ] Substep 1.2 Implement: Parameterize existing OpenCode and Codex deploy functions by base directory.
-  - [ ] Substep 1.3 Implement: Remove Codex command prompt deployment and keep Codex skill/subagent deployment.
-  - [ ] Substep 1.4 Verify: Run focused init tests for path resolution and invalid options.
-- [ ] Step 2: Update CLI behavior and result schema
-  - [ ] Substep 2.1 Implement: Add `--global`, `--local`, expanded `--target`, and help text.
-  - [ ] Substep 2.2 Implement: Return `scope`, `target`, and grouped `codex/opencode` deployment metadata.
-  - [ ] Substep 2.3 Verify: Assert default `init` equals `init --global` behavior.
-- [ ] Step 3: Add global and local integration coverage
-  - [ ] Substep 3.1 Implement: Isolate HOME/config roots in tests for global installs.
-  - [ ] Substep 3.2 Implement: Add assertions for Codex and OpenCode global outputs.
-  - [ ] Substep 3.3 Implement: Update local compatibility tests to use `init --local`.
-  - [ ] Substep 3.4 Verify: Run `pnpm test:local`.
-- [ ] Step 4: Stabilize package behavior
-  - [ ] Substep 4.1 Verify: Run `pnpm test:package`.
-  - [ ] Substep 4.2 Verify: Manually inspect generated YAML for default, target-specific, and local commands.
-  - [ ] Substep 4.3 Implement: Update docs/help text if test output reveals confusing command usage.
+- [x] Step 1: Refactor deployer around scope and target roots
+  - [x] Substep 1.1 Implement: Add scope/target validation and path resolution helpers.
+  - [x] Substep 1.2 Implement: Parameterize existing OpenCode and Codex deploy functions by base directory.
+  - [x] Substep 1.3 Implement: Remove Codex command prompt deployment and keep Codex skill/subagent deployment.
+  - [x] Substep 1.4 Verify: Run focused init tests for path resolution and invalid options.
+- [x] Step 2: Update CLI behavior and result schema
+  - [x] Substep 2.1 Implement: Add `--global`, `--local`, expanded `--target`, and help text.
+  - [x] Substep 2.2 Implement: Return `scope`, `target`, and grouped `codex/opencode` deployment metadata.
+  - [x] Substep 2.3 Verify: Assert default `init` equals `init --global` behavior.
+- [x] Step 3: Add global and local integration coverage
+  - [x] Substep 3.1 Implement: Isolate HOME/config roots in tests for global installs.
+  - [x] Substep 3.2 Implement: Add assertions for Codex and OpenCode global outputs.
+  - [x] Substep 3.3 Implement: Update local compatibility tests to use `init --local`.
+  - [x] Substep 3.4 Verify: Run `pnpm test:local`.
+- [x] Step 4: Stabilize package behavior
+  - [x] Substep 4.1 Verify: Run `pnpm test:package`.
+  - [x] Substep 4.2 Verify: Manually inspect generated YAML for default, target-specific, and local commands.
+  - [x] Substep 4.3 Implement: Update docs/help text if test output reveals confusing command usage.
 
 ## Notes
 
-<!-- Optional sections — add what's relevant. -->
-
 ### Implementation
 
-<!-- Files created/modified, decisions made during coding, deviations from design -->
+- `bin/zest-dev.js` - added `--global`, `--local`, scope-aware target defaults, expanded `--target all|opencode|codex`, and conflicting scope validation.
+- `lib/plugin-deployer.js` - refactored deployment around local/global target roots, added XDG-aware OpenCode global paths, Codex global paths, grouped result metadata, global path validation, scoped legacy OpenCode agent cleanup, and Codex legacy command prompt cleanup.
+- `test/test-integration.js` - updated init coverage for isolated global directories, local compatibility, target-specific installs, Codex command prompt removal, invalid options, and package-safe behavior.
 
 ### Verification
 
-<!-- How the feature was verified: tests written, manual testing steps, results -->
+- `pnpm test:local` - passed, 37 tests.
+- `pnpm test:package` - passed, 37 tests.
+- Manual YAML inspection passed for `init`, `init --target codex`, and `init --local` with isolated `HOME` and `XDG_CONFIG_HOME`.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -335,6 +335,7 @@ test('zest-dev init integration', async (t) => {
       const opencodeOnlyEnv = makeIsolatedGlobalEnv(opencodeOnlyDir);
       const opencodeOnly = yaml.load(runInitArgs('--target opencode', opencodeOnlyDir, opencodeOnlyEnv));
       assert.equal(opencodeOnly.target, 'opencode');
+      assert.equal(opencodeOnly.codex.baseDir, null);
       assert.ok(fs.existsSync(path.join(opencodeOnlyEnv.XDG_CONFIG_HOME, 'opencode/commands')));
       assert.equal(fs.existsSync(path.join(opencodeOnlyEnv.HOME, '.codex/agents')), false);
 
@@ -343,8 +344,31 @@ test('zest-dev init integration', async (t) => {
       const codexOnlyEnv = makeIsolatedGlobalEnv(codexOnlyDir);
       const codexOnly = yaml.load(runInitArgs('--target codex', codexOnlyDir, codexOnlyEnv));
       assert.equal(codexOnly.target, 'codex');
+      assert.equal(codexOnly.opencode.baseDir, null);
       assert.ok(fs.existsSync(path.join(codexOnlyEnv.HOME, '.codex/agents')));
       assert.equal(fs.existsSync(path.join(codexOnlyEnv.XDG_CONFIG_HOME, 'opencode/commands')), false);
+
+      const opencodeWithoutHomeDir = path.join(TEST_DIR, 'opencode-without-home');
+      setup(opencodeWithoutHomeDir);
+      const opencodeWithoutHomeEnv = {
+        HOME: '',
+        XDG_CONFIG_HOME: path.join(opencodeWithoutHomeDir, 'xdg-config')
+      };
+      const opencodeWithoutHome = yaml.load(runInitArgs('--target opencode', opencodeWithoutHomeDir, opencodeWithoutHomeEnv));
+      assert.equal(opencodeWithoutHome.target, 'opencode');
+      assert.ok(fs.existsSync(path.join(opencodeWithoutHomeEnv.XDG_CONFIG_HOME, 'opencode/commands')));
+
+      const codexWithRelativeXdgDir = path.join(TEST_DIR, 'codex-with-relative-xdg');
+      setup(codexWithRelativeXdgDir);
+      const codexWithRelativeXdgEnv = {
+        HOME: path.join(codexWithRelativeXdgDir, 'home'),
+        XDG_CONFIG_HOME: 'relative-config'
+      };
+      fs.mkdirSync(codexWithRelativeXdgEnv.HOME, { recursive: true });
+      const codexWithRelativeXdg = yaml.load(runInitArgs('--target codex', codexWithRelativeXdgDir, codexWithRelativeXdgEnv));
+      assert.equal(codexWithRelativeXdg.target, 'codex');
+      assert.ok(fs.existsSync(path.join(codexWithRelativeXdgEnv.HOME, '.codex/agents')));
+      assert.equal(fs.existsSync(path.join(codexWithRelativeXdgDir, 'relative-config')), false);
     });
 
     await t.test('invalid target fails before writes', () => {

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -578,6 +578,14 @@ test('zest-dev status integration', async (t) => {
       ]);
     });
 
+    await t.test('status works when optional global OpenCode env is invalid', () => {
+      const status = yaml.load(runCommandWithEnv('status', TEST_DIR, {
+        HOME: '',
+        XDG_CONFIG_HOME: 'relative-config'
+      }));
+      assert.equal(status.specs_count, 2);
+    });
+
     await t.test('agent hint is not shown for non-zest markdown files', () => {
       const otherCommandsDir = path.join(TEST_DIR, '.opencode', 'commands');
       fs.mkdirSync(otherCommandsDir, { recursive: true });

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -480,11 +480,14 @@ test('zest-dev status integration', async (t) => {
   setup();
 
   try {
+    const statusEnv = makeIsolatedGlobalEnv(path.join(TEST_DIR, 'status-env'));
+    const runStatus = () => runCommandWithEnv('status', TEST_DIR, statusEnv);
+
     runCreate('first-spec');
     runCreate('second-spec');
 
     await t.test('active_change is null when not set', () => {
-      const status = yaml.load(runCommand('status'));
+      const status = yaml.load(runStatus());
       assert.equal(status.specs_count, 2);
       assert.equal(status.active_change, null);
       assert.equal(status.agent_hints, undefined);
@@ -498,7 +501,7 @@ test('zest-dev status integration', async (t) => {
       assert.ok(secondSpecDir, 'second-spec directory should exist');
 
       runCommand(`set-active ${secondSpecDir}`);
-      const status = yaml.load(runCommand('status'));
+      const status = yaml.load(runStatus());
 
       assert.equal(status.specs_count, 2);
       assert.equal(typeof status.active_change, 'object');
@@ -513,7 +516,7 @@ test('zest-dev status integration', async (t) => {
       const missingSpecId = '19990101-removed-spec';
       createDanglingActiveSymlink(missingSpecId);
 
-      const status = yaml.load(runCommand('status'));
+      const status = yaml.load(runStatus());
 
       assert.equal(status.specs_count, 2);
       assert.deepEqual(status.active_change, {
@@ -533,7 +536,7 @@ test('zest-dev status integration', async (t) => {
       createDanglingActiveSymlink('19990101-removed-spec');
       runCommand(`set-active ${firstSpecDir}`);
 
-      const status = yaml.load(runCommand('status'));
+      const status = yaml.load(runStatus());
       assert.equal(status.active_change.id, firstSpecDir);
     });
 
@@ -552,7 +555,24 @@ test('zest-dev status integration', async (t) => {
       fs.mkdirSync(cursorCommandsDir, { recursive: true });
       fs.writeFileSync(path.join(cursorCommandsDir, 'zest-dev-new.md'), '# test', 'utf-8');
 
-      const status = yaml.load(runCommand('status'));
+      const status = yaml.load(runStatus());
+      assert.deepEqual(status.agent_hints, [
+        'Run `zest-dev init` to update deployed command markdown files.'
+      ]);
+    });
+
+    await t.test('agent hint appears when global OpenCode command markdown exists', () => {
+      const globalEnv = makeIsolatedGlobalEnv(path.join(TEST_DIR, 'global-hint-env'));
+      const globalCommandsDir = path.join(globalEnv.XDG_CONFIG_HOME, 'opencode', 'commands');
+      const cursorZestFile = path.join(TEST_DIR, '.cursor', 'commands', 'zest-dev-new.md');
+      if (fs.existsSync(cursorZestFile)) {
+        fs.unlinkSync(cursorZestFile);
+      }
+
+      fs.mkdirSync(globalCommandsDir, { recursive: true });
+      fs.writeFileSync(path.join(globalCommandsDir, 'zest-dev-new.md'), '# test', 'utf-8');
+
+      const status = yaml.load(runCommandWithEnv('status', TEST_DIR, globalEnv));
       assert.deepEqual(status.agent_hints, [
         'Run `zest-dev init` to update deployed command markdown files.'
       ]);
@@ -569,7 +589,7 @@ test('zest-dev status integration', async (t) => {
         fs.unlinkSync(cursorZestFile);
       }
 
-      const status = yaml.load(runCommand('status'));
+      const status = yaml.load(runStatus());
       assert.equal(status.agent_hints, undefined);
     });
   } finally {

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -27,10 +27,10 @@ const EXPECTED_COMMANDS = [
   'zest-dev-draft.md',
   'zest-dev-implement.md',
   'zest-dev-new.md',
+  'zest-dev-quick-implement.md',
   'zest-dev-research.md',
   'zest-dev-summarize-chat.md',
-  'zest-dev-summarize-pr.md',
-  'zest-dev-quick-implement.md'
+  'zest-dev-summarize-pr.md'
 ];
 const THIN_COMMANDS = [
   'zest-dev-new.md',
@@ -59,10 +59,15 @@ function setup(testDir = TEST_DIR) {
 }
 
 function runCommand(command, cwd = TEST_DIR) {
+  return runCommandWithEnv(command, cwd);
+}
+
+function runCommandWithEnv(command, cwd = TEST_DIR, env = {}) {
   try {
     return execSync(`${CLI_COMMAND} ${command}`, {
       cwd,
-      encoding: 'utf-8'
+      encoding: 'utf-8',
+      env: { ...process.env, ...env }
     });
   } catch (error) {
     const details = [error.message, error.stdout, error.stderr].filter(Boolean).join('\n');
@@ -70,20 +75,21 @@ function runCommand(command, cwd = TEST_DIR) {
   }
 }
 
-function runInit(cwd = TEST_DIR) {
-  return runCommand('init', cwd);
+function runInit(cwd = TEST_DIR, env = {}) {
+  return runCommandWithEnv('init', cwd, env);
 }
 
-function runInitWithTarget(target, cwd = TEST_DIR) {
-  return runCommand(`init -t ${target}`, cwd);
+function runInitArgs(args, cwd = TEST_DIR, env = {}) {
+  return runCommandWithEnv(`init ${args}`.trim(), cwd, env);
 }
 
-function runCommandExpectFailure(command, cwd = TEST_DIR) {
+function runCommandExpectFailure(command, cwd = TEST_DIR, env = {}) {
   try {
     execSync(`${CLI_COMMAND} ${command}`, {
       cwd,
       encoding: 'utf-8',
-      stdio: 'pipe'
+      stdio: 'pipe',
+      env: { ...process.env, ...env }
     });
     return { failed: false, output: '' };
   } catch (error) {
@@ -104,6 +110,14 @@ function runUpdate(spec, status, cwd = TEST_DIR) {
 
 function readCommand(target, filename, testDir = TEST_DIR) {
   return fs.readFileSync(path.join(testDir, target, 'commands', filename), 'utf-8');
+}
+
+function makeIsolatedGlobalEnv(testDir = TEST_DIR) {
+  const homeDir = path.join(testDir, 'fake-home');
+  const xdgConfigHome = path.join(testDir, 'fake-xdg-config');
+  fs.mkdirSync(homeDir, { recursive: true });
+  fs.mkdirSync(xdgConfigHome, { recursive: true });
+  return { HOME: homeDir, XDG_CONFIG_HOME: xdgConfigHome };
 }
 
 function extractFrontmatter(content, filename) {
@@ -131,100 +145,114 @@ test('zest-dev init integration', async (t) => {
   setup();
 
   try {
-    const firstRunOutput = runInit();
+    const globalEnv = makeIsolatedGlobalEnv();
+    const fakeHome = globalEnv.HOME;
+    const fakeXdgConfigHome = globalEnv.XDG_CONFIG_HOME;
+    const globalOpenCodeBase = path.join(fakeXdgConfigHome, 'opencode');
+    const globalOpenCodeCommandsDir = path.join(globalOpenCodeBase, 'commands');
+    const globalOpenCodeSkillsDir = path.join(globalOpenCodeBase, 'skills');
+    const globalCodexSkillsDir = path.join(fakeHome, '.agents/skills/zest-dev');
+    const globalCodexAgentsDir = path.join(fakeHome, '.codex/agents');
+    const localOpenCodeCommandsDir = path.join(TEST_DIR, '.opencode/commands');
+    const localOpenCodeSkillsDir = path.join(TEST_DIR, '.opencode/skills');
+    const localCodexSkillsDir = path.join(TEST_DIR, '.agents/skills/zest-dev');
+    const localCodexAgentsDir = path.join(TEST_DIR, '.codex/agents');
+    const firstRunOutput = runInit(TEST_DIR, globalEnv);
 
-    await t.test('default target output format (opencode)', () => {
+    await t.test('default global init output format', () => {
       const result = yaml.load(firstRunOutput);
 
-      assert.equal(result.ok, true, 'output should include ok: true');
-      assert.equal(result.target, 'opencode', 'default init target should be opencode');
-      assert.ok(result.cursor && result.opencode && result.codex, 'output should include grouped targets');
-      assert.ok(Array.isArray(result.cursor.commands), 'cursor.commands should be an array');
-      assert.ok(Array.isArray(result.opencode.commands), 'opencode.commands should be an array');
-      assert.ok(Array.isArray(result.codex.commands), 'codex.commands should be an array');
-      assert.ok(Array.isArray(result.cursor.skills), 'cursor.skills should be an array');
-      assert.ok(Array.isArray(result.cursor.agents), 'cursor.agents should be an array');
-      assert.ok(Array.isArray(result.opencode.agents), 'opencode.agents should be an array');
-      assert.deepEqual(result.cursor.commands, [], 'cursor.commands should be empty');
-      assert.deepEqual(result.cursor.skills, [], 'cursor.skills should be empty');
-      assert.deepEqual(result.cursor.agents, [], 'cursor.agents should be empty');
-      assert.deepEqual(result.opencode.agents, [], 'opencode.agents should be empty');
-      assert.deepEqual(result.codex.commands, [], 'codex.commands should be empty for opencode target');
-      assert.deepEqual(result.codex.skills, [], 'codex.skills should be empty for opencode target');
-      assert.deepEqual(result.codex.agents, [], 'codex.agents should be empty for opencode target');
+      assert.equal(result.ok, true);
+      assert.equal(result.scope, 'global');
+      assert.equal(result.target, 'all');
+      assert.equal(result.cursor, undefined);
+      assert.equal(result.opencode.baseDir, globalOpenCodeBase);
+      assert.equal(result.codex.baseDir, fakeHome);
+      assert.deepEqual(result.codex.commands, []);
+      assert.deepEqual(result.opencode.agents, []);
+      assert.deepEqual(result.opencode.commands, EXPECTED_COMMANDS);
+      assert.deepEqual(result.codex.agents, CODEX_SUBAGENTS);
     });
 
-    await t.test('directory structure', () => {
-      const expectedDirs = [
-        '.opencode/commands',
-        '.opencode/skills'
-      ];
+    await t.test('default global init deploys opencode and codex artifacts', () => {
+      assert.ok(fs.existsSync(globalOpenCodeCommandsDir));
+      assert.ok(fs.existsSync(globalOpenCodeSkillsDir));
+      assert.ok(fs.existsSync(globalCodexSkillsDir));
+      assert.ok(fs.existsSync(globalCodexAgentsDir));
+      assert.equal(fs.existsSync(localOpenCodeCommandsDir), false);
+      assert.equal(fs.existsSync(localCodexAgentsDir), false);
 
-      for (const dir of expectedDirs) {
-        assert.ok(fs.existsSync(path.join(TEST_DIR, dir)), `directory should exist: ${dir}`);
-      }
-    });
-
-    await t.test('command files', () => {
       for (const file of EXPECTED_COMMANDS) {
-        const filePath = path.join(TEST_DIR, '.opencode', 'commands', file);
-        assert.ok(fs.existsSync(filePath), `.opencode command should exist: ${file}`);
+        assert.ok(fs.existsSync(path.join(globalOpenCodeCommandsDir, file)), `global OpenCode command should exist: ${file}`);
       }
 
-      assert.equal(
-        fs.existsSync(path.join(TEST_DIR, '.cursor')),
-        false,
-        '.cursor should not be created during init'
-      );
+      const subagents = fs.readdirSync(globalCodexAgentsDir).sort();
+      assert.deepEqual(subagents, CODEX_SUBAGENTS);
+      assert.equal(fs.existsSync(path.join(globalCodexSkillsDir, 'commands')), false, 'codex skill should not contain command prompt files');
+      assert.equal(fs.existsSync(path.join(TEST_DIR, '.cursor')), false);
+      assert.equal(fs.existsSync(path.join(TEST_DIR, 'AGENTS.md')), false);
     });
 
-    await t.test('command language alignment rule', () => {
+    await t.test('default global init preserves opencode content rules', () => {
       for (const file of EXPECTED_COMMANDS) {
-        const content = readCommand('.opencode', file);
-        assert.ok(
-          LANGUAGE_ALIGNMENT_RULES.some(rule => content.includes(rule)),
-          `.opencode/commands/${file} should include a supported language alignment rule`
-        );
+        const content = fs.readFileSync(path.join(globalOpenCodeCommandsDir, file), 'utf-8');
+        assert.ok(LANGUAGE_ALIGNMENT_RULES.some(rule => content.includes(rule)));
+      }
+
+      const content = fs.readFileSync(path.join(globalOpenCodeCommandsDir, 'zest-dev-new.md'), 'utf-8');
+      const frontmatter = extractFrontmatter(content, 'zest-dev-new.md');
+      assert.ok(frontmatter.description);
+      assert.equal(frontmatter['argument-hint'], undefined);
+      assert.equal(frontmatter['allowed-tools'], undefined);
+      assert.equal(Object.keys(frontmatter).length, 1);
+
+      for (const file of ['zest-dev-new.md', 'zest-dev-research.md', 'zest-dev-design.md', 'zest-dev-implement.md']) {
+        const body = fs.readFileSync(path.join(globalOpenCodeCommandsDir, file), 'utf-8');
+        assert.ok(body.includes('$ARGUMENTS'));
+      }
+
+      for (const file of THIN_COMMANDS) {
+        const thinContent = fs.readFileSync(path.join(globalOpenCodeCommandsDir, file), 'utf-8');
+        assert.equal(thinContent.includes('**Step 1:'), false);
       }
     });
 
-    await t.test('skills deployment', () => {
-      const opencodeSkillPath = path.join(TEST_DIR, '.opencode/skills/zest-dev/SKILL.md');
-
-      assert.ok(fs.existsSync(opencodeSkillPath), 'OpenCode skill file should exist');
-
+    await t.test('global skills content and codex toml content are preserved', () => {
+      const opencodeSkillPath = path.join(globalOpenCodeSkillsDir, 'zest-dev/SKILL.md');
+      assert.ok(fs.existsSync(opencodeSkillPath));
       const skillContent = fs.readFileSync(opencodeSkillPath, 'utf-8');
       assert.ok(skillContent.includes('This skill is the **canonical workflow source**'));
       assert.ok(skillContent.includes('Commands should stay thin'));
 
       for (const file of SKILL_PHASE_FILES) {
-        const filePath = path.join(TEST_DIR, '.opencode/skills/zest-dev', file);
-        assert.ok(fs.existsSync(filePath), `skill phase file should exist: ${file}`);
+        assert.ok(fs.existsSync(path.join(globalOpenCodeSkillsDir, 'zest-dev', file)));
       }
 
-      const researchPhase = fs.readFileSync(path.join(TEST_DIR, '.opencode/skills/zest-dev/research.md'), 'utf-8');
-      assert.ok(
-        researchPhase.includes('Summarize your understanding of the request and confirm it with the user'),
-        'research phase should preserve the confirmation checkpoint before deeper exploration'
-      );
+      const researchPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/research.md'), 'utf-8');
+      assert.ok(researchPhase.includes('Summarize your understanding of the request and confirm it with the user'));
 
-      const designPhase = fs.readFileSync(path.join(TEST_DIR, '.opencode/skills/zest-dev/design.md'), 'utf-8');
-      assert.ok(
-        designPhase.includes('If the status is `designed` or `implemented`, confirm that the user wants to revise the existing design before continuing.'),
-        'design phase should preserve confirmation when revising an existing design'
-      );
+      const designPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/design.md'), 'utf-8');
+      assert.ok(designPhase.includes('If the status is `designed` or `implemented`, confirm that the user wants to revise the existing design before continuing.'));
+
+      const codexSkillFile = fs.readFileSync(path.join(globalCodexSkillsDir, 'SKILL.md'), 'utf-8');
+      assert.ok(codexSkillFile.includes('This skill is the **canonical workflow source**'));
+
+      for (const subagent of CODEX_SUBAGENTS) {
+        const tomlContent = fs.readFileSync(path.join(globalCodexAgentsDir, subagent), 'utf-8');
+        assert.ok(tomlContent.includes('name = '));
+        assert.ok(tomlContent.includes('developer_instructions = '));
+      }
     });
 
-    await t.test('agents are not deployed', () => {
-      assert.equal(
-        fs.existsSync(path.join(TEST_DIR, '.opencode/agents')),
-        false,
-        '.opencode/agents should not be created during init'
-      );
+    await t.test('explicit --global matches default behavior', () => {
+      const explicitGlobal = yaml.load(runInitArgs('--global', TEST_DIR, globalEnv));
+      assert.equal(explicitGlobal.scope, 'global');
+      assert.equal(explicitGlobal.target, 'all');
+      assert.deepEqual(fs.readdirSync(globalOpenCodeCommandsDir).sort(), EXPECTED_COMMANDS);
     });
 
-    await t.test('init removes only known legacy agent files and keeps other agents content', () => {
-      const agentsDir = path.join(TEST_DIR, '.opencode/agents');
+    await t.test('global init removes only known legacy opencode agent files', () => {
+      const agentsDir = path.join(globalOpenCodeBase, 'agents');
       const staleLegacyFile = path.join(agentsDir, 'code-explorer.md');
       const nonLegacyTopLevelFile = path.join(agentsDir, 'my-custom-agent.md');
       const nestedDir = path.join(agentsDir, 'nested-dir');
@@ -233,132 +261,135 @@ test('zest-dev init integration', async (t) => {
       fs.writeFileSync(staleLegacyFile, '# stale legacy agent', 'utf-8');
       fs.writeFileSync(nonLegacyTopLevelFile, '# user agent', 'utf-8');
 
-      assert.ok(fs.existsSync(staleLegacyFile), 'known legacy file should exist before init');
-      assert.ok(fs.existsSync(nonLegacyTopLevelFile), 'non-legacy file should exist before init');
-      assert.ok(fs.existsSync(agentsDir), 'agents directory should exist before cleanup');
-
-      const rerunOutput = yaml.load(runInit());
-      assert.equal(rerunOutput.ok, true, 'init rerun should succeed during upgrade cleanup');
-
-      assert.equal(fs.existsSync(staleLegacyFile), false, 'known legacy file should be removed');
-      assert.ok(fs.existsSync(nonLegacyTopLevelFile), 'non-legacy top-level file should be preserved');
-      assert.ok(fs.existsSync(agentsDir), 'agents directory should be kept');
-      assert.ok(fs.existsSync(nestedDir), 'subdirectories under agents should be kept');
+      const rerunOutput = yaml.load(runInit(TEST_DIR, globalEnv));
+      assert.equal(rerunOutput.ok, true);
+      assert.equal(fs.existsSync(staleLegacyFile), false);
+      assert.ok(fs.existsSync(nonLegacyTopLevelFile));
+      assert.ok(fs.existsSync(agentsDir));
+      assert.ok(fs.existsSync(nestedDir));
     });
 
-    await t.test('frontmatter transformation', () => {
-      const fileLabel = '.opencode/commands/zest-dev-new.md';
-      const content = readCommand('.opencode', 'zest-dev-new.md');
-      const frontmatter = extractFrontmatter(content, fileLabel);
-
-      assert.ok(frontmatter.description, `${fileLabel} should include description`);
-      assert.equal(
-        frontmatter['argument-hint'],
-        undefined,
-        `${fileLabel} should remove argument-hint`
-      );
-      assert.equal(
-        frontmatter['allowed-tools'],
-        undefined,
-        `${fileLabel} should remove allowed-tools`
-      );
-      assert.equal(
-        Object.keys(frontmatter).length,
-        1,
-        `${fileLabel} should only contain one frontmatter field`
-      );
+    await t.test('global init is idempotent', () => {
+      const secondRun = yaml.load(runInit(TEST_DIR, globalEnv));
+      assert.equal(secondRun.ok, true);
+      assert.equal(fs.readdirSync(globalOpenCodeCommandsDir).length, EXPECTED_COMMANDS.length);
+      assert.deepEqual(fs.readdirSync(globalCodexAgentsDir).sort(), CODEX_SUBAGENTS);
     });
 
-    await t.test('content preservation', () => {
-      const coreCommands = ['zest-dev-new.md', 'zest-dev-research.md', 'zest-dev-design.md', 'zest-dev-implement.md'];
-
-      for (const file of coreCommands) {
-        const content = readCommand('.opencode', file);
-        const match = content.match(/^---\n[\s\S]*?\n---\n\n([\s\S]*)/);
-        assert.ok(match, `should be able to extract command body: ${file}`);
-
-        const bodyContent = match[1];
-        assert.ok(bodyContent.includes('$ARGUMENTS'), `${file} should keep $ARGUMENTS placeholder`);
-      }
+    await t.test('local init defaults to opencode only', () => {
+      const localOutput = yaml.load(runInitArgs('--local', TEST_DIR, globalEnv));
+      assert.equal(localOutput.scope, 'local');
+      assert.equal(localOutput.target, 'opencode');
+      assert.equal(localOutput.opencode.baseDir, TEST_DIR);
+      assert.equal(localOutput.codex.baseDir, TEST_DIR);
+      assert.ok(fs.existsSync(localOpenCodeCommandsDir));
+      assert.ok(fs.existsSync(localOpenCodeSkillsDir));
+      assert.equal(fs.existsSync(localCodexSkillsDir), false);
+      assert.equal(fs.existsSync(localCodexAgentsDir), false);
     });
 
-    await t.test('core workflow commands are thin entrypoints', () => {
-      for (const file of THIN_COMMANDS) {
-        const content = readCommand('.opencode', file);
-        assert.equal(content.includes('**Step 1:'), false, `${file} should not re-describe phase steps`);
-      }
-
-      const newContent = readCommand('.opencode', 'zest-dev-new.md');
-      assert.ok(newContent.includes('Run Zest Dev **New** phase workflow.'));
-      assert.equal(newContent.includes('Treat this command as a request'), false, 'new command should avoid request/run phrasing');
-
-      const implementContent = readCommand('.opencode', 'zest-dev-implement.md');
-      assert.ok(implementContent.includes('Run Zest Dev **Implement** phase workflow.'));
-      assert.equal(implementContent.includes('Treat this command as a request'), false, 'implement command should avoid request/run phrasing');
-
-      const draftContent = readCommand('.opencode', 'zest-dev-draft.md');
-      assert.ok(draftContent.includes('run `zest-dev update active researched`'));
-      assert.ok(draftContent.includes('run `zest-dev update active designed`'));
-      assert.ok(draftContent.includes('the inferred status is persisted'));
-    });
-
-    await t.test('idempotency', () => {
-      const secondRunOutput = runInit();
-      const secondRun = yaml.load(secondRunOutput);
-      assert.equal(secondRun.ok, true, 'second init run should succeed');
-
-      const opencodeCommands = fs.readdirSync(path.join(TEST_DIR, '.opencode/commands'));
-
-      assert.equal(
-        opencodeCommands.length,
-        EXPECTED_COMMANDS.length,
-        'opencode commands count should remain unchanged'
-      );
-    });
-
-    await t.test('codex target deploys codex-specific layout with exactly three subagents', () => {
-      const codexOutput = yaml.load(runInitWithTarget('codex'));
-      assert.equal(codexOutput.ok, true);
+    await t.test('local codex target deploys codex-only layout without command prompts', () => {
+      const codexOutput = yaml.load(runInitArgs('--local --target codex', TEST_DIR, globalEnv));
+      assert.equal(codexOutput.scope, 'local');
       assert.equal(codexOutput.target, 'codex');
-      assert.deepEqual(codexOutput.opencode.commands, [], 'opencode commands should be empty for codex target');
-      assert.equal(fs.existsSync(path.join(TEST_DIR, '.opencode', 'commands', EXPECTED_COMMANDS[0])), true, 'existing opencode files are preserved from previous init');
-
-      const codexAgentsDir = path.join(TEST_DIR, '.codex/agents');
-      const codexSkillRoot = path.join(TEST_DIR, '.agents/skills/zest-dev');
-      const codexCommandsDir = path.join(codexSkillRoot, 'commands');
-
-      assert.ok(fs.existsSync(codexAgentsDir), '.codex/agents should exist');
-      assert.ok(fs.existsSync(codexSkillRoot), '.agents/skills/zest-dev should exist');
-      assert.ok(fs.existsSync(codexCommandsDir), '.agents/skills/zest-dev/commands should exist');
-      assert.equal(fs.existsSync(path.join(TEST_DIR, 'AGENTS.md')), false, 'AGENTS.md should not be generated for codex target');
-
-      const subagents = fs.readdirSync(codexAgentsDir).sort();
-      assert.deepEqual(subagents, CODEX_SUBAGENTS, 'codex should deploy exactly three subagent toml files');
-
-      for (const subagent of CODEX_SUBAGENTS) {
-        const content = fs.readFileSync(path.join(codexAgentsDir, subagent), 'utf-8');
-        assert.ok(content.includes('name = '), `${subagent} should contain name field`);
-        assert.ok(content.includes('developer_instructions = '), `${subagent} should contain developer_instructions field`);
-      }
-
-      const codexCommandFile = path.join(codexCommandsDir, 'zest-dev-new.md');
-      assert.ok(fs.existsSync(codexCommandFile), 'codex command prompt should be deployed');
-      const opencodeCommandFile = path.join(TEST_DIR, '.opencode/commands/zest-dev-new.md');
-      assert.ok(fs.existsSync(opencodeCommandFile), 'opencode command should be deployed');
-      assert.notEqual(
-        codexCommandFile,
-        opencodeCommandFile,
-        'codex and opencode command outputs should differ by target path'
-      );
+      assert.deepEqual(codexOutput.opencode.commands, []);
+      assert.ok(fs.existsSync(localCodexSkillsDir));
+      assert.ok(fs.existsSync(localCodexAgentsDir));
+      assert.deepEqual(fs.readdirSync(localCodexAgentsDir).sort(), CODEX_SUBAGENTS);
+      assert.equal(fs.existsSync(path.join(localCodexSkillsDir, 'commands')), false);
     });
 
-    await t.test('invalid target fails with clear error', () => {
-      const failed = runCommandExpectFailure('init --target invalid');
-      assert.equal(failed.failed, true, 'init with invalid target should fail');
-      assert.ok(
-        failed.output.includes('Invalid target: invalid. Expected one of: opencode, codex'),
-        'error should clearly describe valid targets'
+    await t.test('codex init removes legacy zest command prompts and preserves user command files', () => {
+      const legacyCommandsDir = path.join(localCodexSkillsDir, 'commands');
+      const legacyZestCommand = path.join(legacyCommandsDir, 'zest-dev-new.md');
+      const userCommand = path.join(legacyCommandsDir, 'my-command.md');
+
+      fs.mkdirSync(legacyCommandsDir, { recursive: true });
+      fs.writeFileSync(legacyZestCommand, '# legacy zest command', 'utf-8');
+      fs.writeFileSync(userCommand, '# user command', 'utf-8');
+
+      const codexOutput = yaml.load(runInitArgs('--local --target codex', TEST_DIR, globalEnv));
+      assert.equal(codexOutput.ok, true);
+      assert.equal(fs.existsSync(legacyZestCommand), false);
+      assert.ok(fs.existsSync(userCommand));
+    });
+
+    await t.test('local all target deploys opencode and codex without codex command prompts', () => {
+      const localAllDir = path.join(TEST_DIR, 'local-all');
+      setup(localAllDir);
+      const localAllEnv = makeIsolatedGlobalEnv(localAllDir);
+      const localAll = yaml.load(runInitArgs('--local --target all', localAllDir, localAllEnv));
+
+      assert.equal(localAll.scope, 'local');
+      assert.equal(localAll.target, 'all');
+      assert.ok(fs.existsSync(path.join(localAllDir, '.opencode/commands')));
+      assert.ok(fs.existsSync(path.join(localAllDir, '.opencode/skills')));
+      assert.ok(fs.existsSync(path.join(localAllDir, '.agents/skills/zest-dev')));
+      assert.ok(fs.existsSync(path.join(localAllDir, '.codex/agents')));
+      assert.equal(fs.existsSync(path.join(localAllDir, '.agents/skills/zest-dev/commands')), false);
+    });
+
+    await t.test('target-specific global deploys only requested platform', () => {
+      const opencodeOnlyDir = path.join(TEST_DIR, 'opencode-only');
+      setup(opencodeOnlyDir);
+      const opencodeOnlyEnv = makeIsolatedGlobalEnv(opencodeOnlyDir);
+      const opencodeOnly = yaml.load(runInitArgs('--target opencode', opencodeOnlyDir, opencodeOnlyEnv));
+      assert.equal(opencodeOnly.target, 'opencode');
+      assert.ok(fs.existsSync(path.join(opencodeOnlyEnv.XDG_CONFIG_HOME, 'opencode/commands')));
+      assert.equal(fs.existsSync(path.join(opencodeOnlyEnv.HOME, '.codex/agents')), false);
+
+      const codexOnlyDir = path.join(TEST_DIR, 'codex-only');
+      setup(codexOnlyDir);
+      const codexOnlyEnv = makeIsolatedGlobalEnv(codexOnlyDir);
+      const codexOnly = yaml.load(runInitArgs('--target codex', codexOnlyDir, codexOnlyEnv));
+      assert.equal(codexOnly.target, 'codex');
+      assert.ok(fs.existsSync(path.join(codexOnlyEnv.HOME, '.codex/agents')));
+      assert.equal(fs.existsSync(path.join(codexOnlyEnv.XDG_CONFIG_HOME, 'opencode/commands')), false);
+    });
+
+    await t.test('invalid target fails before writes', () => {
+      const invalidDir = path.join(TEST_DIR, 'invalid-target');
+      setup(invalidDir);
+      const invalidEnv = makeIsolatedGlobalEnv(invalidDir);
+      const failed = runCommandExpectFailure('init --target invalid', invalidDir, invalidEnv);
+      assert.equal(failed.failed, true);
+      assert.ok(failed.output.includes('Invalid target: invalid. Expected one of: all, opencode, codex'));
+      assert.equal(fs.existsSync(path.join(invalidEnv.XDG_CONFIG_HOME, 'opencode')), false);
+      assert.equal(fs.existsSync(path.join(invalidEnv.HOME, '.codex')), false);
+    });
+
+    await t.test('conflicting scope flags fail before writes', () => {
+      const conflictingDir = path.join(TEST_DIR, 'conflicting-scope');
+      setup(conflictingDir);
+      const conflictingEnv = makeIsolatedGlobalEnv(conflictingDir);
+      const failed = runCommandExpectFailure('init --global --local', conflictingDir, conflictingEnv);
+      assert.equal(failed.failed, true);
+      assert.ok(failed.output.includes('Cannot specify both --global and --local'));
+      assert.equal(fs.existsSync(path.join(conflictingDir, '.opencode')), false);
+      assert.equal(fs.existsSync(path.join(conflictingEnv.XDG_CONFIG_HOME, 'opencode')), false);
+    });
+
+    await t.test('relative global environment paths fail before writes', () => {
+      const relativeEnvDir = path.join(TEST_DIR, 'relative-env');
+      setup(relativeEnvDir);
+
+      const relativeXdg = runCommandExpectFailure(
+        'init',
+        relativeEnvDir,
+        { HOME: path.join(relativeEnvDir, 'home'), XDG_CONFIG_HOME: 'relative-config' }
       );
+      assert.equal(relativeXdg.failed, true);
+      assert.ok(relativeXdg.output.includes('XDG_CONFIG_HOME must be an absolute path: relative-config'));
+      assert.equal(fs.existsSync(path.join(relativeEnvDir, 'relative-config')), false);
+
+      const relativeHome = runCommandExpectFailure(
+        'init',
+        relativeEnvDir,
+        { HOME: 'relative-home', XDG_CONFIG_HOME: '' }
+      );
+      assert.equal(relativeHome.failed, true);
+      assert.ok(relativeHome.output.includes('HOME must be an absolute path: relative-home'));
+      assert.equal(fs.existsSync(path.join(relativeEnvDir, 'relative-home')), false);
     });
   } finally {
     cleanup();
@@ -621,7 +652,7 @@ test('zest-dev prompt archive integration', () => {
     assert.ok(prompt.includes('zest-dev unset-active'));
     assert.equal(prompt.includes('zest-dev archive active --no-merge'), false);
 
-    runInit();
+    runInitArgs('--local');
     const deployedArchive = readCommand('.opencode', 'zest-dev-archive.md');
     assert.ok(deployedArchive.includes('zest-dev unset-active'));
     assert.equal(deployedArchive.includes('zest-dev archive active --no-merge'), false);
@@ -661,7 +692,7 @@ test('zest-dev prompt implement supports incremental phases', () => {
     assert.equal(prompt.includes('**Step 1:'), false);
     assert.equal(prompt.includes('Treat this command as a request'), false);
 
-    runInit();
+    runInitArgs('--local');
     const deployedImplement = readCommand('.opencode', 'zest-dev-implement.md');
     assert.ok(deployedImplement.includes('Run Zest Dev **Implement** phase workflow.'));
     assert.equal(deployedImplement.includes('**Step 1:'), false);


### PR DESCRIPTION
## Summary
- Make `zest-dev init` default to global OpenCode and Codex installs with scope-aware target defaults.
- Add local/global path resolution, grouped deployment metadata, and legacy Codex command prompt cleanup.
- Expand integration coverage for global, local, target-specific, invalid-option, and package install flows.

## Verification
- `pnpm test:local`
- `pnpm test:package`