### PR TITLE
Update Zest Dev design template structure

### DIFF
--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -187,33 +187,33 @@ Keep sources compact: use the smallest useful line/range, merge same-file citati
 ```markdown
 ## Design
 
-### Architecture Overview
-[diagram]
-
-Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
-
-### Change Scope
-- Area: ... Impact: ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
+### Design Summary
+- Overall design approach and rationale.
 
 ### Design Decisions
 - Decision: ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
 
-### Why this design
-- ...
+### System Structure
+[optional diagram]
 
-### Test Strategy
-- Phase/area: ... Validation: ... Source: `path/to/file:line`
+Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
 
-### Pseudocode
+### System Procedure
 Flow:
   Step A
   Step B
 
-### File Structure
-- `path/to/file` - ...
+### Interfaces / APIs
+- Optional contracts between components.
+
+### Change Scope
+- Area: ... Impact: ... Files: `path/to/file` Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
+
+### Verification Strategy
+- Phase/area: ... Validation: ... Source: `path/to/file:line`
 ```
 
-Use `### Change Scope` to describe affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, and rollout impact. Execution sequencing belongs in `## Plan`.
+`### System Structure`, `### System Procedure`, and `### Interfaces / APIs` are optional. Use `### Design Summary` to describe the overall design approach and rationale. Use `### Change Scope` to describe affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, file-level changes, and rollout impact. Execution sequencing belongs in `## Plan`.
 
 List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
 

--- a/plugin/skills/zest-dev/design.md
+++ b/plugin/skills/zest-dev/design.md
@@ -18,17 +18,17 @@ Canonical workflow for designing an active change spec.
 6. Wait for answers before finalizing the architecture when the open questions are consequential.
 7. Synthesize one recommended architecture by default, including the matching test strategy.
 8. Fill `## Design` with:
-   - Architecture Overview
-   - Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
-   - Change Scope
+   - Design Summary
    - Design Decisions
-   - Why this design
-   - Test Strategy
-   - Pseudocode
-   - File Structure
-   - Interfaces / APIs
+   - System Structure, optional
+   - Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
+   - System Procedure, optional
+   - Interfaces / APIs, optional
+   - Change Scope
    - Edge Cases
-   - Use Change Scope to describe affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, and rollout impact.
+   - Verification Strategy
+   - Use Design Summary to describe the overall design approach and rationale.
+   - Use Change Scope to describe affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, file-level changes, and rollout impact.
    - Put execution sequencing in `## Plan`.
    - List all design decisions.
    - Every design decision must cite its fact source inline or immediately adjacent to it.


### PR DESCRIPTION
## Summary
- Reorders the Zest Dev design template around Design Summary, Design Decisions, optional structure/procedure/API sections, Change Scope, Edge Cases, and Verification Strategy.
- Folds rationale into Design Summary and file-level changes into Change Scope for a more compact canonical design format.

## Verification
- Reviewed the resulting diff for the canonical skill files.