### PR TITLE
Clarify Zest Dev research inputs

### DIFF
--- a/.zest-dev/template/spec.md
+++ b/.zest-dev/template/spec.md
@@ -11,7 +11,7 @@ created: "{date}"
 
 ## Research
 
-<!-- What have we found out? What are the alternatives considered? -->
+<!-- What facts, existing patterns, references, and constraints can inform the design? -->
 
 ## Design
 

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -11,7 +11,7 @@ created: "{date}"
 
 ## Research
 
-<!-- What have we found out? What are the alternatives considered? -->
+<!-- What facts, existing patterns, references, and constraints can inform the design? -->
 
 ## Design
 

--- a/plugin/commands/draft.md
+++ b/plugin/commands/draft.md
@@ -40,7 +40,7 @@ After the spec is created and the inferred status is persisted, present next-ste
 
 **If status is `new`:**
 ```
-1. Research — Explore the codebase and identify available approaches
+1. Research — Explore the codebase and identify existing patterns and design inputs
 2. Design — Jump straight to architecture (skip research if not needed)
 3. Research then Design — Do both in sequence
 4. Stop here — I'll continue manually when ready

--- a/plugin/skills/zest-dev/SKILL.md
+++ b/plugin/skills/zest-dev/SKILL.md
@@ -169,9 +169,10 @@ Use when the design is ready for coding.
 ### Existing System
 - ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
 
-### Available Approaches
-- **Option A**: ... Source: `path/to/file:line`
-- **Option B**: ... Source: `docs/path.md#section`
+### Design Inputs
+- Existing pattern: ... Source: `path/to/file:line`
+- Reference or best practice: ... Source: `docs/path.md#section`
+- Implementation consideration: ... Source: `path/to/file:line`
 
 ### Constraints & Dependencies
 - ... Source: `path/to/file:line`
@@ -181,6 +182,7 @@ Use when the design is ready for coding.
 
 Every research finding must include a fact source from code, database artifacts, or documentation.
 Keep sources compact: use the smallest useful line/range, merge same-file citations like `src/media.ts:770-811,829,855,877-890`, and move long evidence lists to Key References.
+Do not list competing options, rank alternatives, or recommend a choice in Research; capture design raw materials for the Design phase.
 ```
 
 ### Design

--- a/plugin/skills/zest-dev/research.md
+++ b/plugin/skills/zest-dev/research.md
@@ -16,7 +16,7 @@ Canonical workflow for researching an active change spec.
 7. Read the identified files.
 8. Fill `## Research` with facts only:
    - Existing System
-   - Available Approaches
+   - Design Inputs
    - Constraints & Dependencies
    - Key References
    - Every finding must cite its fact source inline or immediately adjacent to it.
@@ -24,9 +24,10 @@ Canonical workflow for researching an active change spec.
    - Keep sources compact: cite the smallest useful evidence, usually 1 representative line or short range per finding.
    - Merge same-file citations into ranges or grouped refs: `src/media.ts:770-811,829,855,877-890`.
    - Move long evidence lists to `Key References`; keep inline `Source:` entries short.
+   - Do not list competing options, rank alternatives, or recommend a choice; capture existing patterns, reference code, docs, best practices, and implementation considerations as design raw materials.
 9. If the current status is `new`, run `zest-dev update active researched`.
 10. If this is a refresh for a later-phase spec, keep the current status and do not downgrade it.
 11. Summarize findings and point to the design phase.
 
 ## Rule
-Document what exists and what is possible, not what should be chosen.
+Document what exists and what can inform design, not competing options or what should be chosen.


### PR DESCRIPTION
## Summary
- Rename the Research template's approach-oriented section to `Design Inputs`.
- Reframe research guidance around existing patterns, references, constraints, and design raw materials instead of competing options.
- Update spec template comments and draft prompt wording to avoid pushing design decisions into Research.

## Testing
- Not run; documentation/template wording changes only.