### PR TITLE
chore(spec): clarify skill template boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository's custom command prompts are designed for **OpenCode / oh-my-ope
 - When referring to a skill in prompts or command docs, refer to it by its registered skill name (for example `Zest Dev`), not by repository or deployed file paths.
 - Keep workflow process, writing rules, and reusable content templates in skills. The main `Zest Dev` skill should describe the overall flow and route to phase files; phase files should carry concrete section-writing guidance, following progressive disclosure.
 - Keep command prompts thin. Commands should provide a simple entry prompt and route intent into the relevant skill workflow; they should not duplicate detailed process, rules, or templates.
+- Keep the CLI-created spec template thin. `lib/template/spec.md` should create top-level sections with brief placeholders only; concrete section-writing guidance belongs in the `Zest Dev` skill phase files.
 
 ### Prompt format constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ This repository's custom command prompts are designed for **OpenCode / oh-my-ope
 - For user interaction, say **ask the user directly** or **use the question tool** rather than Claude-specific names.
 - For codebase work, describe the goal (read files, search code, inspect references, run shell commands) rather than enumerating a Claude-only tool contract.
 - When referring to a skill in prompts or command docs, refer to it by its registered skill name (for example `Zest Dev`), not by repository or deployed file paths.
+- Keep workflow process, writing rules, and reusable content templates in skills. The main `Zest Dev` skill should describe the overall flow and route to phase files; phase files should carry concrete section-writing guidance, following progressive disclosure.
+- Keep command prompts thin. Commands should provide a simple entry prompt and route intent into the relevant skill workflow; they should not duplicate detailed process, rules, or templates.
 
 ### Prompt format constraints
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# Zest Dev
+
+Zest Dev is a lightweight, human-interactive workflow for AI-assisted coding. This glossary defines the project-specific language used to discuss its workflow resources and spec lifecycle.
+
+## Language
+
+**Spec**:
+A change document that records the overview, research, design, optional plan, and implementation notes for one unit of work.
+_Avoid_: ticket, task document
+
+**Spec Template**:
+The Markdown skeleton used by the CLI to create a new Spec. It defines the initial top-level sections with brief placeholders, not examples, subsection templates, or detailed writing guidance.
+_Avoid_: workflow instructions, writing rules
+
+**Skill**:
+The agent-facing workflow source for Zest Dev. The main Skill defines the overall flow and routes into phase-specific files; it does not carry concrete section templates or phase-specific writing details.
+_Avoid_: command, template
+
+**Phase File**:
+A Skill-owned file for one workflow phase, such as New, Research, Design, or Implement. It carries the concrete instructions for writing that phase's Spec content.
+_Avoid_: command, CLI template
+
+**Command**:
+A user-facing entrypoint that gives a simple prompt and routes intent into the Zest Dev Skill or a related Skill-owned workflow. It does not carry detailed process, rules, or templates.
+_Avoid_: workflow source, template, writing guide
+
+**Summarize Command**:
+A post-hoc command that captures an existing chat or pull request into a Spec. It is not part of the core Zest Dev workflow phases.
+_Avoid_: workflow phase, phase file
+
+**CLI**:
+The `zest-dev` command-line tool that manages Spec lifecycle operations such as creating, showing, activating, and updating Specs.
+_Avoid_: workflow engine, writing guide
+
+## Example Dialogue
+
+Developer: "The Spec Template should only create the empty sections."
+
+Maintainer: "Right. The main Skill routes the workflow, the Phase File explains how to fill the relevant sections, the Command only routes the request, and the CLI creates the Spec from the Spec Template."

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -19,30 +19,7 @@ created: "{date}"
 
 ## Plan
 
-<!-- Optional: Step breakdown for complex features that need multiple implementation steps.
-     Decided during Design. Checked off during Implement.
-     Keep this section compact and step-based.
-     Use markdown checkboxes for all step and substep items, for example:
-     - [ ] Step 1: Foo
-       - [ ] Substep 1.1 Implement: Foo foundation
-       - [ ] Substep 1.2 Implement: Foo integration
-       - [ ] Substep 1.3 Implement: Foo edge handling
-       - [ ] Substep 1.4 Verify: Foo automated coverage
-       - [ ] Substep 1.5 Verify: Foo manual workflow
-     - [ ] Step 2: Bar
-       - [ ] Substep 2.1 Implement: Bar
-       - [ ] Substep 2.2 Verify: Bar
-     - [ ] Step 3: Baz
-       - [ ] Substep 3.1 Implement: Baz
-       - [ ] Substep 3.2 Verify: Baz
-     Use a capability-based step breakdown with reviewable, meaningful increments.
-     Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
-     Each step must include small, independent substeps for implementation and immediate testing/verification.
-     Within each step, list implementation substeps before verification substeps.
-     The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
-     A step is complete only when relevant tests pass.
-     Size steps so one coding agent can implement + validate in a single session.
-     Write each substep as one small, independent task. -->
+<!-- Optional implementation step breakdown, decided during Design and updated during Implement. -->
 
 ## Notes
 

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -160,95 +160,15 @@ Use when the design is ready for coding.
 - Keep explicit checkpoints for confirming new requirements and moving from Design to Implement.
 - Reuse the canonical phase rules from this skill instead of embedding separate thick instructions.
 
-## Content Templates
+## Content Guidance Ownership
 
-### Research
-```markdown
-## Research
+The CLI-created spec template should stay thin: it creates top-level sections and brief placeholders only.
 
-### Existing System
-- ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
-
-### Design Inputs
-- Existing pattern: ... Source: `path/to/file:line`
-- Reference or best practice: ... Source: `docs/path.md#section`
-- Implementation consideration: ... Source: `path/to/file:line`
-
-### Constraints & Dependencies
-- ... Source: `path/to/file:line`
-
-### Key References
-- `path/to/file:line` - ...
-
-Every research finding must include a fact source from code, database artifacts, or documentation.
-Keep sources compact: use the smallest useful line/range, merge same-file citations like `src/media.ts:770-811,829,855,877-890`, and move long evidence lists to Key References.
-Do not list competing options, rank alternatives, or recommend a choice in Research; capture design raw materials for the Design phase.
-```
-
-### Design
-```markdown
-## Design
-
-### Design Summary
-- Overall design approach and rationale.
-
-### Design Decisions
-- Decision: ... Source: `path/to/file:line` / `docs/path.md#section` / `migration_name.sql`
-
-### System Structure
-[optional diagram]
-
-Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
-
-### System Procedure
-Flow:
-  Step A
-  Step B
-
-### Interfaces / APIs
-- Optional contracts between components.
-
-### Change Scope
-- Impact Areas:
-  - Area: ... Impact: ...
-- Planned File Changes:
-  - `path/to/file` - planned change
-
-### Verification Strategy
-- Phase/area: ... Validation: ... Source: `path/to/file:line`
-```
-
-`### System Structure`, `### System Procedure`, and `### Interfaces / APIs` are optional. Use `### Design Summary` to describe the overall design approach and rationale. Use `### Change Scope` as a two-part section: `Impact Areas` for high-level affected areas and `Planned File Changes` for concrete files/directories to modify. Do not include `Source:` citations inside Change Scope items. Execution sequencing belongs in `## Plan`.
-
-List all meaningful design decisions and attach a fact source to each one. Reuse `## Research` sources when possible, and add new factual sources when needed.
-
-If `## Plan` is used, keep it compact and step-based with markdown checkboxes. Example:
-- [ ] Step 1: Foo
-  - [ ] Substep 1.1 Implement: Foo foundation
-  - [ ] Substep 1.2 Implement: Foo integration
-  - [ ] Substep 1.3 Implement: Foo edge handling
-  - [ ] Substep 1.4 Verify: Foo automated coverage
-  - [ ] Substep 1.5 Verify: Foo manual workflow
-- [ ] Step 2: Bar
-  - [ ] Substep 2.1 Implement: Bar
-  - [ ] Substep 2.2 Verify: Bar
-- [ ] Step 3: Baz
-  - [ ] Substep 3.1 Implement: Baz
-  - [ ] Substep 3.2 Verify: Baz
-
-Use a capability-based breakdown with meaningful, easy-to-review increments. Good step boundaries usually align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone. Each step must include small, independent substeps for implementation and immediate testing/verification. Within each step, list implementation substeps before verification substeps. The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements. A step is complete only when its relevant tests pass. Size each step for one coding-agent session, and write each substep as one small, independent task.
-
-### Notes
-```markdown
-## Notes
-
-### Implementation
-- `path/to/file` - what changed
-
-### Verification
-- Tests run and results
-- Manual validation and outcomes
-```
+Concrete section-writing guidance lives in the phase files:
+- `new.md` defines how to write `## Overview`.
+- `research.md` defines how to write `## Research`.
+- `design.md` defines how to write `## Design` and optional `## Plan`.
+- `implement.md` defines how to update `## Plan` and write `## Notes`.
 
 ## Guardrails
 

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -162,8 +162,6 @@ Use when the design is ready for coding.
 
 ## Content Guidance Ownership
 
-The CLI-created spec template should stay thin: it creates top-level sections and brief placeholders only.
-
 Concrete section-writing guidance lives in the phase files:
 - `new.md` defines how to write `## Overview`.
 - `research.md` defines how to write `## Research`.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -474,11 +474,16 @@ test('zest-dev create integration', async (t) => {
       assert.equal(frontmatter.status, 'new');
       assert.equal(typeof frontmatter.created, 'string');
       assert.ok(content.includes('## Overview'), 'should use packaged default template');
+      assert.ok(content.includes('## Research'), 'should include Research section');
+      assert.ok(content.includes('## Design'), 'should include Design section');
+      assert.ok(content.includes('## Plan'), 'should include Plan section');
+      assert.ok(content.includes('## Notes'), 'should include Notes section');
       assert.ok(
-        content.includes('Use markdown checkboxes for all step and substep items'),
-        'packaged default template should include step and substep checkbox guidance'
+        content.includes('Optional implementation step breakdown, decided during Design and updated during Implement.'),
+        'packaged default template should keep Plan guidance brief'
       );
-      assert.ok(content.includes('Substep 1.1 Implement'), 'packaged default template should include substep example');
+      assert.equal(content.includes('Use markdown checkboxes for all step and substep items'), false);
+      assert.equal(content.includes('Substep 1.1 Implement'), false);
       assert.ok(content.includes('### Implementation'), 'packaged default template should include Implementation notes section');
       assert.ok(content.includes('### Verification'), 'packaged default template should include Verification notes section');
       assert.equal(content.includes('Phase 3: Test and verify'), false);


### PR DESCRIPTION
## Summary

- keep the CLI-created spec template thin by replacing the long Plan checklist guidance with a brief placeholder
- move concrete content guidance ownership out of the main Zest Dev skill and into phase files
- document the skill/template/command terminology and prompt-authoring principles
- update integration tests so the packaged default template stays thin

Closes #54.

## Validation

- `pnpm test:local`
- `pnpm test:package` was started, but the package setup phase hung during packaged CLI installation and was interrupted; the temporary test environment was cleaned up.