### PR TITLE
feat(workflow): add plan phase

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,14 @@ _Avoid_: workflow source, template, writing guide
 A post-hoc command that captures an existing chat or pull request into a Spec. It is not part of the core Zest Dev workflow phases.
 _Avoid_: workflow phase, phase file
 
+**Plan Phase**:
+A core workflow phase that turns an approved Design into the Spec's Plan section. It does not produce Design content.
+_Avoid_: design step, planning note
+
+**Planned Status**:
+A Spec lifecycle milestone meaning the Spec's Design and Plan sections are ready for implementation.
+_Avoid_: designed, ready
+
 **CLI**:
 The `zest-dev` command-line tool that manages Spec lifecycle operations such as creating, showing, activating, and updating Specs.
 _Avoid_: workflow engine, writing guide
@@ -37,3 +45,11 @@ _Avoid_: workflow engine, writing guide
 Developer: "The Spec Template should only create the empty sections."
 
 Maintainer: "Right. The main Skill routes the workflow, the Phase File explains how to fill the relevant sections, the Command only routes the request, and the CLI creates the Spec from the Spec Template."
+
+Developer: "Should the Design Phase also write the implementation checklist?"
+
+Maintainer: "No. The Design Phase records decisions and trade-offs; the Plan Phase turns that Design into a checklist."
+
+Developer: "When is a Spec ready for implementation?"
+
+Maintainer: "When it reaches Planned Status: the Design is decided, and the Plan checklist is ready to execute."

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ Work through a feature spec one phase at a time, with human review between each 
 /zest-dev:new "My new feature"   # Create a spec and set it as active
 /zest-dev:research              # Research requirements and explore the codebase
 /zest-dev:design                # Clarify requirements and design the architecture
-/zest-dev:implement             # Build the feature following the design
+/zest-dev:plan                  # Create the implementation plan
+/zest-dev:implement             # Build the feature following the plan
 /zest-dev:archive               # Agent-guided merge into specs/current, then unset active
 ```
 
-Each command routes into the main Zest Dev skill, which advances the spec through `new → researched → designed → implemented`.
+Each command routes into the main Zest Dev skill, which advances the spec through `new → researched → designed → planned → implemented`.
 
 ### Quick Implementation
 
@@ -95,7 +96,7 @@ Archive is intentionally **not** a public CLI subcommand. Use `/zest-dev:archive
 
 ### Status Transitions
 
-Valid status values: `new`, `researched`, `designed`, `implemented`
+Valid status values: `new`, `researched`, `designed`, `planned`, `implemented`
 
 - Forward-only transitions (skipping is allowed): e.g. `new → designed` is valid
 - Backward transitions fail: e.g. `implemented → designed`
@@ -109,6 +110,7 @@ For editors that don't support project-level commands, use `zest-dev prompt` to 
 codex "$(zest-dev prompt new 'some description')"
 codex "$(zest-dev prompt research)"
 codex "$(zest-dev prompt design)"
+codex "$(zest-dev prompt plan)"
 codex "$(zest-dev prompt implement)"
 codex "$(zest-dev prompt archive)"
 codex "$(zest-dev prompt draft)"

--- a/commands/draft.md
+++ b/commands/draft.md
@@ -15,4 +15,6 @@ If the highest reached status is `researched`, run `zest-dev update active resea
 
 If the highest reached status is `designed`, run `zest-dev update active designed`.
 
-If the spec is already `designed`, guide the user to `/implement` as the next explicit step.
+If the highest reached status is `planned`, run `zest-dev update active planned`.
+
+If the spec is already `planned`, guide the user to `/implement` as the next explicit step.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,5 +1,5 @@
 ---
-description: Build feature following the design
+description: Build feature following the plan
 argument-hint: [optional implementation scope or phase hint]
 ---
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,0 +1,12 @@
+---
+description: Create an implementation plan from the design
+argument-hint: [optional planning focus or constraints]
+---
+
+# Plan: Create Implementation Plan
+
+Run Zest Dev **Plan** phase workflow.
+
+**Language rule:** Respond in the user's language by default, if user's language is not English.
+
+**Arguments:** $ARGUMENTS

--- a/commands/quick-implement.md
+++ b/commands/quick-implement.md
@@ -57,19 +57,25 @@ Enter the Zest Dev skill's **Design** phase and let it run the canonical design 
 
 ---
 
-## Checkpoint 2: Approve implementation
+## Stage 3: Plan
 
-After design is ready, present a brief summary and get explicit approval before entering the Implement phase.
+Enter the Zest Dev skill's **Plan** phase and let it run the canonical plan workflow.
 
 ---
 
-## Stage 3: Implement
+## Checkpoint 2: Approve implementation
+
+After the plan is ready, present a brief summary and get explicit approval before entering the Implement phase.
+
+---
+
+## Stage 4: Implement
 
 Enter the Zest Dev skill's **Implement** phase and let it run the canonical implementation workflow.
 
 ---
 
-## Stage 4: Final review
+## Stage 5: Final review
 
 After implementation, review the result, address critical issues, and confirm what status the spec reached.
 

--- a/commands/summarize-chat.md
+++ b/commands/summarize-chat.md
@@ -29,15 +29,17 @@ Based on the conversation, determine the spec status:
 - **"new"**: Only discussed the problem and goals, no exploration yet
 - **"researched"**: Explored codebase, evaluated options, identified approach
 - **"designed"**: Clarified requirements, designed architecture with trade-offs
+- **"planned"**: Created an implementation checklist from the design
 - **"implemented"**: Actually wrote code, tested it, and reviewed quality
 
 **If status is vague or unclear**, use the question tool to ask:
 - "What status should this spec be in?"
-- Options: new, researched, designed, implemented
+- Options: new, researched, designed, planned, implemented
 - Provide brief description:
   - **new**: Problem identified, no exploration
   - **researched**: Codebase explored, options evaluated
   - **designed**: Architecture designed, approach chosen
+  - **planned**: Implementation checklist created
   - **implemented**: Code written, tested, reviewed
 
 **Step 3: Create Spec via CLI**
@@ -75,7 +77,14 @@ Fill sections based on the status:
 - Follow the canonical Design rules from the Zest Dev skill
 - List all meaningful design decisions and attach fact sources
 - Include the matching test strategy alongside the implementation design
-- If a `## Plan` step breakdown is added, use capability-based steps that deliver meaningful, reviewable increments; each step must include small, independent substeps for implementation and immediate verification; list implementation substeps before verification substeps; the final step may focus on overall testing/verification and coverage improvements; each step is complete only when relevant tests pass
+
+**If status is "planned" or later - Fill Plan section:**
+- Follow the canonical Plan rules from the Zest Dev skill
+- Use capability-based steps that deliver meaningful, reviewable increments
+- Each step must include small, independent substeps for implementation and immediate verification
+- List implementation substeps before verification substeps
+- The final step may focus on overall testing/verification and coverage improvements
+- Each step is complete only when relevant tests pass
 
 **If status is "implemented" - Fill Notes section:**
 - `### Implementation`: What was built, files changed, and design deviations
@@ -88,6 +97,7 @@ Use `zest-dev update` for status transitions (do not edit frontmatter manually):
 - If inferred status is `new`: skip status update (new spec is already `new`)
 - If inferred status is `researched`: execute `zest-dev update active researched`
 - If inferred status is `designed`: execute `zest-dev update active designed`
+- If inferred status is `planned`: execute `zest-dev update active planned`
 - If inferred status is `implemented`: execute `zest-dev update active implemented`
 
 **Step 6: Add Notes Section**

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -8,12 +8,13 @@ const ACTIVE_CHANGE_LINK = path.join(SPECS_DIR, 'active');
 const LEGACY_CURRENT_LINK = path.join(SPECS_DIR, 'current');
 const TEMPLATE_PATH = '.zest-dev/template/spec.md';
 const DEFAULT_TEMPLATE_PATH = path.join(__dirname, 'template', 'spec.md');
-const VALID_STATUSES = ['new', 'researched', 'designed', 'implemented'];
+const VALID_STATUSES = ['new', 'researched', 'designed', 'planned', 'implemented'];
 const STATUS_ORDER = {
   new: 0,
   researched: 1,
   designed: 2,
-  implemented: 3
+  planned: 3,
+  implemented: 4
 };
 
 function pathExistsIncludingDanglingSymlink(filePath) {

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -19,7 +19,7 @@ created: "{date}"
 
 ## Plan
 
-<!-- Optional implementation step breakdown, decided during Design and updated during Implement. -->
+<!-- Optional implementation step breakdown, created during Plan and updated during Implement. -->
 
 ## Notes
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -5,17 +5,17 @@ description: "Use ONLY when the user explicitly asks to brainstorm, use brainsto
 
 # Brainstorming Ideas Into Designs
 
-Help turn ideas into Zest Dev specs through natural collaborative dialogue, covering the equivalent of Zest Dev's new, research, and design phases.
+Help turn ideas into Zest Dev specs through natural collaborative dialogue, covering the equivalent of Zest Dev's new, research, design, and plan phases.
 
-Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval, then capture the result in a Zest Dev change spec advanced to `designed`.
+Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and plan for user approval, then capture the result in a Zest Dev change spec advanced to `planned`.
 
 <HARD-GATE>
-When this skill is active, do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY brainstorming session regardless of perceived simplicity.
+When this skill is active, do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and plan and the user has approved them. This applies to EVERY brainstorming session regardless of perceived simplicity.
 </HARD-GATE>
 
 ## Anti-Pattern: "This Is Too Simple To Need A Design"
 
-Every active brainstorming session goes through this process. A todo list, a single-function utility, a config change — all of them can still hide assumptions when the user has explicitly asked to brainstorm. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+Every active brainstorming session goes through this process. A todo list, a single-function utility, a config change — all of them can still hide assumptions when the user has explicitly asked to brainstorm. The design and plan can be short (a few sentences for truly simple projects), but you MUST present them and get approval.
 
 ## Checklist
 
@@ -25,10 +25,10 @@ You MUST create a task for each of these items and complete them in order:
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
+5. **Present design and plan** — in sections scaled to their complexity, get user approval after each section
 6. **Write Zest Dev spec** — use the `zest-dev` CLI to create or update a change spec in the standard Zest Dev spec location; when creating a new spec, immediately set it active with `zest-dev set-active <spec-id>`; write Overview, Research, Design, and Plan content
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **Mark designed** — check the current spec status and use the `zest-dev` CLI to advance it to `designed` only when needed
+8. **Mark planned** — check the current spec status and use the `zest-dev` CLI to advance it to `planned` only when needed
 
 ## Process Flow
 
@@ -39,27 +39,27 @@ digraph brainstorming {
     "Offer Visual Companion\n(own message, no other content)" [shape=box];
     "Ask clarifying questions" [shape=box];
     "Propose 2-3 approaches" [shape=box];
-    "Present design sections" [shape=box];
-    "User approves design?" [shape=diamond];
+    "Present design and plan sections" [shape=box];
+    "User approves design and plan?" [shape=diamond];
     "Write Zest Dev spec" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
-    "Update Zest Dev spec to designed" [shape=doublecircle];
+    "Update Zest Dev spec to planned" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
     "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
     "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
     "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
     "Ask clarifying questions" -> "Propose 2-3 approaches";
-    "Propose 2-3 approaches" -> "Present design sections";
-    "Present design sections" -> "User approves design?";
-    "User approves design?" -> "Present design sections" [label="no, revise"];
-    "User approves design?" -> "Write Zest Dev spec" [label="yes"];
+    "Propose 2-3 approaches" -> "Present design and plan sections";
+    "Present design and plan sections" -> "User approves design and plan?";
+    "User approves design and plan?" -> "Present design and plan sections" [label="no, revise"];
+    "User approves design and plan?" -> "Write Zest Dev spec" [label="yes"];
     "Write Zest Dev spec" -> "Spec self-review\n(fix inline)";
-    "Spec self-review\n(fix inline)" -> "Update Zest Dev spec to designed";
+    "Spec self-review\n(fix inline)" -> "Update Zest Dev spec to planned";
 }
 ```
 
-**The terminal state is the active Zest Dev change spec at `designed`.** Do NOT invoke implementation skills, write implementation code, or start implementation work as part of this skill.
+**The terminal state is the active Zest Dev change spec at `planned`.** Do NOT invoke implementation skills, write implementation code, or start implementation work as part of this skill.
 
 ## The Process
 
@@ -123,8 +123,8 @@ Fix any issues inline. No need to re-review — just fix and move on.
 
 - Check the current spec status first.
 - Confirm the spec is active; if not, run `zest-dev set-active <spec-id>` before updating status.
-- If the spec is not already `designed`, use the `zest-dev` CLI to update it to `designed`.
-- If the spec is already `designed`, skip the status update and finish the skill cleanly.
+- If the spec is not already `planned`, use the `zest-dev` CLI to update it to `planned`.
+- If the spec is already `planned`, skip the status update and finish the skill cleanly.
 - Do NOT invoke any implementation skill or start implementation work.
 
 ## Key Principles

--- a/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -2,7 +2,7 @@
 
 Use this template when dispatching a spec document reviewer subagent.
 
-**Purpose:** Verify the spec is complete, consistent, and ready to mark `designed`.
+**Purpose:** Verify the spec is complete, consistent, and ready to mark `planned`.
 
 **Dispatch after:** Zest Dev change spec content is written in the standard `specs/change/` location.
 
@@ -10,7 +10,7 @@ Use this template when dispatching a spec document reviewer subagent.
 Task tool (general-purpose):
   description: "Review spec document"
   prompt: |
-    You are a spec document reviewer. Verify this spec is complete and ready to mark `designed`.
+    You are a spec document reviewer. Verify this spec is complete and ready to mark `planned`.
 
     **Spec to review:** [SPEC_FILE_PATH]
 
@@ -26,7 +26,7 @@ Task tool (general-purpose):
 
     ## Calibration
 
-    **Only flag issues that would cause real problems when marking the spec designed or later implementing it.**
+    **Only flag issues that would cause real problems when marking the spec planned or later implementing it.**
     A missing section, a contradiction, or a requirement so ambiguous it could be
     interpreted two different ways — those are issues. Minor wording improvements,
     stylistic preferences, and "sections less detailed than others" are not.

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -14,6 +14,7 @@ This skill is the **canonical workflow source** for planned feature work:
 - `new`
 - `research`
 - `design`
+- `plan`
 - `implement`
 
 Commands should stay thin. They exist as explicit entrypoints and compatibility shims. The actual phase logic lives here.
@@ -22,6 +23,7 @@ To keep this file concise, the detailed workflows live in sibling phase docs:
 - `new.md`
 - `research.md`
 - `design.md`
+- `plan.md`
 - `implement.md`
 
 **Core principle:** keep workflow intelligence in the skill, keep commands lightweight.
@@ -31,7 +33,7 @@ To keep this file concise, the detailed workflows live in sibling phase docs:
 Use this skill when the user:
 - asks to create a spec or write a spec
 - mentions Zest Dev or spec-driven development
-- asks to enter a workflow phase such as new, research, design, or implement
+- asks to enter a workflow phase such as new, research, design, plan, or implement
 - wants to continue an active change spec
 - uses a thin command that explicitly routes into this skill
 
@@ -41,7 +43,7 @@ Use this skill when the user:
 - Always respond in the user's language unless the user asks to switch languages.
 
 ### Source of truth
-- Treat this skill as the workflow source for the four core phases.
+- Treat this skill as the workflow source for the five core phases.
 - Treat commands as wrappers that declare intent and hand off to this skill.
 
 ### CLI boundaries
@@ -52,6 +54,7 @@ Use this skill when the user:
   - `new`
   - `researched`
   - `designed`
+  - `planned`
   - `implemented`
 
 ### Spec writing principles
@@ -68,7 +71,7 @@ Use this skill when the user:
 
 ### Questions and approvals
 - Ask targeted clarifying questions when requirements or architecture are underspecified.
-- During quick-implement, get explicit user approval when transitioning from Design to Implement.
+- During quick-implement, get explicit user approval when transitioning from Plan to Implement.
 - If the user says “whatever you think is best,” provide your recommendation and get confirmation when the choice is consequential.
 
 ## Entry Modes
@@ -79,6 +82,7 @@ Examples:
 - `/zest-dev:new`
 - `/zest-dev:research`
 - `/zest-dev:design`
+- `/zest-dev:plan`
 - `/zest-dev:implement`
 
 Interpret the command as a request to run the corresponding phase in this skill.
@@ -89,6 +93,7 @@ Examples:
 - “create a spec for this”
 - “research this change”
 - “design the architecture”
+- “plan the implementation”
 - “implement the active spec”
 
 Infer the intended phase from user intent and current spec status.
@@ -112,7 +117,7 @@ User intent or thin command
 Valid progression:
 
 ```text
-new → researched → designed → implemented
+new → researched → designed → planned → implemented
 ```
 
 ## Phase Routing
@@ -124,10 +129,13 @@ Use when there is no spec yet and the user wants to formalize a requirement.
 Use when a spec exists and the team needs repository facts, patterns, and options.
 
 ### Design phase
-Use when research or direct understanding is sufficient to make an implementation plan.
+Use when research or direct understanding is sufficient to choose an implementation design.
+
+### Plan phase
+Use when the design is ready to turn into an implementation checklist.
 
 ### Implement phase
-Use when the design is ready for coding.
+Use when the plan is ready for coding.
 
 ## Canonical Phase Workflow Files
 
@@ -141,7 +149,11 @@ Use when the design is ready for coding.
 
 ### Design
 - The canonical Design workflow lives in `design.md`.
-- Use it for clarifications, architecture synthesis, plan shaping, and status advancement to `designed`.
+- Use it for clarifications, architecture synthesis, design decisions, and status advancement to `designed`.
+
+### Plan
+- The canonical Plan workflow lives in `plan.md`.
+- Use it for implementation checklist shaping and status advancement to `planned`.
 
 ### Implement
 - The canonical Implement workflow lives in `implement.md`.
@@ -157,7 +169,7 @@ Use when the design is ready for coding.
 ### Quick Implement
 - Create or resume the active spec.
 - Run the remaining core phases in order.
-- Keep explicit checkpoints for confirming new requirements and moving from Design to Implement.
+- Keep explicit checkpoints for confirming new requirements and moving from Plan to Implement.
 - Reuse the canonical phase rules from this skill instead of embedding separate thick instructions.
 
 ## Content Guidance Ownership
@@ -165,7 +177,8 @@ Use when the design is ready for coding.
 Concrete section-writing guidance lives in the phase files:
 - `new.md` defines how to write `## Overview`.
 - `research.md` defines how to write `## Research`.
-- `design.md` defines how to write `## Design` and optional `## Plan`.
+- `design.md` defines how to write `## Design`.
+- `plan.md` defines how to write `## Plan`.
 - `implement.md` defines how to update `## Plan` and write `## Notes`.
 
 ## Guardrails

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -3,7 +3,7 @@
 Canonical workflow for designing an active change spec.
 
 ## When to use
-- Research or direct understanding is sufficient to form an implementation plan
+- Research or direct understanding is sufficient to choose an implementation design
 - A thin `design` command routes here
 
 ## Workflow
@@ -12,7 +12,7 @@ Canonical workflow for designing an active change spec.
 3. Check status gating before proceeding:
    - If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
    - If the status is `researched`, continue.
-   - If the status is `designed` or `implemented`, confirm that the user wants to revise the existing design before continuing.
+   - If the status is `designed`, `planned`, or `implemented`, confirm that the user wants to revise the existing design before continuing.
 4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
 5. Ask the user clarifying questions when needed.
 6. Wait for answers before finalizing the architecture when the open questions are consequential.
@@ -32,38 +32,13 @@ Canonical workflow for designing an active change spec.
      - Impact Areas: high-level affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, and rollout impact.
      - Planned File Changes: concrete files or directories expected to change, plus a brief note about each planned modification.
    - Do not add `Source:` citations inside Change Scope items.
-   - Put execution sequencing in `## Plan`.
+   - Put execution sequencing in `## Plan` during the Plan phase.
    - List all design decisions.
    - Every design decision must cite its fact source inline or immediately adjacent to it.
    - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
-9. Fill `## Plan` only when implementation should be split into steps.
-   - Use a capability-based step breakdown.
-   - Keep the plan compact and step-based.
-   - Use markdown checkboxes for every step and substep.
-   - Format as a short checklist, for example:
-      - [ ] Step 1: Foo
-        - [ ] Substep 1.1 Implement: Foo foundation
-        - [ ] Substep 1.2 Implement: Foo integration
-        - [ ] Substep 1.3 Implement: Foo edge handling
-        - [ ] Substep 1.4 Verify: Foo automated coverage
-        - [ ] Substep 1.5 Verify: Foo manual workflow
-      - [ ] Step 2: Bar
-        - [ ] Substep 2.1 Implement: Bar
-        - [ ] Substep 2.2 Verify: Bar
-      - [ ] Step 3: Baz
-        - [ ] Substep 3.1 Implement: Baz
-        - [ ] Substep 3.2 Verify: Baz
-   - Prefer steps that each deliver one meaningful increment and remain easy to review.
-   - Good step boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
-   - Each step must include small, independent substeps for implementation work and immediate testing/verification.
-   - Within each step, list implementation substeps before verification substeps.
-   - The final step may focus on overall testing/verification, edge-case validation, regression coverage, and test coverage improvements.
-   - A step is complete only when its relevant tests pass.
-   - Size each step so a coding agent can implement and validate it within a single session.
-   - Write each substep as one small, independent task.
-10. Run `zest-dev update active designed`.
-11. Present the design and stop.
+9. Run `zest-dev update active designed`.
+10. Present the design and stop.
 
 ## Rule
 This is where decisions, trade-offs, and recommendations belong.

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -3,15 +3,15 @@
 Canonical workflow for implementing an active change spec.
 
 ## When to use
-- The design is ready for coding
+- The plan is ready for coding
 - A thin `implement` command routes here
 
 ## Workflow
-1. Run `zest-dev status` and verify an active change spec exists with status `designed`.
+1. Run `zest-dev status` and verify an active change spec exists with status `planned`.
 2. Run `zest-dev show active` and read the full spec.
 3. Read all relevant implementation files before coding.
 4. Create a task list.
-5. Implement the feature following the design and repository conventions.
+5. Implement the feature following the plan, design, and repository conventions.
 6. Write or update tests alongside the implementation, not afterward.
 7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
 8. After each completed plan step or substep, mark the corresponding `## Plan` checkbox as `[x]` only when that item is complete and relevant tests pass.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -39,7 +39,10 @@ Canonical workflow for planning implementation of an active change spec.
       - [ ] Step 3: Baz
         - [ ] Substep 3.1 Implement: Baz
         - [ ] Substep 3.2 Verify: Baz
-8. Run `zest-dev update active planned`.
+8. Update status based on the starting state:
+   - If the spec started as `designed`, run `zest-dev update active planned`.
+   - If the spec started as `planned`, skip the update and keep the status as-is.
+   - If the spec started as `implemented`, skip the update and keep the status as-is while revising the plan.
 9. Present the plan and stop.
 
 ## Rule

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -1,0 +1,46 @@
+# Zest Dev Phase: Plan
+
+Canonical workflow for planning implementation of an active change spec.
+
+## When to use
+- The design is ready to turn into an implementation checklist
+- A thin `plan` command routes here
+
+## Workflow
+1. Run `zest-dev status` and verify an active change spec exists.
+2. Run `zest-dev show active` and read the spec file.
+3. Check status before proceeding:
+   - If the status is `new` or `researched`, suggest design first unless the implementation approach is already sufficiently decided.
+   - If the status is `designed`, continue.
+   - If the status is `planned` or `implemented`, confirm that the user wants to revise the existing plan before continuing.
+4. Identify implementation increments, immediate verification points, edge-case validation, and any dependencies between steps.
+5. Ask the user clarifying questions when needed.
+6. Wait for answers before finalizing the plan when the open questions are consequential.
+7. Fill `## Plan` with a compact capability-based checklist:
+   - Use markdown checkboxes for every step and substep.
+   - Prefer steps that each deliver one meaningful increment and remain easy to review.
+   - Good step boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
+   - Each step must include small, independent substeps for implementation work and immediate testing/verification.
+   - Within each step, list implementation substeps before verification substeps.
+   - The final step may focus on overall testing/verification, edge-case validation, regression coverage, and test coverage improvements.
+   - A step is complete only when its relevant tests pass.
+   - Size each step so a coding agent can implement and validate it within a single session.
+   - Write each substep as one small, independent task.
+   - Format as a short checklist, for example:
+      - [ ] Step 1: Foo
+        - [ ] Substep 1.1 Implement: Foo foundation
+        - [ ] Substep 1.2 Implement: Foo integration
+        - [ ] Substep 1.3 Implement: Foo edge handling
+        - [ ] Substep 1.4 Verify: Foo automated coverage
+        - [ ] Substep 1.5 Verify: Foo manual workflow
+      - [ ] Step 2: Bar
+        - [ ] Substep 2.1 Implement: Bar
+        - [ ] Substep 2.2 Verify: Bar
+      - [ ] Step 3: Baz
+        - [ ] Substep 3.1 Implement: Baz
+        - [ ] Substep 3.2 Verify: Baz
+8. Run `zest-dev update active planned`.
+9. Present the plan and stop.
+
+## Rule
+This is where implementation sequencing and verification checkpoints belong.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -27,6 +27,7 @@ const EXPECTED_COMMANDS = [
   'zest-dev-draft.md',
   'zest-dev-implement.md',
   'zest-dev-new.md',
+  'zest-dev-plan.md',
   'zest-dev-quick-implement.md',
   'zest-dev-research.md',
   'zest-dev-summarize-chat.md',
@@ -36,11 +37,12 @@ const THIN_COMMANDS = [
   'zest-dev-new.md',
   'zest-dev-research.md',
   'zest-dev-design.md',
+  'zest-dev-plan.md',
   'zest-dev-implement.md',
   'zest-dev-draft.md',
   'zest-dev-quick-implement.md'
 ];
-const SKILL_PHASE_FILES = ['new.md', 'research.md', 'design.md', 'implement.md'];
+const SKILL_PHASE_FILES = ['new.md', 'research.md', 'design.md', 'plan.md', 'implement.md'];
 const CODEX_SUBAGENTS = ['code-architect.toml', 'code-explorer.toml', 'code-reviewer.toml'];
 const LANGUAGE_ALIGNMENT_RULES = [
   'Respond in the user\'s language by default, if user\'s language is not English.',
@@ -237,7 +239,7 @@ test('zest-dev init integration', async (t) => {
       assert.equal(frontmatter['allowed-tools'], undefined);
       assert.equal(Object.keys(frontmatter).length, 1);
 
-      for (const file of ['zest-dev-new.md', 'zest-dev-research.md', 'zest-dev-design.md', 'zest-dev-implement.md']) {
+      for (const file of ['zest-dev-new.md', 'zest-dev-research.md', 'zest-dev-design.md', 'zest-dev-plan.md', 'zest-dev-implement.md']) {
         const body = fs.readFileSync(path.join(globalOpenCodeCommandsDir, file), 'utf-8');
         assert.ok(body.includes('$ARGUMENTS'));
       }
@@ -263,7 +265,10 @@ test('zest-dev init integration', async (t) => {
       assert.ok(researchPhase.includes('Summarize your understanding of the request and confirm it with the user'));
 
       const designPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/design.md'), 'utf-8');
-      assert.ok(designPhase.includes('If the status is `designed` or `implemented`, confirm that the user wants to revise the existing design before continuing.'));
+      assert.ok(designPhase.includes('If the status is `designed`, `planned`, or `implemented`, confirm that the user wants to revise the existing design before continuing.'));
+
+      const planPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/plan.md'), 'utf-8');
+      assert.ok(planPhase.includes('Run `zest-dev update active planned`.'));
 
       const codexSkillFile = fs.readFileSync(path.join(globalCodexSkillsDir, 'SKILL.md'), 'utf-8');
       assert.ok(codexSkillFile.includes('This skill is the **canonical workflow source**'));
@@ -479,7 +484,7 @@ test('zest-dev create integration', async (t) => {
       assert.ok(content.includes('## Plan'), 'should include Plan section');
       assert.ok(content.includes('## Notes'), 'should include Notes section');
       assert.ok(
-        content.includes('Optional implementation step breakdown, decided during Design and updated during Implement.'),
+        content.includes('Optional implementation step breakdown, created during Plan and updated during Implement.'),
         'packaged default template should keep Plan guidance brief'
       );
       assert.equal(content.includes('Use markdown checkboxes for all step and substep items'), false);
@@ -709,8 +714,8 @@ test('zest-dev update integration', async (t) => {
 
     await t.test('fails on invalid target status', () => {
       assert.throws(
-        () => runUpdate(firstSpecId, 'planned'),
-        /Invalid status "planned"\. Valid: new, researched, designed, implemented/
+        () => runUpdate(firstSpecId, 'ready'),
+        /Invalid status "ready"\. Valid: new, researched, designed, planned, implemented/
       );
     });
 
@@ -724,6 +729,20 @@ test('zest-dev update integration', async (t) => {
       assert.equal(updateActive.ok, true);
       assert.equal(updateActive.spec.id, aliasSpecId);
       assert.equal(updateActive.spec.status, 'implemented');
+    });
+
+    await t.test('allows planned status before implemented', () => {
+      const plannedSpecId = yaml.load(runCreate('planned-spec')).spec.id;
+      const plannedResult = yaml.load(runUpdate(plannedSpecId, 'planned'));
+      assert.equal(plannedResult.ok, true);
+      assert.equal(plannedResult.spec.status, 'planned');
+      assert.equal(plannedResult.status.from, 'new');
+      assert.equal(plannedResult.status.to, 'planned');
+
+      const implementedResult = yaml.load(runUpdate(plannedSpecId, 'implemented'));
+      assert.equal(implementedResult.ok, true);
+      assert.equal(implementedResult.status.from, 'planned');
+      assert.equal(implementedResult.status.to, 'implemented');
     });
   } finally {
     cleanup();
@@ -757,11 +776,15 @@ test('zest-dev prompt supports actual command set and summarize alias', () => {
     assert.ok(quickPrompt.includes('Thin bridge entrypoint'));
     assert.ok(quickPrompt.includes('test feature'));
 
+    const planPrompt = runCommand('prompt plan');
+    assert.ok(planPrompt.includes('Run Zest Dev **Plan** phase workflow.'));
+
     const draftPrompt = runCommand('prompt draft');
     assert.ok(draftPrompt.includes('Bridge entrypoint into the Zest Dev skill.'));
     assert.ok(draftPrompt.includes('guide the user to `/implement` as the next explicit step'));
     assert.ok(draftPrompt.includes('run `zest-dev update active researched`'));
     assert.ok(draftPrompt.includes('run `zest-dev update active designed`'));
+    assert.ok(draftPrompt.includes('run `zest-dev update active planned`'));
 
     const summarizeAliasPrompt = runCommand('prompt summarize');
     const summarizeChatPrompt = runCommand('prompt summarize-chat');

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -268,7 +268,7 @@ test('zest-dev init integration', async (t) => {
       assert.ok(designPhase.includes('If the status is `designed`, `planned`, or `implemented`, confirm that the user wants to revise the existing design before continuing.'));
 
       const planPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/plan.md'), 'utf-8');
-      assert.ok(planPhase.includes('Run `zest-dev update active planned`.'));
+      assert.ok(planPhase.includes('If the spec started as `designed`, run `zest-dev update active planned`.'));
 
       const codexSkillFile = fs.readFileSync(path.join(globalCodexSkillsDir, 'SKILL.md'), 'utf-8');
       assert.ok(codexSkillFile.includes('This skill is the **canonical workflow source**'));


### PR DESCRIPTION
## Summary

- Add `planned` as a forward-only CLI status between `designed` and `implemented`
- Add the thin `/zest-dev:plan` command and canonical `skills/zest-dev/plan.md` phase workflow
- Move Plan checklist guidance out of Design and update Implement to require `planned`
- Update bridge commands, brainstorming guidance, README, template text, glossary, and integration tests

## Verification

- `pnpm test:local`
- `pnpm test:package`

Closes #55