### PR TITLE
docs: add methodology references to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ Create a custom spec template at `.zest-dev/template/spec.md`.
 ## References
 
 - [OpenSpec](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md) - Inspired by its current-spec methodology, where specs act as the source of truth for how a system currently behaves and changes are managed separately until they are merged back.
-- [Matt Pocock Skills: `tdd`](https://github.com/mattpocock/skills/tree/main/skills/tdd) - References its test-driven development methodology built around a red-green-refactor loop and small vertical slices.
+- [Matt Pocock Skills: `tdd`](https://github.com/mattpocock/skills/tree/main/skills/engineering/tdd) - References its test-driven development methodology built around a red-green-refactor loop and small vertical slices.

--- a/README.md
+++ b/README.md
@@ -150,3 +150,8 @@ project/
 ```
 
 Create a custom spec template at `.zest-dev/template/spec.md`.
+
+## References
+
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md) - Inspired by its current-spec methodology, where specs act as the source of truth for how a system currently behaves and changes are managed separately until they are merged back.
+- [Matt Pocock Skills: `tdd`](https://github.com/mattpocock/skills/tree/main/skills/tdd) - References its test-driven development methodology built around a red-green-refactor loop and small vertical slices.


### PR DESCRIPTION
## Summary
- add a new References section to the README
- link OpenSpec and note its CurrentSpec methodology as an influence
- link Matt Pocock Skills and note its TDD methodology as an influence

## Why
- document the upstream methodologies that shaped Zest Dev
- give readers direct links for the concepts mentioned in the project

## Validation
- npm test

Closes #59

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>