### PR TITLE
feat(plan): use issue-scale step planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,5 @@ Create a custom spec template at `.zest-dev/template/spec.md`.
 ## References
 
 - [OpenSpec](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md) - Inspired by its current-spec methodology, where specs act as the source of truth for how a system currently behaves and changes are managed separately until they are merged back.
-- [Matt Pocock Skills: `tdd`](https://github.com/mattpocock/skills/tree/main/skills/engineering/tdd) - References its test-driven development methodology built around a red-green-refactor loop and small vertical slices.
+- [Matt Pocock Skills: `to-issues`](https://github.com/mattpocock/skills/tree/main/skills/engineering/to-issues) - References its issue-scale vertical-slice planning style for breaking design work into Zest Dev Plan steps.
+- [Matt Pocock Skills: `tdd`](https://github.com/mattpocock/skills/tree/main/skills/engineering/tdd) - References its test-driven implementation methodology for coding work, separate from Plan step slicing.

--- a/commands/summarize-chat.md
+++ b/commands/summarize-chat.md
@@ -29,7 +29,7 @@ Based on the conversation, determine the spec status:
 - **"new"**: Only discussed the problem and goals, no exploration yet
 - **"researched"**: Explored codebase, evaluated options, identified approach
 - **"designed"**: Clarified requirements, designed architecture with trade-offs
-- **"planned"**: Created an implementation checklist from the design
+- **"planned"**: Created issue-scale implementation steps from the design
 - **"implemented"**: Actually wrote code, tested it, and reviewed quality
 
 **If status is vague or unclear**, use the question tool to ask:
@@ -39,7 +39,7 @@ Based on the conversation, determine the spec status:
   - **new**: Problem identified, no exploration
   - **researched**: Codebase explored, options evaluated
   - **designed**: Architecture designed, approach chosen
-  - **planned**: Implementation checklist created
+  - **planned**: Issue-scale implementation steps created
   - **implemented**: Code written, tested, reviewed
 
 **Step 3: Create Spec via CLI**
@@ -80,13 +80,14 @@ Fill sections based on the status:
 
 **If status is "planned" or later - Fill Plan section:**
 - Follow the canonical Plan rules from the Zest Dev skill
-- Use capability-based steps that deliver meaningful, reviewable increments
-- Each step must include small, independent substeps for implementation and immediate verification
-- List implementation substeps before verification substeps
-- The final step may focus on overall testing/verification and coverage improvements
-- Each step is complete only when relevant tests pass
+- Use `Step 1`, `Step 2`, and so on for issue-scale vertical slices
+- Reference the slicing spirit of Matt Pocock's registered `to-issues` skill, but keep the output inside `## Plan`
+- Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that
+- Do not use markdown checkboxes in `## Plan`
+- Add or update `## Notes` → `### Progress` with one thin checkbox per Plan step
 
 **If status is "implemented" - Fill Notes section:**
+- `### Progress`: Step completion checkboxes
 - `### Implementation`: What was built, files changed, and design deviations
 - `### Verification`: Tests written/run, results, manual validation, and relevant fix-and-rerun notes
 - Only treat work as implemented when the relevant tests were actually run and passed

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -132,7 +132,7 @@ Use when a spec exists and the team needs repository facts, patterns, and option
 Use when research or direct understanding is sufficient to choose an implementation design.
 
 ### Plan phase
-Use when the design is ready to turn into an implementation checklist.
+Use when the design is ready to turn into issue-scale implementation steps.
 
 ### Implement phase
 Use when the plan is ready for coding.
@@ -153,7 +153,7 @@ Use when the plan is ready for coding.
 
 ### Plan
 - The canonical Plan workflow lives in `plan.md`.
-- Use it for implementation checklist shaping and status advancement to `planned`.
+- Use it for issue-scale step shaping and status advancement to `planned`.
 
 ### Implement
 - The canonical Implement workflow lives in `implement.md`.

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -14,8 +14,9 @@ Canonical workflow for implementing an active change spec.
 5. Implement the feature following the plan, design, and repository conventions.
 6. Write or update tests alongside the implementation, not afterward.
 7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
-8. After each completed plan step or substep, mark the corresponding `## Plan` checkbox as `[x]` only when that item is complete and relevant tests pass.
+8. After each completed plan step, mark the corresponding `## Notes` → `### Progress` checkbox as `[x]` only when that step is complete and relevant tests pass.
 9. Fill `## Notes` with brief:
+    - `### Progress`
     - `### Implementation`
     - `### Verification`
 10. If the full spec is complete, run `zest-dev update active implemented`.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -3,7 +3,7 @@
 Canonical workflow for planning implementation of an active change spec.
 
 ## When to use
-- The design is ready to turn into an implementation checklist
+- The design is ready to turn into implementation steps
 - A thin `plan` command routes here
 
 ## Workflow
@@ -13,37 +13,60 @@ Canonical workflow for planning implementation of an active change spec.
    - If the status is `new` or `researched`, suggest design first unless the implementation approach is already sufficiently decided.
    - If the status is `designed`, continue.
    - If the status is `planned` or `implemented`, confirm that the user wants to revise the existing plan before continuing.
-4. Identify implementation increments, immediate verification points, edge-case validation, and any dependencies between steps.
+4. Identify implementation steps using issue-scale slicing:
+   - Use the slicing spirit of Matt Pocock's registered `to-issues` skill as a reference for scale and sequencing.
+   - Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that.
+   - Treat each Plan step as the spec-local counterpart to an issue-sized vertical slice.
+   - Prefer thin vertical slices that can be implemented independently and verified meaningfully.
+   - Avoid splitting only by horizontal layers such as schema, backend, UI, docs, or tests unless that layer is genuinely the whole change.
+   - Mark steps as `HITL` when they need user review, product judgment, or approval before continuing.
+   - Mark steps as `AFK` when an agent can implement them independently from the written spec and repository context.
+   - Capture dependencies between steps.
 5. Ask the user clarifying questions when needed.
 6. Wait for answers before finalizing the plan when the open questions are consequential.
-7. Fill `## Plan` with a compact capability-based checklist:
-   - Use markdown checkboxes for every step and substep.
-   - Prefer steps that each deliver one meaningful increment and remain easy to review.
-   - Good step boundaries usually align with one user-visible workflow, one subsystem or integration boundary, one migration or rollout step, or one stabilization milestone.
-   - Each step must include small, independent substeps for implementation work and immediate testing/verification.
-   - Within each step, list implementation substeps before verification substeps.
-   - The final step may focus on overall testing/verification, edge-case validation, regression coverage, and test coverage improvements.
-   - A step is complete only when its relevant tests pass.
-   - Size each step so a coding agent can implement and validate it within a single session.
-   - Write each substep as one small, independent task.
-   - Format as a short checklist, for example:
+7. Fill `## Plan` with compact structured steps:
+   - Do not use markdown checkboxes in `## Plan`.
+   - Keep the step label as `Step 1`, `Step 2`, and so on.
+   - Prefer steps that each deliver one meaningful vertical slice and remain easy to review.
+   - Good step boundaries usually align with one user-visible workflow, one subsystem integration boundary, one migration or rollout step, or one stabilization milestone.
+   - Each step should be issue-scale: large enough to matter, small enough for a coding agent to implement and validate in one focused session.
+   - Keep fields brief. Do not turn each step into a second design document.
+   - Include `Type`, `Goal`, `Scope`, and `Depends on`.
+   - Use `Depends on: None` when the step has no dependency.
+   - Add acceptance criteria only when they are necessary to remove ambiguity.
+   - Format as structured prose, for example:
+      ```markdown
+      ### Step 1: Foo
+
+      Type: AFK
+      Goal: Deliver the smallest useful end-to-end Foo behavior.
+      Scope: Update the Foo command path and its integration tests.
+      Depends on: None
+
+      ### Step 2: Bar
+
+      Type: HITL
+      Goal: Choose and apply the Bar user-facing behavior.
+      Scope: Confirm the behavior with the user, then update Bar prompts and docs.
+      Depends on: Step 1
+      ```
+8. Add or update `## Notes` with a thin progress checklist:
+   - Use the heading `### Progress`.
+   - Add one checkbox per Plan step.
+   - Keep each checklist item to the step title only.
+   - This checklist is for implementation progress tracking, not for describing the plan.
+   - Format:
+      ```markdown
+      ### Progress
+
       - [ ] Step 1: Foo
-        - [ ] Substep 1.1 Implement: Foo foundation
-        - [ ] Substep 1.2 Implement: Foo integration
-        - [ ] Substep 1.3 Implement: Foo edge handling
-        - [ ] Substep 1.4 Verify: Foo automated coverage
-        - [ ] Substep 1.5 Verify: Foo manual workflow
       - [ ] Step 2: Bar
-        - [ ] Substep 2.1 Implement: Bar
-        - [ ] Substep 2.2 Verify: Bar
-      - [ ] Step 3: Baz
-        - [ ] Substep 3.1 Implement: Baz
-        - [ ] Substep 3.2 Verify: Baz
-8. Update status based on the starting state:
+      ```
+9. Update status based on the starting state:
    - If the spec started as `designed`, run `zest-dev update active planned`.
    - If the spec started as `planned`, skip the update and keep the status as-is.
    - If the spec started as `implemented`, skip the update and keep the status as-is while revising the plan.
-9. Present the plan and stop.
+10. Present the plan and stop.
 
 ## Rule
-This is where implementation sequencing and verification checkpoints belong.
+This is where Design becomes issue-scale spec-local implementation steps. Do not publish issues unless the user explicitly asks for that.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -269,6 +269,14 @@ test('zest-dev init integration', async (t) => {
 
       const planPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/plan.md'), 'utf-8');
       assert.ok(planPhase.includes('If the spec started as `designed`, run `zest-dev update active planned`.'));
+      assert.ok(planPhase.includes('Use the slicing spirit of Matt Pocock\'s registered `to-issues` skill as a reference for scale and sequencing.'));
+      assert.ok(planPhase.includes('Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that.'));
+      assert.ok(planPhase.includes('Do not use markdown checkboxes in `## Plan`.'));
+      assert.ok(planPhase.includes('Use the heading `### Progress`.'));
+
+      const implementPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/implement.md'), 'utf-8');
+      assert.ok(implementPhase.includes('mark the corresponding `## Notes` → `### Progress` checkbox as `[x]`'));
+      assert.equal(implementPhase.includes('mark the corresponding `## Plan` checkbox'), false);
 
       const codexSkillFile = fs.readFileSync(path.join(globalCodexSkillsDir, 'SKILL.md'), 'utf-8');
       assert.ok(codexSkillFile.includes('This skill is the **canonical workflow source**'));


### PR DESCRIPTION
## Summary

- Reframe the Zest Dev Plan phase around issue-scale `Step` slices inspired by Matt Pocock's `to-issues` skill
- Keep Plan output inside the spec instead of creating GitHub issues, and move checkbox tracking into `## Notes` → `### Progress`
- Update Implement and summarize-chat guidance plus integration assertions for the new Plan/Progress boundary

Closes #56.

## Verification

- `pnpm test:local`
- `pnpm test:package`