### PR TITLE
feat(implement): reference tdd skill

### DIFF
--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -10,17 +10,18 @@ Canonical workflow for implementing an active change spec.
 1. Run `zest-dev status` and verify an active change spec exists with status `planned`.
 2. Run `zest-dev show active` and read the full spec.
 3. Read all relevant implementation files before coding.
-4. Create a task list.
-5. Implement the feature following the plan, design, and repository conventions.
-6. Write or update tests alongside the implementation, not afterward.
-7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
-8. After each completed plan step, mark the corresponding `## Notes` → `### Progress` checkbox as `[x]` only when that step is complete and relevant tests pass.
-9. Fill `## Notes` with brief:
+4. When the implementation work is suitable for test-driven development, try to use the registered `tdd` skill and its red-green-refactor loop; judge applicability from the spec, plan step, and files being changed.
+5. Create a task list.
+6. Implement the feature following the plan, design, and repository conventions.
+7. Write or update tests alongside the implementation, not afterward.
+8. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
+9. After each completed plan step, mark the corresponding `## Notes` → `### Progress` checkbox as `[x]` only when that step is complete and relevant tests pass.
+10. Fill `## Notes` with brief:
     - `### Progress`
     - `### Implementation`
     - `### Verification`
-10. If the full spec is complete, run `zest-dev update active implemented`.
-11. If only part of the work is complete, keep the current non-final status and document what was done.
+11. If the full spec is complete, run `zest-dev update active implemented`.
+12. If only part of the work is complete, keep the current non-final status and document what was done.
 
 ## Rule
 Only mark the spec `implemented` when the whole plan is finished.

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -11,17 +11,16 @@ Canonical workflow for implementing an active change spec.
 2. Run `zest-dev show active` and read the full spec.
 3. Read all relevant implementation files before coding.
 4. When the implementation work is suitable for test-driven development, try to use the registered `tdd` skill and its red-green-refactor loop; judge applicability from the spec, plan step, and files being changed.
-5. Create a task list.
-6. Implement the feature following the plan, design, and repository conventions.
-7. Write or update tests alongside the implementation, not afterward.
-8. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
-9. After each completed plan step, mark the corresponding `## Notes` → `### Progress` checkbox as `[x]` only when that step is complete and relevant tests pass.
-10. Fill `## Notes` with brief:
+5. Implement the feature following the plan, design, and repository conventions.
+6. Write or update tests alongside the implementation, not afterward.
+7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
+8. After each completed plan step, mark the corresponding `## Notes` → `### Progress` checkbox as `[x]` only when that step is complete and relevant tests pass.
+9. Fill `## Notes` with brief:
     - `### Progress`
     - `### Implementation`
     - `### Verification`
-11. If the full spec is complete, run `zest-dev update active implemented`.
-12. If only part of the work is complete, keep the current non-final status and document what was done.
+10. If the full spec is complete, run `zest-dev update active implemented`.
+11. If only part of the work is complete, keep the current non-final status and document what was done.
 
 ## Rule
 Only mark the spec `implemented` when the whole plan is finished.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -275,6 +275,8 @@ test('zest-dev init integration', async (t) => {
       assert.ok(planPhase.includes('Use the heading `### Progress`.'));
 
       const implementPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/implement.md'), 'utf-8');
+      assert.ok(implementPhase.includes('try to use the registered `tdd` skill'));
+      assert.ok(implementPhase.includes('judge applicability from the spec, plan step, and files being changed'));
       assert.ok(implementPhase.includes('mark the corresponding `## Notes` → `### Progress` checkbox as `[x]`'));
       assert.equal(implementPhase.includes('mark the corresponding `## Plan` checkbox'), false);
 


### PR DESCRIPTION
## Summary

- Prompt the Zest Dev Implement phase to try the registered `tdd` skill when implementation work is suitable for test-driven development.
- Keep command prompts thin by placing the guidance in the Implement phase file.
- Add integration coverage that deployed `implement.md` keeps the `tdd` skill guidance.

## Validation

- `pnpm test:local`
- `pnpm test:package`