### PR TITLE
feat(plan): report AFK and HITL steps

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,18 @@ _Avoid_: design step, planning note
 A Spec lifecycle milestone meaning the Spec's Design and Plan sections are ready for implementation.
 _Avoid_: designed, ready
 
+**Plan Step**:
+One issue-scale implementation slice inside a Spec's Plan section. A Plan Step has a Type that describes whether the next implementer can proceed independently or needs human input.
+_Avoid_: task, ticket
+
+**AFK Plan Step**:
+A Plan Step that an agent can implement independently from the written Spec and repository context.
+_Avoid_: automatic step, background task
+
+**HITL Plan Step**:
+A Plan Step that needs user review, product judgment, or approval before continuing. The Plan Phase completion response should tell the user what needs to be discussed in conversation.
+_Avoid_: manual step, blocked step
+
 **CLI**:
 The `zest-dev` command-line tool that manages Spec lifecycle operations such as creating, showing, activating, and updating Specs.
 _Avoid_: workflow engine, writing guide
@@ -53,3 +65,7 @@ Maintainer: "No. The Design Phase records decisions and trade-offs; the Plan Pha
 Developer: "When is a Spec ready for implementation?"
 
 Maintainer: "When it reaches Planned Status: the Design is decided, and the Plan checklist is ready to execute."
+
+Developer: "Can an agent start Step 2 without me?"
+
+Maintainer: "Only if Step 2 is an AFK Plan Step. If it is a HITL Plan Step, the Plan Phase completion response should tell you what we need to discuss first."

--- a/commands/quick-implement.md
+++ b/commands/quick-implement.md
@@ -65,7 +65,7 @@ Enter the Zest Dev skill's **Plan** phase and let it run the canonical plan work
 
 ## Checkpoint 2: Approve implementation
 
-After the plan is ready, present a brief summary and get explicit approval before entering the Implement phase.
+After the plan is ready, use the Plan phase's AFK/HITL step summary and get explicit approval before entering the Implement phase.
 
 ---
 

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -66,7 +66,10 @@ Canonical workflow for planning implementation of an active change spec.
    - If the spec started as `designed`, run `zest-dev update active planned`.
    - If the spec started as `planned`, skip the update and keep the status as-is.
    - If the spec started as `implemented`, skip the update and keep the status as-is while revising the plan.
-10. Present the plan and stop.
+10. Present the plan and stop:
+   - Report every Plan step's `Type` as `AFK` or `HITL`.
+   - For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues.
+   - If all steps are `AFK`, say that no user action is required before implementation.
 
 ## Rule
 This is where Design becomes issue-scale spec-local implementation steps. Do not publish issues unless the user explicitly asks for that.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -273,6 +273,8 @@ test('zest-dev init integration', async (t) => {
       assert.ok(planPhase.includes('Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that.'));
       assert.ok(planPhase.includes('Do not use markdown checkboxes in `## Plan`.'));
       assert.ok(planPhase.includes('Use the heading `### Progress`.'));
+      assert.ok(planPhase.includes('Report every Plan step\'s `Type` as `AFK` or `HITL`.'));
+      assert.ok(planPhase.includes('For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues.'));
 
       const implementPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/implement.md'), 'utf-8');
       assert.ok(implementPhase.includes('try to use the registered `tdd` skill'));
@@ -785,6 +787,7 @@ test('zest-dev prompt supports actual command set and summarize alias', () => {
     const quickPrompt = runCommand('prompt quick-implement test feature');
     assert.ok(quickPrompt.includes('Thin bridge entrypoint'));
     assert.ok(quickPrompt.includes('test feature'));
+    assert.ok(quickPrompt.includes('use the Plan phase\'s AFK/HITL step summary'));
 
     const planPrompt = runCommand('prompt plan');
     assert.ok(planPrompt.includes('Run Zest Dev **Plan** phase workflow.'));


### PR DESCRIPTION
## Summary
- Require Plan phase completion responses to report each step as AFK or HITL
- Tell the user what needs discussion, review, judgment, or approval for HITL steps in conversation
- Align quick-implement approval wording and add integration coverage for deployed Plan phase text
- Document Plan Step, AFK Plan Step, and HITL Plan Step terminology in CONTEXT.md

## Validation
- `pnpm test:local`
- `git diff --check`