### PR TITLE
feat(ralph): add progress to tasks command

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,14 @@ _Avoid_: designed, ready
 One issue-scale implementation slice inside a Spec's Plan section. A Plan Step has a Type that describes whether the next implementer can proceed independently or needs human input.
 _Avoid_: task, ticket
 
+**Progress Checklist**:
+A thin completion checklist in a Spec's Notes section, with one checkbox per Plan Step. It tracks implementation completion; it is not the implementation plan itself.
+_Avoid_: plan, task list
+
+**Ralph Task**:
+A markdown checkbox item consumed by Ralph Tasks Mode from `.ralph/ralph-tasks.md`. It is generated from a Progress Checklist item when Zest Dev hands planned work to Ralph.
+_Avoid_: Plan Step, Progress item
+
 **AFK Plan Step**:
 A Plan Step that an agent can implement independently from the written Spec and repository context.
 _Avoid_: automatic step, background task
@@ -69,3 +77,7 @@ Maintainer: "When it reaches Planned Status: the Design is decided, and the Plan
 Developer: "Can an agent start Step 2 without me?"
 
 Maintainer: "Only if Step 2 is an AFK Plan Step. If it is a HITL Plan Step, the Plan Phase completion response should tell you what we need to discuss first."
+
+Developer: "Can we send the Progress Checklist to Ralph?"
+
+Maintainer: "Yes. The Progress Checklist records which Plan Steps are complete; `zest-dev ralph` can convert its unchecked items into Ralph Tasks for Ralph Tasks Mode."

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -18,6 +18,7 @@ const {
 } = require('../lib/spec-manager');
 const { deployPlugin } = require('../lib/plugin-deployer');
 const { generatePrompt } = require('../lib/prompt-generator');
+const { setupRalphFromActiveSpec } = require('../lib/ralph-setup');
 
 const program = new Command();
 
@@ -255,6 +256,20 @@ program
       const scope = options.local ? 'local' : 'global';
       const target = options.target || (scope === 'local' ? 'opencode' : 'all');
       const result = deployPlugin({ scope, target });
+      console.log(yaml.dump(result));
+    } catch (error) {
+      console.error('Error:', error.message);
+      process.exit(1);
+    }
+  });
+
+// zest-dev ralph
+program
+  .command('ralph')
+  .description('Convert active spec Progress items into Ralph tasks')
+  .action(() => {
+    try {
+      const result = setupRalphFromActiveSpec(process.cwd());
       console.log(yaml.dump(result));
     } catch (error) {
       console.error('Error:', error.message);

--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -1,0 +1,120 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { getSpec } = require('./spec-manager');
+const { generatePrompt } = require('./prompt-generator');
+
+const FINAL_RALPH_TASK = 'Make sure all tasks are done in ralph loops, and then create PR';
+
+function findSection(content, heading) {
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const headingPattern = new RegExp(`^${escapedHeading}\\s*$`, 'm');
+  const match = headingPattern.exec(content);
+
+  if (!match) {
+    return null;
+  }
+
+  const bodyStart = match.index + match[0].length;
+  const level = heading.match(/^#+/)[0].length;
+  const nextHeadingPattern = new RegExp(`^#{1,${level}}\\s+`, 'm');
+  const rest = content.slice(bodyStart);
+  const nextMatch = nextHeadingPattern.exec(rest);
+
+  return nextMatch ? rest.slice(0, nextMatch.index) : rest;
+}
+
+function parseProgressTasks(specContent) {
+  const notes = findSection(specContent, '## Notes');
+  if (notes === null) {
+    throw new Error('Active spec is missing ## Notes');
+  }
+
+  const progress = findSection(notes, '### Progress');
+  if (progress === null) {
+    throw new Error('Active spec is missing ## Notes -> ### Progress');
+  }
+
+  const tasks = [];
+  let sawCheckbox = false;
+
+  for (const line of progress.split(/\r?\n/)) {
+    if (line.trim() === '') {
+      continue;
+    }
+
+    const match = line.match(/^- \[([ xX])\] (.+)$/);
+    if (!match) {
+      throw new Error(`Unsupported Progress line: ${line}`);
+    }
+
+    sawCheckbox = true;
+    const marker = match[1].toLowerCase();
+    if (marker === ' ') {
+      tasks.push(match[2]);
+    }
+  }
+
+  if (!sawCheckbox) {
+    throw new Error('Active spec Progress section has no checkbox items');
+  }
+
+  return tasks;
+}
+
+function runRalphAddTask(task, cwd) {
+  const result = spawnSync('ralph', ['--add-task', task], {
+    cwd,
+    encoding: 'utf-8'
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run ralph --add-task: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const details = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`ralph --add-task failed for "${task}"${details ? `:\n${details}` : ''}`);
+  }
+
+  return {
+    task,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim()
+  };
+}
+
+function setupRalphFromActiveSpec(cwd = process.cwd()) {
+  const spec = getSpec('active');
+  const specContent = fs.readFileSync(spec.path, 'utf-8');
+  const progressTasks = parseProgressTasks(specContent);
+  const tasks = [...progressTasks, FINAL_RALPH_TASK];
+  const ralphDir = path.join(cwd, '.ralph');
+
+  fs.rmSync(ralphDir, { recursive: true, force: true });
+
+  const ralph_results = tasks.map(task => runRalphAddTask(task, cwd));
+  const prompt = generatePrompt('implement');
+  const taskPath = path.join(cwd, 'task.md');
+  fs.writeFileSync(taskPath, `${prompt}\n`, 'utf-8');
+
+  return {
+    ok: true,
+    spec: {
+      id: spec.id,
+      path: spec.path
+    },
+    tasks_added: tasks,
+    ralph_results,
+    task_md: {
+      path: 'task.md',
+      bytes: Buffer.byteLength(`${prompt}\n`, 'utf-8')
+    }
+  };
+}
+
+module.exports = {
+  FINAL_RALPH_TASK,
+  parseProgressTasks,
+  setupRalphFromActiveSpec
+};

--- a/specs/change/20260604-ralph-progress-to-tasks/spec.md
+++ b/specs/change/20260604-ralph-progress-to-tasks/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260604-ralph-progress-to-tasks
 name: Ralph Progress To Tasks
-status: planned
+status: implemented
 created: '2026-06-04'
 ---
 
@@ -159,15 +159,18 @@ Depends on: Step 2, Step 3
 
 ### Progress
 
-- [ ] Step 1: Parse active Progress into task text
-- [ ] Step 2: Execute Ralph setup workflow
-- [ ] Step 3: Write implement prompt file
-- [ ] Step 4: Integrate CLI tests and command help
+- [x] Step 1: Parse active Progress into task text
+- [x] Step 2: Execute Ralph setup workflow
+- [x] Step 3: Write implement prompt file
+- [x] Step 4: Integrate CLI tests and command help
 
 ### Implementation
 
-<!-- Files created/modified, decisions made during coding, deviations from design -->
+- Added `lib/ralph-setup.js` to parse active Spec `## Notes` -> `### Progress`, fail on malformed/missing Progress input, clear `.ralph/`, call `ralph --add-task`, and overwrite `task.md` with `generatePrompt("implement")`.
+- Added `zest-dev ralph` CLI wiring in `bin/zest-dev.js` using the existing YAML output and fail-fast error style.
+- Added integration coverage with a fake `ralph` executable for success, completed-only Progress, missing active Spec, missing Progress, malformed Progress, `.ralph` cleanup, and `task.md` generation.
 
 ### Verification
 
-<!-- How the feature was verified: tests written, manual testing steps, results -->
+- `pnpm test:local` - passed, 47 pass / 1 skip.
+- `pnpm test:package` - passed, 48 pass.

--- a/specs/change/20260604-ralph-progress-to-tasks/spec.md
+++ b/specs/change/20260604-ralph-progress-to-tasks/spec.md
@@ -1,0 +1,173 @@
+---
+id: 20260604-ralph-progress-to-tasks
+name: Ralph Progress To Tasks
+status: planned
+created: '2026-06-04'
+---
+
+## Overview
+
+Add a `zest-dev ralph` command that converts a Spec's `## Notes` -> `### Progress` checklist into Ralph Tasks.
+
+The command should be deterministic and programmatic, not LLM-based. The goal is to let a planned Zest Dev Spec become Ralph's task-mode input without manually copying checklist items.
+
+## Research
+
+### Existing System
+
+- Issue 62 requests a new `zest-dev ralph` command that converts spec `progress` into `ralph tasks`, and explicitly says to use a programmatic approach rather than an LLM. Source: https://github.com/nettee/zest-dev/issues/62
+- Specs live under `specs/change/<YYYYMMDD-slug>/`, and only directory names matching `^\d{8}-` are recognized. Source: `lib/spec-manager.js:32-41`
+- The active Spec is resolved from `specs/change/active`, with legacy fallback to `specs/change/current`. Source: `lib/spec-manager.js:6-8,71-72`
+- `getSpec("active")` fails immediately when no active change spec exists. Source: `lib/spec-manager.js:157-160`
+- Current valid Spec statuses include `new`, `researched`, `designed`, `planned`, and `implemented`. Source: `lib/spec-manager.js:11-18`
+- The CLI currently defines commands for status, show, create, set-active, unset-active, update, create-branch, init, and prompt; there is no `ralph` command handler yet. Source: `bin/zest-dev.js:128-270`
+- `zest-dev prompt <command>` delegates prompt generation to `generatePrompt(command, args)`. Source: `bin/zest-dev.js:265-270`; `lib/prompt-generator.js:19-42`
+- Prompt generation reads `commands/<command>.md`, strips YAML frontmatter, replaces `$ARGUMENTS`, trims whitespace, and returns the prompt. Source: `lib/prompt-generator.js:19-42`
+- The implement command prompt lives in `commands/implement.md`. Source: `commands/implement.md:1-10`
+- The Plan Phase writes `## Notes` -> `### Progress` as one checkbox per Plan step, and says this checklist tracks implementation progress rather than describing the plan. Source: `skills/zest-dev/plan.md:54-65`
+- The Implement Phase marks the matching Progress checkbox `[x]` only when that Plan step is complete and relevant tests pass. Source: `skills/zest-dev/implement.md:1-18`
+
+### Design Inputs
+
+- Project language distinguishes a `Plan Step` from a task or ticket; it is an issue-scale implementation slice in the Spec's Plan section. Source: `CONTEXT.md:39-41`
+- Planned Status means the Spec's Design and Plan sections are ready for implementation. Source: `CONTEXT.md:35-37`
+- Ralph stores task-mode files in the current working directory's `.ralph` folder, with tasks at `.ralph/ralph-tasks.md`. Source: `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/ralph.ts:20-24`
+- Ralph `--add-task` creates `.ralph/ralph-tasks.md` with `# Ralph Tasks` when missing and appends top-level `- [ ] <description>` items. Source: `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/ralph.ts:616-640`
+- Ralph parses top-level tasks with `- [ ]`, `- [/]`, and `- [x]`, and parses indented checkbox items as subtasks. Source: `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/ralph.ts:731-769`
+- Ralph Tasks Mode tells agents to mark the next unchecked task as `[/]`, mark verified completed tasks as `[x]`, and only finish when all tasks are `[x]`. Source: `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/ralph.ts:1395-1447`
+- Ralph's README says Tasks Mode stores tasks in `.ralph/ralph-tasks.md` and supports `ralph --list-tasks`, `ralph --add-task`, and `ralph --remove-task`. Source: `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/README.md:221-251`
+
+### Constraints & Dependencies
+
+- The command must not rely on an LLM for conversion. Source: https://github.com/nettee/zest-dev/issues/62
+- Zest Dev's "let it crash" rule requires missing required inputs, invalid state, and failed required steps to fail immediately with clear errors rather than silently substituting defaults. Source: `AGENTS.md:33-50`
+- CLI errors are expected to print a clear message and exit non-zero. Source: `bin/zest-dev.js:132-145,152-159,166-172,218-225`
+
+### Key References
+
+- `bin/zest-dev.js:128-270` - current CLI command registration shape.
+- `lib/spec-manager.js:6-18,32-41,157-160` - active Spec lookup and status model.
+- `skills/zest-dev/plan.md:54-65` - canonical Progress Checklist format.
+- `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/ralph.ts:20-24,616-640,731-769,1395-1447` - Ralph task path, file creation, markdown parsing, and workflow.
+
+## Design
+
+### Design Summary
+
+Add `zest-dev ralph` as a CLI command that reads the active Spec, extracts unfinished implementation items, resets local Ralph state, and creates Ralph Tasks by invoking Ralph's own task-management CLI.
+
+### Design Decisions
+
+- Decision: `zest-dev ralph` operates only on the active Spec; it does not accept a Spec id argument in this change. If there is no active Spec, it fails fast with the same clear-error pattern as other CLI commands. Source: user decision; `lib/spec-manager.js:157-160`; `bin/zest-dev.js:132-145,152-159,218-225`; `AGENTS.md:33-50`
+- Decision: `zest-dev ralph` must not write `.ralph/ralph-tasks.md` directly or assume Ralph's internal task-file format. It should clear existing `.ralph/` state first and create tasks by running `ralph --add-task "<description>"` for each generated task. Source: user decision; `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/README.md:231-245`; `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/ralph.ts:616-640`
+- Decision: Only unfinished items are converted into Ralph Tasks; completed items are skipped. Source: user decision; `skills/zest-dev/implement.md:17-18`
+- Decision: The conversion source is only `## Notes` -> `### Progress` checkbox items. The command should not infer tasks from `## Plan`; if the Progress section is missing, malformed, or contains unsupported checkbox syntax, it fails fast with a clear error. Source: user decision; `skills/zest-dev/plan.md:54-65`; `AGENTS.md:33-50`
+- Decision: Each unfinished Progress checkbox becomes one Ralph Task using the checkbox text exactly as written after the marker. Source: user decision; `skills/zest-dev/plan.md:54-65`
+- Decision: After all unfinished Progress items are added, append a fixed final Ralph Task: `Make sure all tasks are done in ralph loops, and then create PR`. Source: user decision
+- Decision: `zest-dev ralph` writes the implement command prompt into project-root `./task.md`, overwriting any existing content. The prompt content comes from the same generator used by `zest-dev prompt implement`. Source: user decision; `bin/zest-dev.js:265-270`; `lib/prompt-generator.js:19-42`; `commands/implement.md:1-10`
+- Decision: `zest-dev ralph` executes the setup workflow in one run: add Ralph tasks, write `task.md`, then print the results of both steps for human confirmation. Any required operation that fails, including Ralph state cleanup, any `ralph --add-task`, or writing `task.md`, causes an immediate non-zero failure. Source: user decision; `AGENTS.md:33-50`; `bin/zest-dev.js:132-145,152-159,218-225`; `/Users/william/.nvm/versions/node/v24.13.0/lib/node_modules/@th0rgal/ralph-wiggum/README.md:231-245`
+
+### System Procedure
+
+```mermaid
+flowchart TD
+  A["zest-dev ralph"] --> B["Load active Spec"]
+  B --> C["Parse ## Notes -> ### Progress"]
+  C --> D["Collect unchecked checkbox text"]
+  D --> E["Remove existing .ralph/ state"]
+  E --> F["Run ralph --add-task for each Progress item"]
+  F --> G["Run ralph --add-task for fixed PR task"]
+  G --> H["Write ./task.md from prompt implement"]
+  H --> I["Print task-add results and task.md result"]
+```
+
+### Interfaces / APIs
+
+- CLI: `zest-dev ralph`
+- Input: the active Spec's `## Notes` -> `### Progress` checkbox list.
+- Generated Ralph Tasks:
+  - One task per unfinished Progress checkbox, using the checkbox text exactly.
+  - One final fixed task: `Make sure all tasks are done in ralph loops, and then create PR`.
+- Generated prompt file: project-root `task.md`, overwritten with `generatePrompt("implement")`.
+- Output: command output should show the `ralph --add-task` results and the `task.md` write result so the user can inspect what happened.
+
+### Change Scope
+
+Impact Areas:
+
+- CLI command surface: add a new `zest-dev ralph` command.
+- Spec parsing: add deterministic markdown section/checkbox extraction for Progress.
+- Ralph setup integration: clear `.ralph/`, call Ralph CLI task commands, and surface subprocess failures.
+- Prompt generation reuse: write the existing implement prompt to `./task.md`.
+- Tests: cover active-spec lookup, Progress parsing, fail-fast errors, Ralph subprocess integration, and `task.md` generation.
+
+Planned File Changes:
+
+- `bin/zest-dev.js` - register `ralph` command and wire command errors through existing CLI error handling.
+- `lib/spec-manager.js` or a new helper under `lib/` - expose enough active Spec content/path access for conversion.
+- `lib/prompt-generator.js` - reuse existing `generatePrompt("implement")`; no behavior change expected unless tests need export coverage.
+- `test/test-integration.js` - add integration tests for `zest-dev ralph`.
+
+### Edge Cases
+
+- No active Spec: fail fast.
+- Active Spec has no `## Notes` -> `### Progress`: fail fast.
+- Progress section contains non-checkbox content, nested subtasks, or unsupported checkbox markers: fail fast.
+- Progress section has only completed `[x]` items: create only the fixed final PR task.
+- Existing `.ralph/` directory exists: remove it before adding tasks.
+- `ralph` executable is missing or any `ralph --add-task` exits non-zero: fail fast.
+- `task.md` already exists: overwrite it.
+
+### Verification Strategy
+
+- Add tests that create an active planned Spec with mixed `[ ]` and `[x]` Progress items, run `zest-dev ralph`, and verify only unfinished Progress text plus the fixed PR task are passed to Ralph. Source: `skills/zest-dev/plan.md:54-65`; user decision
+- Add tests for fail-fast behavior when no active Spec exists and when Progress is missing or malformed. Source: `lib/spec-manager.js:157-160`; `AGENTS.md:33-50`
+- Add tests that existing `.ralph/` state is cleared before task creation. Source: user decision
+- Add tests that `task.md` is overwritten with the same content as `zest-dev prompt implement`. Source: `lib/prompt-generator.js:19-42`; `commands/implement.md:1-10`
+
+## Plan
+
+### Step 1: Parse active Progress into task text
+
+Type: AFK
+Goal: Deterministically read the active Spec and extract unfinished Progress checkbox text.
+Scope: Add or reuse helpers for active Spec content loading, Progress section detection, checkbox parsing, and fail-fast validation errors.
+Depends on: None
+
+### Step 2: Execute Ralph setup workflow
+
+Type: AFK
+Goal: Convert parsed Progress items into Ralph Tasks without assuming Ralph's task-file format.
+Scope: Remove existing `.ralph/`, run `ralph --add-task` for each unfinished Progress item plus the fixed PR task, fail on subprocess errors, and print task-add results.
+Depends on: Step 1
+
+### Step 3: Write implement prompt file
+
+Type: AFK
+Goal: Produce the prompt file Ralph or an agent can use to implement the active Spec.
+Scope: Generate the existing implement prompt, overwrite project-root `task.md`, and print the write result.
+Depends on: Step 1
+
+### Step 4: Integrate CLI tests and command help
+
+Type: AFK
+Goal: Make the command reliable and visible in the CLI.
+Scope: Register `zest-dev ralph`, add focused integration tests for success and fail-fast cases, and verify the local test suite.
+Depends on: Step 2, Step 3
+
+## Notes
+
+### Progress
+
+- [ ] Step 1: Parse active Progress into task text
+- [ ] Step 2: Execute Ralph setup workflow
+- [ ] Step 3: Write implement prompt file
+- [ ] Step 4: Integrate CLI tests and command help
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -161,6 +161,52 @@ function createDanglingActiveSymlink(targetId, testDir = TEST_DIR) {
   fs.symlinkSync(targetId, activeLinkPath);
 }
 
+function createActiveSpecWithBody(slug, body, testDir = TEST_DIR) {
+  const result = yaml.load(runCreate(slug, testDir));
+  const specPath = path.join(testDir, result.spec.path);
+  fs.writeFileSync(specPath, body, 'utf-8');
+  runCommand(`set-active ${result.spec.id}`, testDir);
+  return { id: result.spec.id, path: specPath };
+}
+
+function makeFakeRalphEnv(testDir = TEST_DIR) {
+  const fakeBinDir = path.join(testDir, 'fake-bin');
+  const logPath = path.join(testDir, 'ralph-args.log');
+  const fakeRalphPath = path.join(fakeBinDir, 'ralph');
+
+  fs.mkdirSync(fakeBinDir, { recursive: true });
+  fs.writeFileSync(
+    fakeRalphPath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+if (process.argv[2] !== '--add-task' || process.argv.length !== 4) {
+  console.error('unexpected ralph args: ' + process.argv.slice(2).join(' '));
+  process.exit(2);
+}
+fs.appendFileSync(process.env.RALPH_LOG_PATH, JSON.stringify(process.argv[3]) + '\\n');
+fs.mkdirSync('.ralph', { recursive: true });
+fs.appendFileSync('.ralph/ralph-tasks.md', '- [ ] ' + process.argv[3] + '\\n');
+console.log('Added task: ' + process.argv[3]);
+`,
+    'utf-8'
+  );
+  fs.chmodSync(fakeRalphPath, 0o755);
+
+  return {
+    PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`,
+    RALPH_LOG_PATH: logPath
+  };
+}
+
+function readFakeRalphTasks(testDir = TEST_DIR) {
+  const logPath = path.join(testDir, 'ralph-args.log');
+  return fs.readFileSync(logPath, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
 test('zest-dev init integration', async (t) => {
   setup();
 
@@ -755,6 +801,146 @@ test('zest-dev update integration', async (t) => {
       assert.equal(implementedResult.ok, true);
       assert.equal(implementedResult.status.from, 'planned');
       assert.equal(implementedResult.status.to, 'implemented');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('zest-dev ralph integration', async (t) => {
+  setup();
+
+  try {
+    await t.test('converts unfinished active Progress items into Ralph tasks and task.md', () => {
+      const spec = createActiveSpecWithBody('ralph-progress', `---
+id: test-ralph-progress
+name: Ralph Progress
+status: planned
+created: '2026-06-04'
+---
+
+## Overview
+
+Test spec.
+
+## Notes
+
+### Progress
+
+- [ ] Step 1: Parse active Progress into task text
+- [x] Step 2: Already complete
+- [ ] Step 3: Write implement prompt file
+
+### Implementation
+
+`);
+      const staleFile = path.join(TEST_DIR, '.ralph', 'stale.txt');
+      fs.mkdirSync(path.dirname(staleFile), { recursive: true });
+      fs.writeFileSync(staleFile, 'stale', 'utf-8');
+
+      const env = makeFakeRalphEnv();
+      const output = yaml.load(runCommandWithEnv('ralph', TEST_DIR, env));
+      const tasks = readFakeRalphTasks();
+
+      assert.equal(output.ok, true);
+      assert.equal(output.spec.id, spec.id);
+      assert.deepEqual(tasks, [
+        'Step 1: Parse active Progress into task text',
+        'Step 3: Write implement prompt file',
+        'Make sure all tasks are done in ralph loops, and then create PR'
+      ]);
+      assert.deepEqual(output.tasks_added, tasks);
+      assert.equal(fs.existsSync(staleFile), false, 'existing .ralph state should be removed before adding tasks');
+      assert.equal(
+        fs.readFileSync(path.join(TEST_DIR, 'task.md'), 'utf-8'),
+        runCommand('prompt implement')
+      );
+    });
+
+    await t.test('creates only the fixed final task when all Progress items are complete', () => {
+      cleanup();
+      setup();
+      createActiveSpecWithBody('ralph-complete-progress', `---
+id: test-ralph-complete-progress
+name: Ralph Complete Progress
+status: planned
+created: '2026-06-04'
+---
+
+## Notes
+
+### Progress
+
+- [x] Step 1: Done
+- [X] Step 2: Also done
+`);
+
+      const env = makeFakeRalphEnv();
+      runCommandWithEnv('ralph', TEST_DIR, env);
+
+      assert.deepEqual(readFakeRalphTasks(), [
+        'Make sure all tasks are done in ralph loops, and then create PR'
+      ]);
+    });
+
+    await t.test('fails when no active spec exists', () => {
+      cleanup();
+      setup();
+
+      const failed = runCommandExpectFailure('ralph');
+
+      assert.equal(failed.failed, true);
+      assert.ok(failed.output.includes('No active change spec set'));
+      assert.equal(fs.existsSync(path.join(TEST_DIR, 'task.md')), false);
+    });
+
+    await t.test('fails when Progress is missing', () => {
+      cleanup();
+      setup();
+      createActiveSpecWithBody('ralph-missing-progress', `---
+id: test-ralph-missing-progress
+name: Ralph Missing Progress
+status: planned
+created: '2026-06-04'
+---
+
+## Notes
+
+### Implementation
+
+`);
+
+      const failed = runCommandExpectFailure('ralph', TEST_DIR, makeFakeRalphEnv());
+
+      assert.equal(failed.failed, true);
+      assert.ok(failed.output.includes('Active spec is missing ## Notes -> ### Progress'));
+      assert.equal(fs.existsSync(path.join(TEST_DIR, '.ralph')), false);
+      assert.equal(fs.existsSync(path.join(TEST_DIR, 'task.md')), false);
+    });
+
+    await t.test('fails on unsupported Progress syntax', () => {
+      cleanup();
+      setup();
+      createActiveSpecWithBody('ralph-malformed-progress', `---
+id: test-ralph-malformed-progress
+name: Ralph Malformed Progress
+status: planned
+created: '2026-06-04'
+---
+
+## Notes
+
+### Progress
+
+- [/] Step 1: In progress is not supported
+`);
+
+      const failed = runCommandExpectFailure('ralph', TEST_DIR, makeFakeRalphEnv());
+
+      assert.equal(failed.failed, true);
+      assert.ok(failed.output.includes('Unsupported Progress line: - [/] Step 1: In progress is not supported'));
+      assert.equal(fs.existsSync(path.join(TEST_DIR, '.ralph')), false);
+      assert.equal(fs.existsSync(path.join(TEST_DIR, 'task.md')), false);
     });
   } finally {
     cleanup();


### PR DESCRIPTION
## Summary
- add `zest-dev ralph` to convert active Spec Progress checkboxes into Ralph tasks
- clear existing `.ralph/`, call `ralph --add-task`, and write `task.md` from the implement prompt
- cover success and fail-fast behavior with integration tests

## Verification
- `pnpm test:local`
- `pnpm test:package`