### PR TITLE
fix(ralph): fail when progress is complete

### DIFF
--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -59,6 +59,10 @@ function parseProgressTasks(specContent) {
     throw new Error('Active spec Progress section has no checkbox items');
   }
 
+  if (tasks.length === 0) {
+    throw new Error('Active spec Progress section has no unfinished checkbox items');
+  }
+
   return tasks;
 }
 

--- a/specs/change/20260604-ralph-progress-to-tasks/spec.md
+++ b/specs/change/20260604-ralph-progress-to-tasks/spec.md
@@ -168,9 +168,10 @@ Depends on: Step 2, Step 3
 
 - Added `lib/ralph-setup.js` to parse active Spec `## Notes` -> `### Progress`, fail on malformed/missing Progress input, clear `.ralph/`, call `ralph --add-task`, and overwrite `task.md` with `generatePrompt("implement")`.
 - Added `zest-dev ralph` CLI wiring in `bin/zest-dev.js` using the existing YAML output and fail-fast error style.
-- Added integration coverage with a fake `ralph` executable for success, completed-only Progress, missing active Spec, missing Progress, malformed Progress, `.ralph` cleanup, and `task.md` generation.
+- Added integration coverage with a fake `ralph` executable for success, all-complete Progress fail-fast behavior, missing active Spec, missing Progress, malformed Progress, `.ralph` cleanup, and `task.md` generation.
 
 ### Verification
 
 - `pnpm test:local` - passed, 47 pass / 1 skip.
 - `pnpm test:package` - passed, 48 pass.
+- Manual case check with `/Users/william/projects/vela-wt-model-priority/specs/change/20260604-runtime-catalog-route-weights-config/spec.md`: original all-complete Progress fails fast; temporary unchecked copy generates three Step tasks plus the fixed PR task.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -857,7 +857,7 @@ Test spec.
       );
     });
 
-    await t.test('creates only the fixed final task when all Progress items are complete', () => {
+    await t.test('fails when all Progress items are complete', () => {
       cleanup();
       setup();
       createActiveSpecWithBody('ralph-complete-progress', `---
@@ -875,12 +875,12 @@ created: '2026-06-04'
 - [X] Step 2: Also done
 `);
 
-      const env = makeFakeRalphEnv();
-      runCommandWithEnv('ralph', TEST_DIR, env);
+      const failed = runCommandExpectFailure('ralph', TEST_DIR, makeFakeRalphEnv());
 
-      assert.deepEqual(readFakeRalphTasks(), [
-        'Make sure all tasks are done in ralph loops, and then create PR'
-      ]);
+      assert.equal(failed.failed, true);
+      assert.ok(failed.output.includes('Active spec Progress section has no unfinished checkbox items'));
+      assert.equal(fs.existsSync(path.join(TEST_DIR, '.ralph')), false);
+      assert.equal(fs.existsSync(path.join(TEST_DIR, 'task.md')), false);
     });
 
     await t.test('fails when no active spec exists', () => {


### PR DESCRIPTION
## Summary
- fail fast when active Spec Progress has no unfinished checkbox items
- update Ralph integration coverage for the all-complete Progress case
- record manual verification with the runtime catalog route weights spec case

## Verification
- `pnpm test:local`
- `pnpm test:package`
- copied `/Users/william/projects/vela-wt-model-priority/specs/change/20260604-runtime-catalog-route-weights-config/spec.md` into a temp project: original all-complete Progress fails fast; temporary unchecked copy generates the expected Ralph tasks