### PR TITLE
fix: simplify zest-dev ralph output

### DIFF
--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -97,7 +97,7 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
 
   fs.rmSync(ralphDir, { recursive: true, force: true });
 
-  const ralph_results = tasks.map(task => runRalphAddTask(task, cwd));
+  tasks.forEach(task => runRalphAddTask(task, cwd));
   const prompt = generatePrompt('implement');
   const taskPath = path.join(cwd, 'task.md');
   fs.writeFileSync(taskPath, `${prompt}\n`, 'utf-8');
@@ -109,10 +109,9 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
       path: spec.path
     },
     tasks_added: tasks,
-    ralph_results,
     task_md: {
       path: 'task.md',
-      bytes: Buffer.byteLength(`${prompt}\n`, 'utf-8')
+      content: `${prompt}\n`
     }
   };
 }

--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -97,7 +97,7 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
 
   fs.rmSync(ralphDir, { recursive: true, force: true });
 
-  tasks.forEach(task => runRalphAddTask(task, cwd));
+  const ralph_results = tasks.map(task => runRalphAddTask(task, cwd));
   const prompt = generatePrompt('implement');
   const taskPath = path.join(cwd, 'task.md');
   fs.writeFileSync(taskPath, `${prompt}\n`, 'utf-8');
@@ -109,6 +109,7 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
       path: spec.path
     },
     tasks_added: tasks,
+    ralph_results,
     task_md: {
       path: 'task.md',
       content: `${prompt}\n`

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -850,7 +850,11 @@ Test spec.
         'Make sure all tasks are done in ralph loops, and then create PR'
       ]);
       assert.deepEqual(output.tasks_added, tasks);
-      assert.equal(Object.hasOwn(output, 'ralph_results'), false);
+      assert.deepEqual(output.ralph_results, tasks.map(task => ({
+        task,
+        stdout: `Added task: ${task}`,
+        stderr: ''
+      })));
       assert.equal(fs.existsSync(staleFile), false, 'existing .ralph state should be removed before adding tasks');
       const prompt = runCommand('prompt implement');
 

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -850,10 +850,17 @@ Test spec.
         'Make sure all tasks are done in ralph loops, and then create PR'
       ]);
       assert.deepEqual(output.tasks_added, tasks);
+      assert.equal(Object.hasOwn(output, 'ralph_results'), false);
       assert.equal(fs.existsSync(staleFile), false, 'existing .ralph state should be removed before adding tasks');
+      const prompt = runCommand('prompt implement');
+
+      assert.deepEqual(output.task_md, {
+        path: 'task.md',
+        content: prompt
+      });
       assert.equal(
         fs.readFileSync(path.join(TEST_DIR, 'task.md'), 'utf-8'),
-        runCommand('prompt implement')
+        prompt
       );
     });
 


### PR DESCRIPTION
## Summary
- remove `ralph_results` from `zest-dev ralph` output
- return full `task.md` content instead of a byte count
- update the integration test to assert the new output contract

## Validation
- `pnpm test:local`

Closes #69

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>