### PR TITLE
fix: remove ralph_results from zest-dev ralph output

### DIFF
--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -97,7 +97,9 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
 
   fs.rmSync(ralphDir, { recursive: true, force: true });
 
-  const ralph_results = tasks.map(task => runRalphAddTask(task, cwd));
+  tasks.forEach(task => {
+    runRalphAddTask(task, cwd);
+  });
   const prompt = generatePrompt('implement');
   const taskPath = path.join(cwd, 'task.md');
   fs.writeFileSync(taskPath, `${prompt}\n`, 'utf-8');
@@ -109,7 +111,6 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
       path: spec.path
     },
     tasks_added: tasks,
-    ralph_results,
     task_md: {
       path: 'task.md',
       content: `${prompt}\n`

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -850,11 +850,7 @@ Test spec.
         'Make sure all tasks are done in ralph loops, and then create PR'
       ]);
       assert.deepEqual(output.tasks_added, tasks);
-      assert.deepEqual(output.ralph_results, tasks.map(task => ({
-        task,
-        stdout: `Added task: ${task}`,
-        stderr: ''
-      })));
+      assert.equal('ralph_results' in output, false);
       assert.equal(fs.existsSync(staleFile), false, 'existing .ralph state should be removed before adding tasks');
       const prompt = runCommand('prompt implement');
 


### PR DESCRIPTION
## Summary
- remove `ralph_results` from `zest-dev ralph` output while still executing each Ralph task add step
- keep the remaining YAML contract unchanged: `ok`, `spec`, `tasks_added`, and `task_md`
- update the integration test to assert the field is absent

## Why
Issue #71 requests that the verbose per-task command result payload be removed from the command output. The task setup side effects still need to happen, but the CLI should no longer serialize those internal command results.

## Validation
- `pnpm test:local`
- `pnpm test:package`

Closes #71

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>