### PR TITLE
进一步精简单流程 command 文案

### DIFF
--- a/commands/design.md
+++ b/commands/design.md
@@ -3,10 +3,4 @@ description: Clarify requirements and design architecture
 argument-hint: [optional design focus or constraints]
 ---
 
-# Design: Clarify Requirements & Design Architecture
-
-Run Zest Dev **Design** phase workflow.
-
-**Language rule:** Respond in the user's language by default, if user's language is not English.
-
-**Arguments:** $ARGUMENTS
+Follow the Zest Dev workflow to advance the active spec to designed, using this focus if relevant: $ARGUMENTS.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -3,10 +3,4 @@ description: Build feature following the plan
 argument-hint: [optional implementation scope or phase hint]
 ---
 
-# Implement: Build the Feature
-
-Run Zest Dev **Implement** phase workflow.
-
-**Language rule:** Respond in the user's language by default, if user's language is not English.
-
-**Arguments:** $ARGUMENTS
+Follow the Zest Dev workflow to advance the active spec to implemented, using this focus if relevant: $ARGUMENTS.

--- a/commands/new.md
+++ b/commands/new.md
@@ -3,10 +3,4 @@ description: Create a new feature spec from description
 argument-hint: <description of feature or requirement>
 ---
 
-# Create New Feature Spec
-
-Run Zest Dev **New** phase workflow.
-
-**Language rule:** Respond in the user's language by default, if user's language is not English.
-
-**User's description:** $ARGUMENTS
+Follow the Zest Dev workflow to create a new spec from this request: $ARGUMENTS.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -3,10 +3,4 @@ description: Create an implementation plan from the design
 argument-hint: [optional planning focus or constraints]
 ---
 
-# Plan: Create Implementation Plan
-
-Run Zest Dev **Plan** phase workflow.
-
-**Language rule:** Respond in the user's language by default, if user's language is not English.
-
-**Arguments:** $ARGUMENTS
+Follow the Zest Dev workflow to advance the active spec to planned, using this focus if relevant: $ARGUMENTS.

--- a/commands/research.md
+++ b/commands/research.md
@@ -3,10 +3,4 @@ description: Research feature requirements and explore codebase patterns
 argument-hint: [optional focus or scope hint]
 ---
 
-# Research: Understand Requirements & Explore Codebase
-
-Run Zest Dev **Research** phase workflow.
-
-**Language rule:** Respond in the user's language by default, if user's language is not English.
-
-**Arguments:** $ARGUMENTS
+Follow the Zest Dev workflow to advance the active spec to researched, using this focus if relevant: $ARGUMENTS.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -44,11 +44,6 @@ const THIN_COMMANDS = [
 ];
 const SKILL_PHASE_FILES = ['new.md', 'research.md', 'design.md', 'plan.md', 'implement.md'];
 const CODEX_SUBAGENTS = ['code-architect.toml', 'code-explorer.toml', 'code-reviewer.toml'];
-const LANGUAGE_ALIGNMENT_RULES = [
-  'Respond in the user\'s language by default, if user\'s language is not English.',
-  'Always respond in the user\'s language throughout the flow unless the user asks to switch languages.'
-];
-
 function cleanup(testDir = TEST_DIR) {
   if (fs.existsSync(testDir)) {
     fs.rmSync(testDir, { recursive: true, force: true });
@@ -275,7 +270,7 @@ test('zest-dev init integration', async (t) => {
     await t.test('default global init preserves opencode content rules', () => {
       for (const file of EXPECTED_COMMANDS) {
         const content = fs.readFileSync(path.join(globalOpenCodeCommandsDir, file), 'utf-8');
-        assert.ok(LANGUAGE_ALIGNMENT_RULES.some(rule => content.includes(rule)));
+        assert.ok(content.startsWith('---\n'), `deployed command should preserve markdown frontmatter: ${file}`);
       }
 
       const content = fs.readFileSync(path.join(globalOpenCodeCommandsDir, 'zest-dev-new.md'), 'utf-8');
@@ -983,7 +978,10 @@ test('zest-dev prompt supports actual command set and summarize alias', () => {
     assert.ok(quickPrompt.includes('use the Plan phase\'s AFK/HITL step summary'));
 
     const planPrompt = runCommand('prompt plan');
-    assert.ok(planPrompt.includes('Run Zest Dev **Plan** phase workflow.'));
+    assert.equal(
+      planPrompt.trim(),
+      'Follow the Zest Dev workflow to advance the active spec to planned, using this focus if relevant: .'
+    );
 
     const draftPrompt = runCommand('prompt draft');
     assert.ok(draftPrompt.includes('Bridge entrypoint into the Zest Dev skill.'));
@@ -1005,13 +1003,18 @@ test('zest-dev prompt implement supports incremental phases', () => {
 
   try {
     const prompt = runCommand('prompt implement');
-    assert.ok(prompt.includes('Run Zest Dev **Implement** phase workflow.'));
+    assert.equal(
+      prompt.trim(),
+      'Follow the Zest Dev workflow to advance the active spec to implemented, using this focus if relevant: .'
+    );
     assert.equal(prompt.includes('**Step 1:'), false);
     assert.equal(prompt.includes('Treat this command as a request'), false);
 
     runInitArgs('--local');
     const deployedImplement = readCommand('.opencode', 'zest-dev-implement.md');
-    assert.ok(deployedImplement.includes('Run Zest Dev **Implement** phase workflow.'));
+    assert.ok(
+      deployedImplement.includes('Follow the Zest Dev workflow to advance the active spec to implemented, using this focus if relevant: $ARGUMENTS.')
+    );
     assert.equal(deployedImplement.includes('**Step 1:'), false);
     assert.equal(deployedImplement.includes('Treat this command as a request'), false);
   } finally {


### PR DESCRIPTION
## Summary
- reduce the `new`, `research`, `design`, `plan`, and `implement` command prompts to a single driving sentence each
- keep the existing frontmatter and `$ARGUMENTS` placeholders intact so prompt generation and deployment continue to work
- update integration tests to assert the new thin prompt shape and deployed command behavior

## Why
- issue #80 asks for the single-phase commands to be further simplified so they act as minimal workflow drivers instead of repeating phase boilerplate

## Validation
- `pnpm test:local`

Closes #80

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>