### PR TITLE
feat(spec): add design summary and EAG sections

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,12 +16,28 @@ _Avoid_: full spec, source of truth file
 A Markdown file inside a Spec directory that carries lower-review-frequency workflow detail, such as design research or step-by-step implementation records.
 _Avoid_: appendix, attachment
 
+**Design Section**:
+The conceptual Design area of a Spec. It spans the Main Spec File's Design section for high-frequency review content and `design.md` for lower-frequency Design Detail.
+_Avoid_: design file, design-only section
+
+**Design Summary**:
+A concise, high-frequency review summary inside the Main Spec File's Design section. It captures the chosen approach without replacing Design Detail.
+_Avoid_: full design, design detail
+
+**E2E Acceptance Gate (EAG)**:
+A small, preferably single, automated end-to-end acceptance gate in the Main Spec File's Design section. It states both the user- or system-visible behavior to accept and the executable verification path; when no automated end-to-end gate exists, the Spec should say there is no EAG.
+_Avoid_: test checklist, unit test plan, acceptance case list, manual acceptance step
+
+**Design Detail**:
+The `## Design Detail` section in `design.md` that carries lower-review-frequency design reasoning, trade-offs, architecture notes, and verification strategy.
+_Avoid_: design summary, main design
+
 **Steps File**:
 The `steps.md` Spec Supporting File that records implementation and verification by Plan Step. It does not split implementation and verification into separate global sections.
 _Avoid_: implementation log, verification log
 
 **Spec Template**:
-The built-in Markdown skeletons used by the CLI to create a new Spec layout. They define initial sections with brief placeholders, not examples, subsection templates, or detailed writing guidance.
+The built-in Markdown skeletons used by the CLI to create a new Spec layout. They define initial sections and required subsections with brief placeholders, not examples or detailed writing guidance.
 _Avoid_: workflow instructions, writing rules
 
 **Skill**:
@@ -81,6 +97,18 @@ Maintainer: "Right. The main Skill routes the workflow, the Phase File explains 
 Developer: "Should the Design Phase also write the implementation checklist?"
 
 Maintainer: "No. The Design Phase records decisions and trade-offs; the Plan Phase turns that Design into a checklist."
+
+Developer: "When should the EAG be chosen?"
+
+Maintainer: "During the Design Phase. It is part of the Design Section, and later Plan or Implement work should use it as the end-to-end validation gate."
+
+Developer: "Where should the short version of the design go?"
+
+Maintainer: "The Design Section spans both files: put Design Summary in the Main Spec File for review, and keep Design Detail in `design.md` for the reasoning and supporting detail."
+
+Developer: "Should the acceptance gate list every test case?"
+
+Maintainer: "No. The EAG should be one small automated end-to-end gate whenever possible: the visible behavior to accept plus the command or path that verifies it. If no automated end-to-end gate exists, say there is no EAG."
 
 Developer: "When is a Spec ready for implementation?"
 

--- a/lib/template/design.md
+++ b/lib/template/design.md
@@ -4,6 +4,6 @@
 
 <!-- What facts, existing patterns, references, and constraints can inform the design? -->
 
-## Design
+## Design Detail
 
 <!-- Technical approach, architecture decisions, and test strategy. Each design decision should cite a fact source. -->

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -19,11 +19,11 @@ See [design.md](./design.md).
 
 <!-- Overall design approach and rationale. -->
 
+See [design.md](./design.md) for design detail.
+
 ### E2E Acceptance Gate (EAG)
 
 <!-- Automated end-to-end acceptance behavior and verification path, or state that there is no EAG. -->
-
-See [design.md](./design.md) for design detail.
 
 ## Plan
 

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -15,7 +15,15 @@ See [design.md](./design.md).
 
 ## Design
 
-See [design.md](./design.md).
+### Design Summary
+
+<!-- Overall design approach and rationale. -->
+
+### E2E Acceptance Gate (EAG)
+
+<!-- Automated end-to-end acceptance behavior and verification path, or state that there is no EAG. -->
+
+See [design.md](./design.md) for design detail.
 
 ## Plan
 

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -141,7 +141,7 @@ Use when the plan is ready for coding.
 Concrete section-writing guidance lives in the phase files:
 - `new.md` defines how to write `## Overview`.
 - `research.md` defines how to write `design.md` → `## Research`.
-- `design.md` defines how to write `design.md` → `## Design`.
+- `design.md` defines how to write the Design Section: `spec.md` → `## Design` for Design Summary and EAG, plus `design.md` → `## Design Detail`.
 - `plan.md` defines how to write `spec.md` → `## Plan` and `## Progress`.
 - `implement.md` defines how to update `spec.md` → `## Progress` and write `steps.md`.
 

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -16,16 +16,19 @@ Canonical workflow for designing an active change spec.
 5. Ask the user clarifying questions when needed.
 6. Wait for answers before finalizing the architecture when the open questions are consequential.
 7. Synthesize one recommended architecture by default, including the matching test strategy.
-8. Fill `design.md` → `## Design` with:
-   - Design Summary
-   - Design Decisions
-   - System Structure, optional
-   - Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
-   - System Procedure, optional
-   - Interfaces / APIs, optional
-   - Change Scope
-   - Edge Cases
-   - Verification Strategy
+8. Fill the Design Section:
+   - In `spec.md` → `## Design`, write:
+     - `### Design Summary`
+     - `### E2E Acceptance Gate (EAG)`
+   - In `design.md` → `## Design Detail`, write:
+     - Design Decisions
+     - System Structure, optional
+     - Prefer Mermaid for state transition diagrams, sequence diagrams, module diagrams, and other structured visuals; use ASCII only for quick sketches where Mermaid adds no clarity.
+     - System Procedure, optional
+     - Interfaces / APIs, optional
+     - Change Scope
+     - Edge Cases
+     - Verification Strategy
    - Use Design Summary to describe the overall design approach and rationale.
    - Use Change Scope as a two-part section:
      - Impact Areas: high-level affected modules, database/schema changes, architecture boundaries, API contracts, compatibility constraints, generated artifacts, and rollout impact.
@@ -41,3 +44,13 @@ Canonical workflow for designing an active change spec.
 
 ## Rule
 This is where decisions, trade-offs, and recommendations belong.
+
+### E2E Acceptance Gate (EAG)
+
+The EAG is the Design Section's automated end-to-end acceptance gate, not a general test plan. Use it as a small, preferably single, reviewer-facing handle for judging whether the Spec's validation proves the intended user- or system-visible behavior.
+
+Write both parts:
+- Acceptance behavior: the end-to-end behavior that must be true.
+- Verification path: the command, workflow, or automated check that proves it.
+
+Do not use unit tests, manual checks, or a broad case list as the EAG. If no automated end-to-end gate exists, state that there is no EAG.

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -564,12 +564,12 @@ test('zest-dev create integration', async (t) => {
       assert.ok(content.includes('See [design.md](./design.md).'), 'should reference design file naturally');
       assert.ok(content.includes('## Design'), 'should include Design section');
       assert.ok(content.includes('### Design Summary'), 'should include Design Summary subsection');
+      assert.ok(content.includes('### Design Summary\n\n<!-- Overall design approach and rationale. -->\n\nSee [design.md](./design.md) for design detail.'), 'should place the design detail link with the top-level Design section');
       assert.ok(content.includes('### E2E Acceptance Gate (EAG)'), 'should include EAG subsection');
       assert.ok(
         content.includes('Automated end-to-end acceptance behavior and verification path, or state that there is no EAG.'),
         'EAG placeholder should stay brief and require automated end-to-end verification or an explicit no-EAG statement'
       );
-      assert.ok(content.includes('See [design.md](./design.md) for design detail.'), 'should reference design detail naturally');
       assert.ok(content.includes('## Plan'), 'should include Plan section');
       assert.ok(content.includes('## Progress'), 'should include Progress section');
       assert.ok(content.includes('## Implementation'), 'should include Implementation section');

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -303,6 +303,12 @@ test('zest-dev init integration', async (t) => {
 
       const designPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/design.md'), 'utf-8');
       assert.ok(designPhase.includes('If the status is `designed`, `planned`, or `implemented`, confirm that the user wants to revise the existing design before continuing.'));
+      assert.ok(designPhase.includes('Fill the Design Section:'));
+      assert.ok(designPhase.includes('### E2E Acceptance Gate (EAG)'));
+      assert.ok(designPhase.includes("The EAG is the Design Section's automated end-to-end acceptance gate, not a general test plan."));
+      assert.ok(designPhase.includes('`### E2E Acceptance Gate (EAG)`'));
+      assert.ok(designPhase.includes('small, preferably single, reviewer-facing handle'));
+      assert.ok(designPhase.includes('If no automated end-to-end gate exists, state that there is no EAG.'));
 
       const planPhase = fs.readFileSync(path.join(globalOpenCodeSkillsDir, 'zest-dev/plan.md'), 'utf-8');
       assert.ok(planPhase.includes('If the spec started as `designed`, run `zest-dev update active planned`.'));
@@ -557,6 +563,13 @@ test('zest-dev create integration', async (t) => {
       assert.ok(content.includes('## Research'), 'should include Research section');
       assert.ok(content.includes('See [design.md](./design.md).'), 'should reference design file naturally');
       assert.ok(content.includes('## Design'), 'should include Design section');
+      assert.ok(content.includes('### Design Summary'), 'should include Design Summary subsection');
+      assert.ok(content.includes('### E2E Acceptance Gate (EAG)'), 'should include EAG subsection');
+      assert.ok(
+        content.includes('Automated end-to-end acceptance behavior and verification path, or state that there is no EAG.'),
+        'EAG placeholder should stay brief and require automated end-to-end verification or an explicit no-EAG statement'
+      );
+      assert.ok(content.includes('See [design.md](./design.md) for design detail.'), 'should reference design detail naturally');
       assert.ok(content.includes('## Plan'), 'should include Plan section');
       assert.ok(content.includes('## Progress'), 'should include Progress section');
       assert.ok(content.includes('## Implementation'), 'should include Implementation section');
@@ -574,7 +587,8 @@ test('zest-dev create integration', async (t) => {
       assert.equal(content.includes('Substep 1.1 Implement'), false);
       assert.equal(content.includes('## Notes'), false);
       assert.ok(designContent.includes('## Research'), 'design template should include Research section');
-      assert.ok(designContent.includes('## Design'), 'design template should include Design section');
+      assert.ok(designContent.includes('## Design Detail'), 'design template should include Design Detail section');
+      assert.equal(designContent.includes('## Design\n'), false, 'design template should not keep the old Design section name');
       assert.ok(stepsContent.includes('## Step 1'), 'steps template should include an initial step section');
       assert.equal(stepsContent.includes('## Implementation'), false, 'steps template should not split implementation globally');
       assert.equal(stepsContent.includes('## Verification'), false, 'steps template should not split verification globally');


### PR DESCRIPTION
## Summary

- Add `Design Summary` and `E2E Acceptance Gate (EAG)` subsections to the main `spec.md` Design section.
- Rename the supporting `design.md` design section to `## Design Detail`.
- Update Zest Dev design-phase guidance and integration tests for the new Design Section split and automated EAG rules.
- Capture the resolved terminology in `CONTEXT.md`.

## Validation

- `pnpm test:local`
- `pnpm test:package`

Closes #85