### PR TITLE
feat(spec): add deferred follow-ups section

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,9 +72,17 @@ _Avoid_: designed, ready
 One issue-scale implementation slice inside a Spec's Plan section. A Plan Step has a Type that describes whether the next implementer can proceed independently or needs human input.
 _Avoid_: task, ticket
 
+**Documentation Sync**:
+The final Plan Step that checks whether the current implementation changed documented behavior, usage, commands, setup, or workflows, and updates relevant project documentation when needed. It is part of the current Spec's implementation work, not a Deferred Follow-Up.
+_Avoid_: documentation follow-up
+
 **Progress Checklist**:
 A thin completion checklist in the Main Spec File, with one checkbox per Plan Step. It tracks implementation completion; it is not the implementation plan itself.
 _Avoid_: plan, task list, notes
+
+**Deferred Follow-Ups (DFU)**:
+A final Main Spec File section for follow-up items explicitly deferred out of the current Spec during Design because they should be done only after the current Spec is complete. DFU is fixed as part of the Design Phase and is not part of the Plan or Progress Checklist.
+_Avoid_: backlog, future tasks, documentation follow-up
 
 **Ralph Task**:
 A markdown checkbox item consumed by Ralph Tasks Mode from `.ralph/ralph-tasks.md`. It is generated from a Progress Checklist item when Zest Dev hands planned work to Ralph.

--- a/e2e/tests/conftest.py
+++ b/e2e/tests/conftest.py
@@ -34,6 +34,10 @@ FINAL_RALPH_TASK = (
     "Make sure all tasks are done in ralph loops, and then create PR. "
     "If there is a related issue, make sure to link it in the PR."
 )
+DFU_RALPH_TASK = (
+    "If the spec has Deferred Follow-Ups (DFU), create one GitHub issue "
+    "for each DFU item and link those issues in the PR."
+)
 
 
 class Cli:

--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -86,7 +86,7 @@ def test_default_global_init_deploys_expected_artifacts(cli):
 
     skill_content = (skills_dir / "zest-dev" / "SKILL.md").read_text(encoding="utf-8")
     assert "This skill defines the workflow for planned feature work" in skill_content
-    assert "always include a final documentation follow-up step" in skill_content
+    assert "always include a final Documentation Sync step" in skill_content
     for filename in SKILL_PHASE_FILES:
         assert (skills_dir / "zest-dev" / filename).exists()
 
@@ -101,6 +101,8 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "`### E2E Acceptance Gate (EAG)`" in design_phase
     assert "small, preferably single, reviewer-facing handle" in design_phase
     assert "If no automated end-to-end gate exists, state that there is no EAG." in design_phase
+    assert "## Deferred Follow-Ups (DFU)" in design_phase
+    assert "write `None.` when the Design defers no follow-up work" in design_phase
 
     plan_phase = (skills_dir / "zest-dev" / "plan.md").read_text(encoding="utf-8")
     assert "If the spec started as `designed`, run `zest-dev update active planned`." in plan_phase
@@ -108,6 +110,7 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that." in plan_phase
     assert "Do not use markdown checkboxes in `## Plan`." in plan_phase
     assert "Add or update `spec.md` → `## Progress` with a thin progress checklist:" in plan_phase
+    assert "### Step 3: Documentation Sync" in plan_phase
     assert "Report every Plan step's `Type` as `AFK` or `HITL`." in plan_phase
     assert "For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues." in plan_phase
 
@@ -115,6 +118,7 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "try to use the registered `tdd` skill" in implement_phase
     assert "judge applicability from the spec, plan step, and files being changed" in implement_phase
     assert "mark the corresponding `spec.md` → `## Progress` checkbox as `[x]`" in implement_phase
+    assert "DFU is fixed during the Design Phase" in implement_phase
     assert "mark the corresponding `## Plan` checkbox" not in implement_phase
 
     codex_skill = (codex_skill_dir / "SKILL.md").read_text(encoding="utf-8")

--- a/e2e/tests/test_ralph.py
+++ b/e2e/tests/test_ralph.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from conftest import (
+    DFU_RALPH_TASK,
     FINAL_RALPH_TASK,
     create_active_spec_with_body,
     fake_ralph_env,
@@ -48,6 +49,7 @@ See [steps.md](./steps.md).
         "Step 1: Parse active Progress into task text",
         "Step 3: Write implement prompt file",
         FINAL_RALPH_TASK,
+        DFU_RALPH_TASK,
     ]
     assert output["tasks_added"] == tasks
     assert "ralph_results" not in output
@@ -92,6 +94,7 @@ Legacy spec.
         "Step 1: Preserve legacy Ralph handoff",
         "Step 3: Keep split layout support",
         FINAL_RALPH_TASK,
+        DFU_RALPH_TASK,
     ]
     assert output["tasks_added"] == tasks
 

--- a/e2e/tests/test_ralph.py
+++ b/e2e/tests/test_ralph.py
@@ -48,8 +48,8 @@ See [steps.md](./steps.md).
     assert tasks == [
         "Step 1: Parse active Progress into task text",
         "Step 3: Write implement prompt file",
-        FINAL_RALPH_TASK,
         DFU_RALPH_TASK,
+        FINAL_RALPH_TASK,
     ]
     assert output["tasks_added"] == tasks
     assert "ralph_results" not in output
@@ -93,8 +93,8 @@ Legacy spec.
     assert tasks == [
         "Step 1: Preserve legacy Ralph handoff",
         "Step 3: Keep split layout support",
-        FINAL_RALPH_TASK,
         DFU_RALPH_TASK,
+        FINAL_RALPH_TASK,
     ]
     assert output["tasks_added"] == tasks
 

--- a/e2e/tests/test_spec_lifecycle.py
+++ b/e2e/tests/test_spec_lifecycle.py
@@ -41,6 +41,8 @@ def test_create_uses_builtin_split_templates(cli):
     assert "## Progress" in content
     assert "## Implementation" in content
     assert "See [steps.md](./steps.md)." in content
+    assert "## Deferred Follow-Ups (DFU)" in content
+    assert "Follow-up items deferred out of this Spec during Design, or None." in content
     assert "Optional completion checklist, created during Plan and updated during Implement." not in content
     assert "Optional implementation step breakdown, created during Plan." in content
     assert "Use markdown checkboxes for all step and substep items" not in content

--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -5,6 +5,7 @@ const { getSpec } = require('./spec-manager');
 const { generatePrompt } = require('./prompt-generator');
 
 const FINAL_RALPH_TASK = 'Make sure all tasks are done in ralph loops, and then create PR. If there is a related issue, make sure to link it in the PR.';
+const DFU_RALPH_TASK = 'If the spec has Deferred Follow-Ups (DFU), create one GitHub issue for each DFU item and link those issues in the PR.';
 
 function findSection(content, heading) {
   const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -95,7 +96,7 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
   const spec = getSpec('active');
   const specContent = fs.readFileSync(spec.path, 'utf-8');
   const progressTasks = parseProgressTasks(specContent);
-  const tasks = [...progressTasks, FINAL_RALPH_TASK];
+  const tasks = [...progressTasks, FINAL_RALPH_TASK, DFU_RALPH_TASK];
   const ralphDir = path.join(cwd, '.ralph');
 
   fs.rmSync(ralphDir, { recursive: true, force: true });
@@ -122,6 +123,7 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
 }
 
 module.exports = {
+  DFU_RALPH_TASK,
   FINAL_RALPH_TASK,
   parseProgressTasks,
   setupRalphFromActiveSpec

--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -96,7 +96,7 @@ function setupRalphFromActiveSpec(cwd = process.cwd()) {
   const spec = getSpec('active');
   const specContent = fs.readFileSync(spec.path, 'utf-8');
   const progressTasks = parseProgressTasks(specContent);
-  const tasks = [...progressTasks, FINAL_RALPH_TASK, DFU_RALPH_TASK];
+  const tasks = [...progressTasks, DFU_RALPH_TASK, FINAL_RALPH_TASK];
   const ralphDir = path.join(cwd, '.ralph');
 
   fs.rmSync(ralphDir, { recursive: true, force: true });

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -34,3 +34,7 @@ See [design.md](./design.md) for design detail.
 ## Implementation
 
 See [steps.md](./steps.md).
+
+## Deferred Follow-Ups (DFU)
+
+<!-- Follow-up items deferred out of this Spec during Design, or None. -->

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -125,12 +125,12 @@ Use when the plan is ready for coding.
 
 ### Design
 - The canonical Design workflow lives in `design.md`.
-- Use it for clarifications, architecture synthesis, design decisions, and status advancement to `designed`.
+- Use it for clarifications, architecture synthesis, design decisions, Deferred Follow-Ups (DFU), and status advancement to `designed`.
 
 ### Plan
 - The canonical Plan workflow lives in `plan.md`.
 - Use it for issue-scale step shaping and status advancement to `planned`.
-- During planning, always include a final documentation follow-up step that tells the implementer to update relevant project documentation if the implemented change makes that necessary.
+- During planning, always include a final Documentation Sync step that tells the implementer to update relevant project documentation if the implemented change makes that necessary.
 
 ### Implement
 - The canonical Implement workflow lives in `implement.md`.
@@ -141,7 +141,7 @@ Use when the plan is ready for coding.
 Concrete section-writing guidance lives in the phase files:
 - `new.md` defines how to write `## Overview`.
 - `research.md` defines how to write `design.md` → `## Research`.
-- `design.md` defines how to write the Design Section: `spec.md` → `## Design` for Design Summary and EAG, plus `design.md` → `## Design Detail`.
+- `design.md` defines how to write the Design Section: `spec.md` → `## Design` for Design Summary and EAG, `spec.md` → `## Deferred Follow-Ups (DFU)`, plus `design.md` → `## Design Detail`.
 - `plan.md` defines how to write `spec.md` → `## Plan` and `## Progress`.
 - `implement.md` defines how to update `spec.md` → `## Progress` and write `steps.md`.
 

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -20,6 +20,7 @@ Canonical workflow for designing an active change spec.
    - In `spec.md` → `## Design`, write:
      - `### Design Summary`
      - `### E2E Acceptance Gate (EAG)`
+   - In `spec.md` → `## Deferred Follow-Ups (DFU)`, write deferred follow-up items as concise bullets, or write `None.` when the Design defers no follow-up work.
    - In `design.md` → `## Design Detail`, write:
      - Design Decisions
      - System Structure, optional
@@ -35,6 +36,8 @@ Canonical workflow for designing an active change spec.
      - Planned File Changes: concrete files or directories expected to change, plus a brief note about each planned modification.
    - Do not add `Source:` citations inside Change Scope items.
    - Put execution sequencing in `## Plan` during the Plan phase.
+   - Use DFU only for follow-up work intentionally deferred out of the current Spec and meant to happen after this Spec is complete.
+   - Do not put current-Spec implementation work, Documentation Sync work, or Progress items in DFU.
    - List all design decisions.
    - Every design decision must cite its fact source inline or immediately adjacent to it.
    - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -18,8 +18,9 @@ Canonical workflow for implementing an active change spec.
     - what changed
     - how the step was verified
     - any design deviation or follow-up relevant to that step
-10. If the full spec is complete, run `zest-dev update active implemented`.
-11. If only part of the work is complete, keep the current non-final status and document what was done.
+10. Do not add new Deferred Follow-Ups (DFU) during implementation. DFU is fixed during the Design Phase; if implementation reveals missing deferred work that changes the Design boundary, revise the Design instead of silently appending DFU.
+11. If the full spec is complete, run `zest-dev update active implemented`.
+12. If only part of the work is complete, keep the current non-final status and document what was done.
 
 ## Rule
 Only mark the spec `implemented` when the whole plan is finished.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -22,7 +22,7 @@ Canonical workflow for planning implementation of an active change spec.
    - Do not mark a step as `HITL` merely because the output is documentation, runbook text, an operator-facing procedure, or a workflow that humans will later execute.
    - Mark steps as `AFK` when an agent can implement them independently from the written spec and repository context.
    - Capture dependencies between steps.
-5. Add a final Plan step for documentation follow-up:
+5. Add a final Plan step for Documentation Sync:
    - Always include this as the final Plan step.
    - The step should tell the implementer to update relevant project documentation if the implemented change makes that necessary.
    - Do not decide during planning whether documentation must change. Leave that check to implementation, when the final code and behavior are visible.
@@ -55,7 +55,7 @@ Canonical workflow for planning implementation of an active change spec.
       Scope: Confirm the behavior with the user, then update Bar prompts and docs.
       Depends on: Step 1
 
-      ### Step 3: Documentation Follow-Up
+      ### Step 3: Documentation Sync
 
       Type: AFK
       Goal: Keep project documentation aligned with the implemented behavior.
@@ -66,6 +66,7 @@ Canonical workflow for planning implementation of an active change spec.
    - Add one checkbox per Plan step.
    - Keep each checklist item to the step title only.
    - This checklist is for implementation progress tracking, not for describing the plan.
+   - Do not include Deferred Follow-Ups (DFU), because DFU is outside the current Spec's Plan.
    - Format:
       ```markdown
       ## Progress

--- a/specs/change/20260614-dfu-spec-section/design.md
+++ b/specs/change/20260614-dfu-spec-section/design.md
@@ -1,0 +1,39 @@
+# Design
+
+## Research
+
+- Issue #89 asks for a separate Spec section at the end for follow-up items deferred out of the current Spec, because those items become accurately describable only after the current Spec is complete. Source: https://github.com/nettee/zest-dev/issues/89
+- The current built-in main Spec template ends with `## Progress` and `## Implementation`, with implementation detail linked to `steps.md`. Source: `lib/template/spec.md`
+- The Design Phase currently owns Design Summary and EAG content, while Plan owns Plan/Progress and Implement owns Progress/steps updates. Source: `skills/zest-dev/design.md`; `skills/zest-dev/plan.md`; `skills/zest-dev/implement.md`
+- `zest-dev ralph` currently converts unfinished Progress checkboxes into Ralph tasks and appends one fixed PR task. Source: `lib/ralph-setup.js`
+
+## Design Detail
+
+### Design Decisions
+
+- Decision: Add `## Deferred Follow-Ups (DFU)` after `## Implementation` in the main Spec template so it is visibly last and belongs to the whole Spec lifecycle. Source: user decision; `lib/template/spec.md`
+- Decision: DFU is fixed during the Design Phase. The Design workflow must write concise bullets or `None.`, and Implement must not silently append DFU items. Source: user decision; `skills/zest-dev/design.md`; `skills/zest-dev/implement.md`
+- Decision: Keep DFU outside Plan and Progress. `Documentation Follow-Up` is renamed to `Documentation Sync` to preserve the current final documentation step without confusing it with DFU. Source: user decision; `skills/zest-dev/plan.md`; `CONTEXT.md`
+- Decision: `zest-dev ralph` should stay simple and append one additional fixed Ralph task for DFU issue creation/linking after the existing PR task. Source: user decision; `lib/ralph-setup.js`
+
+### Change Scope
+
+Impact Areas:
+- Built-in Spec template gains a final DFU section.
+- Zest Dev skill guidance defines Design ownership, Plan exclusion, Implement immutability, and Documentation Sync naming.
+- Ralph setup appends a DFU handoff task.
+- E2E tests assert template, deployment, and Ralph task behavior.
+
+Planned File Changes:
+- `CONTEXT.md`: add glossary terms for DFU and Documentation Sync.
+- `lib/template/spec.md`: add `## Deferred Follow-Ups (DFU)` after `## Implementation`.
+- `skills/zest-dev/SKILL.md`: route DFU to Design and rename the final documentation step to Documentation Sync.
+- `skills/zest-dev/design.md`: require DFU bullets or `None.` during Design.
+- `skills/zest-dev/plan.md`: rename the final documentation step and keep DFU out of Progress.
+- `skills/zest-dev/implement.md`: prohibit adding DFU during implementation without revising Design.
+- `lib/ralph-setup.js`: append the DFU Ralph task.
+- `e2e/tests/*`: update assertions for new template, deployed skill text, and Ralph tasks.
+
+### Verification Strategy
+
+- Run `pnpm test:local` and `pnpm test:package` to cover local and packaged CLI lifecycle, deployment artifacts, and Ralph task generation.

--- a/specs/change/20260614-dfu-spec-section/spec.md
+++ b/specs/change/20260614-dfu-spec-section/spec.md
@@ -1,0 +1,65 @@
+---
+id: 20260614-dfu-spec-section
+name: Dfu Spec Section
+status: implemented
+created: '2026-06-14'
+---
+
+## Overview
+
+Add a first-class `## Deferred Follow-Ups (DFU)` section to Specs so Design can record follow-up work that is explicitly deferred until after the current Spec is complete.
+
+## Research
+
+See [design.md](./design.md).
+
+## Design
+
+### Design Summary
+
+Add DFU as a final main `spec.md` section after `## Implementation`. The Design Phase owns DFU content and must write concise bullets or `None.`; Plan, Progress, Implement, and Ralph keep DFU outside the current Spec's implementation work.
+
+See [design.md](./design.md) for design detail.
+
+### E2E Acceptance Gate (EAG)
+
+Acceptance behavior: creating a new Spec includes `## Deferred Follow-Ups (DFU)`, deployed workflow guidance documents DFU as Design-owned, and `zest-dev ralph` appends a DFU issue-linking Ralph task.
+
+Verification path: `pnpm test:local` and `pnpm test:package`
+
+## Plan
+
+### Step 1: Add DFU Template And Workflow Guidance
+
+Type: AFK
+Goal: Make DFU a canonical main Spec section owned by the Design Phase.
+Scope: Update the built-in Spec template, Zest Dev skill guidance, glossary, and deployment assertions.
+Depends on: None
+
+### Step 2: Add Ralph DFU Handoff Task
+
+Type: AFK
+Goal: Make Ralph handoff include a final reminder to create and link issues for DFU items.
+Scope: Update Ralph setup constants and E2E tests for generated tasks.
+Depends on: Step 1
+
+### Step 3: Documentation Sync
+
+Type: AFK
+Goal: Keep project documentation aligned with the implemented behavior.
+Scope: If the implementation changes documented behavior, usage, commands, setup, or workflows, update the relevant project docs.
+Depends on: Step 2
+
+## Progress
+
+- [x] Step 1: Add DFU Template And Workflow Guidance
+- [x] Step 2: Add Ralph DFU Handoff Task
+- [x] Step 3: Documentation Sync
+
+## Implementation
+
+See [steps.md](./steps.md).
+
+## Deferred Follow-Ups (DFU)
+
+None.

--- a/specs/change/20260614-dfu-spec-section/steps.md
+++ b/specs/change/20260614-dfu-spec-section/steps.md
@@ -1,0 +1,20 @@
+# Steps
+
+## Step 1
+
+- Added `## Deferred Follow-Ups (DFU)` to the built-in main Spec template after `## Implementation`.
+- Updated Zest Dev workflow guidance so Design owns DFU, Plan excludes DFU from Progress, Implement does not append DFU, and the final documentation Plan step is named Documentation Sync.
+- Added glossary entries for Deferred Follow-Ups (DFU) and Documentation Sync.
+- Verified with `pnpm test:local` and `pnpm test:package`.
+
+## Step 2
+
+- Added a fixed DFU Ralph task after the existing PR task in `lib/ralph-setup.js`.
+- Updated Ralph E2E fixtures and assertions to expect the extra task.
+- Verified with `pnpm test:local` and `pnpm test:package`.
+
+## Step 3
+
+- Updated deployed skill assertions and spec lifecycle tests for the new DFU section and Documentation Sync wording.
+- No extra project docs beyond glossary and skill workflow docs were needed.
+- Verified with `pnpm test:local` and `pnpm test:package`.


### PR DESCRIPTION
## Summary

- Add `## Deferred Follow-Ups (DFU)` as the final main Spec section after `## Implementation`.
- Make DFU a Design Phase output with concise bullets or `None.`, outside Plan and Progress.
- Rename the final documentation Plan step to `Documentation Sync` to avoid follow-up terminology confusion.
- Append a Ralph handoff task that asks the implementer to create and link issues for DFU items.

Closes #89.

## Validation

- `pnpm test:local`
- `pnpm test:package`