### PR TITLE
Clarify DFU criteria for explicit user confirmation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,7 +81,7 @@ A thin completion checklist in the Main Spec File, with one checkbox per Plan St
 _Avoid_: plan, task list, notes
 
 **Deferred Follow-Ups (DFU)**:
-A final Main Spec File section for follow-up items explicitly deferred out of the current Spec during Design because they should be done only after the current Spec is complete. DFU is fixed as part of the Design Phase and is not part of the Plan or Progress Checklist.
+A final Main Spec File section for follow-up items explicitly deferred out of the current Spec during Design because they should be done only after the current Spec is complete. Add DFU only when the user explicitly wants to handle that work later, or when a clear functional gap is discovered and confirmed with the user first. DFU is fixed as part of the Design Phase and is not part of the Plan or Progress Checklist.
 _Avoid_: backlog, future tasks, documentation follow-up
 
 **Ralph Task**:

--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -103,6 +103,8 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "If no automated end-to-end gate exists, state that there is no EAG." in design_phase
     assert "## Deferred Follow-Ups (DFU)" in design_phase
     assert "write `None.` when the Design defers no follow-up work" in design_phase
+    assert "Add DFU items only when the user explicitly says they want to handle that work later" in design_phase
+    assert "Do not add DFU items on your own initiative." in design_phase
 
     plan_phase = (skills_dir / "zest-dev" / "plan.md").read_text(encoding="utf-8")
     assert "If the spec started as `designed`, run `zest-dev update active planned`." in plan_phase
@@ -119,6 +121,7 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "judge applicability from the spec, plan step, and files being changed" in implement_phase
     assert "mark the corresponding `spec.md` → `## Progress` checkbox as `[x]`" in implement_phase
     assert "DFU is fixed during the Design Phase" in implement_phase
+    assert "confirm the DFU with the user instead of silently appending it" in implement_phase
     assert "mark the corresponding `## Plan` checkbox" not in implement_phase
 
     codex_skill = (codex_skill_dir / "SKILL.md").read_text(encoding="utf-8")

--- a/e2e/tests/test_spec_lifecycle.py
+++ b/e2e/tests/test_spec_lifecycle.py
@@ -42,7 +42,7 @@ def test_create_uses_builtin_split_templates(cli):
     assert "## Implementation" in content
     assert "See [steps.md](./steps.md)." in content
     assert "## Deferred Follow-Ups (DFU)" in content
-    assert "Follow-up items deferred out of this Spec during Design, or None." in content
+    assert "Follow-up items deferred out of this Spec during Design only when the user explicitly wants them handled later or confirms a discovered functional gap, or None." in content
     assert "Optional completion checklist, created during Plan and updated during Implement." not in content
     assert "Optional implementation step breakdown, created during Plan." in content
     assert "Use markdown checkboxes for all step and substep items" not in content

--- a/lib/template/spec.md
+++ b/lib/template/spec.md
@@ -37,4 +37,4 @@ See [steps.md](./steps.md).
 
 ## Deferred Follow-Ups (DFU)
 
-<!-- Follow-up items deferred out of this Spec during Design, or None. -->
+<!-- Follow-up items deferred out of this Spec during Design only when the user explicitly wants them handled later or confirms a discovered functional gap, or None. -->

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -37,6 +37,8 @@ Canonical workflow for designing an active change spec.
    - Do not add `Source:` citations inside Change Scope items.
    - Put execution sequencing in `## Plan` during the Plan phase.
    - Use DFU only for follow-up work intentionally deferred out of the current Spec and meant to happen after this Spec is complete.
+   - Add DFU items only when the user explicitly says they want to handle that work later, or when a clear functional gap is discovered and you confirm with the user before placing it into DFU.
+   - Do not add DFU items on your own initiative.
    - Do not put current-Spec implementation work, Documentation Sync work, or Progress items in DFU.
    - List all design decisions.
    - Every design decision must cite its fact source inline or immediately adjacent to it.

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -18,7 +18,7 @@ Canonical workflow for implementing an active change spec.
     - what changed
     - how the step was verified
     - any design deviation or follow-up relevant to that step
-10. Do not add new Deferred Follow-Ups (DFU) during implementation. DFU is fixed during the Design Phase; if implementation reveals missing deferred work that changes the Design boundary, revise the Design instead of silently appending DFU.
+10. Do not add new Deferred Follow-Ups (DFU) during implementation. DFU is fixed during the Design Phase; if implementation reveals missing deferred work that changes the Design boundary, revise the Design and confirm the DFU with the user instead of silently appending it.
 11. If the full spec is complete, run `zest-dev update active implemented`.
 12. If only part of the work is complete, keep the current non-final status and document what was done.
 


### PR DESCRIPTION
## Summary
- require explicit user direction or confirmed functional gaps before adding DFU items
- keep implementation guidance aligned so DFU is never appended without user confirmation
- update template and E2E assertions to lock the wording in

## Validation
- `pnpm test:local`

Closes #93

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>