### PR TITLE
feat: add dedicated EAG validation plan step

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,8 +72,12 @@ _Avoid_: designed, ready
 One issue-scale implementation slice inside a Spec's Plan section. A Plan Step has a Type that describes whether the next implementer can proceed independently or needs human input.
 _Avoid_: task, ticket
 
+**EAG Validation**:
+The Plan Step that comes after the functional implementation steps and before Documentation Sync. It validates the completed change against the Design section's EAG, or explicitly confirms that the Design says there is no EAG and uses the best available Spec-defined validation.
+_Avoid_: general test plan, documentation step
+
 **Documentation Sync**:
-The final Plan Step that checks whether the current implementation changed documented behavior, usage, commands, setup, or workflows, and updates relevant project documentation when needed. It is part of the current Spec's implementation work, not a Deferred Follow-Up.
+The final Plan Step, after EAG Validation, that checks whether the current implementation changed documented behavior, usage, commands, setup, or workflows, and updates relevant project documentation when needed. It is part of the current Spec's implementation work, not a Deferred Follow-Up.
 _Avoid_: documentation follow-up
 
 **Progress Checklist**:
@@ -113,6 +117,10 @@ Maintainer: "No. The Design Phase records decisions and trade-offs; the Plan Pha
 Developer: "When should the EAG be chosen?"
 
 Maintainer: "During the Design Phase. It is part of the Design Section, and later Plan or Implement work should use it as the end-to-end validation gate."
+
+Developer: "Where does that validation show up in the Plan?"
+
+Maintainer: "As its own EAG Validation step after the functional changes and before Documentation Sync."
 
 Developer: "Where should the short version of the design go?"
 

--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -90,6 +90,9 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     for filename in SKILL_PHASE_FILES:
         assert (skills_dir / "zest-dev" / filename).exists()
 
+    brainstorming_skill = (skills_dir / "brainstorming" / "SKILL.md").read_text(encoding="utf-8")
+    assert "include a dedicated `EAG Validation` step before the final `Documentation Sync` step" in brainstorming_skill
+
     research_phase = (skills_dir / "zest-dev" / "research.md").read_text(encoding="utf-8")
     assert "Summarize your understanding of the request and confirm it with the user" in research_phase
 

--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -86,7 +86,7 @@ def test_default_global_init_deploys_expected_artifacts(cli):
 
     skill_content = (skills_dir / "zest-dev" / "SKILL.md").read_text(encoding="utf-8")
     assert "This skill defines the workflow for planned feature work" in skill_content
-    assert "always include a final Documentation Sync step" in skill_content
+    assert "always include a dedicated EAG Validation step before the final Documentation Sync step" in skill_content
     for filename in SKILL_PHASE_FILES:
         assert (skills_dir / "zest-dev" / filename).exists()
 
@@ -110,7 +110,8 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that." in plan_phase
     assert "Do not use markdown checkboxes in `## Plan`." in plan_phase
     assert "Add or update `spec.md` → `## Progress` with a thin progress checklist:" in plan_phase
-    assert "### Step 3: Documentation Sync" in plan_phase
+    assert "### Step 3: EAG Validation" in plan_phase
+    assert "### Step 4: Documentation Sync" in plan_phase
     assert "Report every Plan step's `Type` as `AFK` or `HITL`." in plan_phase
     assert "For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues." in plan_phase
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -26,7 +26,7 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design and plan** — in sections scaled to their complexity, get user approval after each section
-6. **Write Zest Dev spec** — use the `zest-dev` CLI to create or update a change spec in the standard Zest Dev spec location; when creating a new spec, immediately set it active with `zest-dev set-active <spec-id>`; write Overview, Research, Design, and Plan content
+6. **Write Zest Dev spec** — use the `zest-dev` CLI to create or update a change spec in the standard Zest Dev spec location; when creating a new spec, immediately set it active with `zest-dev set-active <spec-id>`; write Overview, Research, Design, and Plan content, and make the Plan include a dedicated `EAG Validation` step before the final `Documentation Sync` step
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **Mark planned** — check the current spec status and use the `zest-dev` CLI to advance it to `planned` only when needed
 
@@ -107,6 +107,7 @@ digraph brainstorming {
 - Create or update the relevant change spec in Zest Dev's standard spec directory.
 - If you create a new spec with `zest-dev create <slug>`, immediately set the created spec active with `zest-dev set-active <spec-id>` before editing or advancing it.
 - Write concise content for **Overview**, **Research**, **Design** and **Plan** sections.
+- When writing **Plan**, include a dedicated `EAG Validation` step after the functional implementation steps and before the final `Documentation Sync` step.
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 
 **Spec Self-Review:**
@@ -115,7 +116,8 @@ After writing the spec document, look at it with fresh eyes:
 1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
 2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
-4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+4. **Plan invariant check:** Does the Plan include a dedicated `EAG Validation` step before the final `Documentation Sync` step? Fix it if not.
+5. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
 
 Fix any issues inline. No need to re-review — just fix and move on.
 

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -130,7 +130,7 @@ Use when the plan is ready for coding.
 ### Plan
 - The canonical Plan workflow lives in `plan.md`.
 - Use it for issue-scale step shaping and status advancement to `planned`.
-- During planning, always include a final Documentation Sync step that tells the implementer to update relevant project documentation if the implemented change makes that necessary.
+- During planning, always include a dedicated EAG Validation step before the final Documentation Sync step.
 
 ### Implement
 - The canonical Implement workflow lives in `implement.md`.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -22,14 +22,19 @@ Canonical workflow for planning implementation of an active change spec.
    - Do not mark a step as `HITL` merely because the output is documentation, runbook text, an operator-facing procedure, or a workflow that humans will later execute.
    - Mark steps as `AFK` when an agent can implement them independently from the written spec and repository context.
    - Capture dependencies between steps.
-5. Add a final Plan step for Documentation Sync:
+5. Add a dedicated Plan step for EAG Validation:
+   - Place it after the functional implementation steps and before Documentation Sync.
+   - The step should tell the implementer to validate the completed change against the Design section's EAG.
+   - When the Design says there is no EAG, the step should explicitly confirm that no dedicated automated end-to-end gate exists and use the best available validation already defined by the Spec.
+   - Do not redefine the EAG during planning. Reuse the Design section's acceptance behavior and verification path as written.
+6. Add a final Plan step for Documentation Sync:
    - Always include this as the final Plan step.
    - The step should tell the implementer to update relevant project documentation if the implemented change makes that necessary.
    - Do not decide during planning whether documentation must change. Leave that check to implementation, when the final code and behavior are visible.
    - Do not automatically include glossary or ADR work. Treat those as special documentation updates only when the implemented change genuinely calls for them.
-6. Ask the user clarifying questions when needed.
-7. Wait for answers before finalizing the plan when the open questions are consequential.
-8. Fill `## Plan` with compact structured steps:
+7. Ask the user clarifying questions when needed.
+8. Wait for answers before finalizing the plan when the open questions are consequential.
+9. Fill `## Plan` with compact structured steps:
    - Do not use markdown checkboxes in `## Plan`.
    - Keep the step label as `Step 1`, `Step 2`, and so on.
    - Prefer steps that each deliver one meaningful vertical slice and remain easy to review.
@@ -55,14 +60,21 @@ Canonical workflow for planning implementation of an active change spec.
       Scope: Confirm the behavior with the user, then update Bar prompts and docs.
       Depends on: Step 1
 
-      ### Step 3: Documentation Sync
+      ### Step 3: EAG Validation
+
+      Type: AFK
+      Goal: Validate the completed change against the Spec's EAG before wrap-up work.
+      Scope: Run the automated end-to-end verification path defined in the Design section, or confirm that the Design explicitly says there is no EAG and use the best available Spec-defined validation.
+      Depends on: Step 2
+
+      ### Step 4: Documentation Sync
 
       Type: AFK
       Goal: Keep project documentation aligned with the implemented behavior.
       Scope: If the implementation changes documented behavior, usage, commands, setup, or workflows, update the relevant project docs.
-      Depends on: Step 2
+      Depends on: Step 3
       ```
-9. Add or update `spec.md` → `## Progress` with a thin progress checklist:
+10. Add or update `spec.md` → `## Progress` with a thin progress checklist:
    - Add one checkbox per Plan step.
    - Keep each checklist item to the step title only.
    - This checklist is for implementation progress tracking, not for describing the plan.
@@ -74,11 +86,11 @@ Canonical workflow for planning implementation of an active change spec.
       - [ ] Step 1: Foo
       - [ ] Step 2: Bar
       ```
-10. Update status based on the starting state:
+11. Update status based on the starting state:
    - If the spec started as `designed`, run `zest-dev update active planned`.
    - If the spec started as `planned`, skip the update and keep the status as-is.
    - If the spec started as `implemented`, skip the update and keep the status as-is while revising the plan.
-11. Present the plan and stop:
+12. Present the plan and stop:
    - Report every Plan step's `Type` as `AFK` or `HITL`.
    - For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues.
    - If all steps are `AFK`, say that no user action is required before implementation.


### PR DESCRIPTION
## Summary
- add a dedicated `EAG Validation` Plan step after functional implementation work and before the final `Documentation Sync` step
- update the Zest Dev glossary and example dialogue so the new step ordering is part of the documented workflow language
- update deployment assertions to verify the shipped skill text and example Plan sequence

## Testing
- `pnpm test:local`

Closes #92

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>