### PR TITLE
Limit Ralph tasks to leading AFK steps

### DIFF
--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -115,8 +115,9 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that." in plan_phase
     assert "Do not use markdown checkboxes in `## Plan`." in plan_phase
     assert "Add or update `spec.md` → `## Progress` with a thin progress checklist:" in plan_phase
-    assert "### Step 3: EAG Validation" in plan_phase
-    assert "### Step 4: Documentation Sync" in plan_phase
+    assert "### Step 3 (AFK): EAG Validation" in plan_phase
+    assert "### Step 4 (AFK): Documentation Sync" in plan_phase
+    assert "Step N (AFK): ..." in plan_phase
     assert "Report every Plan step's `Type` as `AFK` or `HITL`." in plan_phase
     assert "For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues." in plan_phase
 

--- a/e2e/tests/test_ralph.py
+++ b/e2e/tests/test_ralph.py
@@ -99,6 +99,44 @@ Legacy spec.
     assert output["tasks_added"] == tasks
 
 
+def test_ralph_only_adds_leading_afk_progress_tasks(cli):
+    create_active_spec_with_body(
+        cli,
+        "ralph-leading-afk-progress",
+        """---
+id: test-ralph-leading-afk-progress
+name: Ralph Leading AFK Progress
+status: planned
+created: '2026-06-04'
+---
+
+## Overview
+
+Test spec.
+
+## Progress
+
+- [ ] Step 1 (AFK): AMR API Admin Grant
+- [ ] Step 2 (AFK): Admin Grant Workflow
+- [ ] Step 3 (AFK): Wallet Source Copy
+- [ ] Step 4 (HITL): Test/Production Secret Setup
+- [ ] Step 5 (AFK): Should not enter Ralph after HITL
+
+""",
+    )
+    output = cli.yaml("ralph", env=fake_ralph_env(cli.project_dir))
+    tasks = read_fake_ralph_tasks(cli.project_dir)
+
+    assert tasks == [
+        "Step 1 (AFK): AMR API Admin Grant",
+        "Step 2 (AFK): Admin Grant Workflow",
+        "Step 3 (AFK): Wallet Source Copy",
+        DFU_RALPH_TASK,
+        FINAL_RALPH_TASK,
+    ]
+    assert output["tasks_added"] == tasks
+
+
 def test_ralph_failure_cases_do_not_write_outputs(cli):
     create_active_spec_with_body(
         cli,
@@ -167,5 +205,26 @@ created: '2026-06-04'
     )
     failed = cli.fail("ralph", env=fake_ralph_env(project))
     assert "Unsupported Progress line: - [/] Step 1: In progress is not supported" in failed
+    assert not (project / ".ralph").exists()
+    assert not (project / "task.md").exists()
+
+    create_active_spec_with_body(
+        cli,
+        "ralph-mixed-progress-labels",
+        """---
+id: test-ralph-mixed-progress-labels
+name: Ralph Mixed Progress Labels
+status: planned
+created: '2026-06-04'
+---
+
+## Progress
+
+- [ ] Step 1 (AFK): Annotated
+- [ ] Step 2: Plain mixed into annotated Progress
+""",
+    )
+    failed = cli.fail("ralph", env=fake_ralph_env(project))
+    assert "Unsupported Progress line: - [ ] Step 2: Plain mixed into annotated Progress" in failed
     assert not (project / ".ralph").exists()
     assert not (project / "task.md").exists()

--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -41,6 +41,8 @@ function parseProgressTasks(specContent) {
 
   const tasks = [];
   let sawCheckbox = false;
+  let stoppedAtHitl = false;
+  let progressMode = null;
 
   for (const line of progress.split(/\r?\n/)) {
     if (line.trim() === '') {
@@ -54,8 +56,31 @@ function parseProgressTasks(specContent) {
 
     sawCheckbox = true;
     const marker = match[1].toLowerCase();
+    const taskText = match[2];
+    const stepMatch = taskText.match(/^Step \d+(?: \((AFK|HITL)\))?: .+$/);
+
+    if (!stepMatch) {
+      throw new Error(`Unsupported Progress line: ${line}`);
+    }
+
+    const lineMode = stepMatch[1] ? 'annotated' : 'plain';
+    if (progressMode === null) {
+      progressMode = lineMode;
+    } else if (progressMode !== lineMode) {
+      throw new Error(`Unsupported Progress line: ${line}`);
+    }
+
+    if (stoppedAtHitl) {
+      continue;
+    }
+
+    if (stepMatch[1] === 'HITL') {
+      stoppedAtHitl = true;
+      continue;
+    }
+
     if (marker === ' ') {
-      tasks.push(match[2]);
+      tasks.push(taskText);
     }
   }
 

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -13,7 +13,7 @@ Canonical workflow for implementing an active change spec.
 5. Implement the feature following the plan, design, and repository conventions.
 6. Write or update tests alongside the implementation, not afterward.
 7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
-8. After each completed plan step, mark the corresponding `spec.md` → `## Progress` checkbox as `[x]` only when that step is complete and relevant tests pass.
+8. After each completed plan step, mark the corresponding `spec.md` → `## Progress` checkbox as `[x]` only when that step is complete and relevant tests pass; preserve the `Step N (AFK): ...` or `Step N (HITL): ...` title format.
 9. Fill `steps.md` with one section per completed Plan step. Each section should briefly combine:
     - what changed
     - how the step was verified

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -36,40 +36,36 @@ Canonical workflow for planning implementation of an active change spec.
 8. Wait for answers before finalizing the plan when the open questions are consequential.
 9. Fill `## Plan` with compact structured steps:
    - Do not use markdown checkboxes in `## Plan`.
-   - Keep the step label as `Step 1`, `Step 2`, and so on.
+   - Put the step type directly after the step number in every step heading: `Step 1 (AFK): ...` or `Step 2 (HITL): ...`.
    - Prefer steps that each deliver one meaningful vertical slice and remain easy to review.
    - Good step boundaries usually align with one user-visible workflow, one subsystem integration boundary, one migration or rollout step, or one stabilization milestone.
    - Each step should be issue-scale: large enough to matter, small enough for a coding agent to implement and validate in one focused session.
    - Keep fields brief. Do not turn each step into a second design document.
-   - Include `Type`, `Goal`, `Scope`, and `Depends on`.
+   - Include `Goal`, `Scope`, and `Depends on`; the type belongs in the step heading, not as a separate field.
    - Use `Depends on: None` when the step has no dependency.
    - Add acceptance criteria only when they are necessary to remove ambiguity.
    - Format as structured prose, for example:
       ```markdown
-      ### Step 1: Foo
+      ### Step 1 (AFK): Foo
 
-      Type: AFK
       Goal: Deliver the smallest useful end-to-end Foo behavior.
       Scope: Update the Foo command path and its integration tests.
       Depends on: None
 
-      ### Step 2: Bar
+      ### Step 2 (HITL): Bar
 
-      Type: HITL
       Goal: Choose and apply the Bar user-facing behavior.
       Scope: Confirm the behavior with the user, then update Bar prompts and docs.
       Depends on: Step 1
 
-      ### Step 3: EAG Validation
+      ### Step 3 (AFK): EAG Validation
 
-      Type: AFK
       Goal: Validate the completed change against the Spec's EAG before wrap-up work.
       Scope: Run the automated end-to-end verification path defined in the Design section, or confirm that the Design explicitly says there is no EAG and use the best available Spec-defined validation.
       Depends on: Step 2
 
-      ### Step 4: Documentation Sync
+      ### Step 4 (AFK): Documentation Sync
 
-      Type: AFK
       Goal: Keep project documentation aligned with the implemented behavior.
       Scope: If the implementation changes documented behavior, usage, commands, setup, or workflows, update the relevant project docs.
       Depends on: Step 3
@@ -77,14 +73,15 @@ Canonical workflow for planning implementation of an active change spec.
 10. Add or update `spec.md` → `## Progress` with a thin progress checklist:
    - Add one checkbox per Plan step.
    - Keep each checklist item to the step title only.
+   - Preserve the step type marker after the step number, matching the Plan heading form: `Step N (AFK): ...` or `Step N (HITL): ...`.
    - This checklist is for implementation progress tracking, not for describing the plan.
    - Do not include Deferred Follow-Ups (DFU), because DFU is outside the current Spec's Plan.
    - Format:
       ```markdown
       ## Progress
 
-      - [ ] Step 1: Foo
-      - [ ] Step 2: Bar
+      - [ ] Step 1 (AFK): Foo
+      - [ ] Step 2 (HITL): Bar
       ```
 11. Update status based on the starting state:
    - If the spec started as `designed`, run `zest-dev update active planned`.


### PR DESCRIPTION
## Summary\n- Parse Ralph progress tasks as either all plain steps or typed AFK/HITL steps\n- Stop adding Ralph tasks at the first HITL step\n- Document Step N (AFK/HITL) markers in the Zest Dev plan/progress workflow\n\n## Tests\n- pnpm test:local