### PR TITLE
feat(cli): add issue dump/load

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: full spec, source of truth file
 A Markdown file inside a Spec directory that carries lower-review-frequency workflow detail, such as design research or step-by-step implementation records.
 _Avoid_: appendix, attachment
 
+**Issue Spec Representation**:
+A forge-neutral representation of a Spec stored in an issue body plus issue comments, with protocol metadata sufficient to reconstruct the Spec without relying on an LLM.
+_Avoid_: GitHub dump, issue attachment format
+
 **Design Section**:
 The conceptual Design area of a Spec. It spans the Main Spec File's Design section for high-frequency review content and `design.md` for lower-frequency Design Detail.
 _Avoid_: design file, design-only section

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The `zest-dev` CLI manages spec files. Use it to inspect and update specs outsid
 | `zest-dev unset-active` | Unset active change spec |
 | `zest-dev update <spec-id\|active> <status>` | Update spec status |
 | `zest-dev create-branch` | Create a git branch from the active change spec |
+| `zest-dev dump <spec-id\|active> [--dry-run]` | Archive a spec as an issue representation or GitHub issue |
+| `zest-dev load [issue] [--from-file <path>]` | Reconstruct a spec from an issue representation or GitHub issue |
 
 ### Status Transitions
 

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -14,7 +14,9 @@ const {
   setActiveChangeSpec,
   unsetActiveChangeSpec,
   updateSpecStatus,
-  createBranchFromActiveChangeSpec
+  createBranchFromActiveChangeSpec,
+  dumpSpec,
+  loadIssueRepresentation
 } = require('../lib/spec-manager');
 const { deployPlugin } = require('../lib/plugin-deployer');
 const { generatePrompt } = require('../lib/prompt-generator');
@@ -234,6 +236,36 @@ program
     try {
       const result = createBranchFromActiveChangeSpec();
       console.log(yaml.dump(result));
+    } catch (error) {
+      console.error('Error:', error.message);
+      process.exit(1);
+    }
+  });
+
+// zest-dev dump <spec_id|active>
+program
+  .command('dump <spec>')
+  .description('Dump a spec to an issue representation or forge issue')
+  .option('--dry-run', 'Print the local Issue Spec Representation without creating an issue')
+  .action((spec, options) => {
+    try {
+      const result = dumpSpec(spec, { dryRun: Boolean(options.dryRun) });
+      console.log(yaml.dump(result, { lineWidth: -1 }));
+    } catch (error) {
+      console.error('Error:', error.message);
+      process.exit(1);
+    }
+  });
+
+// zest-dev load [issue]
+program
+  .command('load [issue]')
+  .description('Load a spec from an issue representation or forge issue')
+  .option('--from-file <path>', 'Load from a local Issue Spec Representation YAML file')
+  .action((issue, options) => {
+    try {
+      const result = loadIssueRepresentation(issue, { fromFile: options.fromFile });
+      console.log(yaml.dump(result, { lineWidth: -1 }));
     } catch (error) {
       console.error('Error:', error.message);
       process.exit(1);

--- a/docs/issue-spec-representation.md
+++ b/docs/issue-spec-representation.md
@@ -1,0 +1,199 @@
+# Issue Spec Representation
+
+This document defines the forge-neutral issue representation used by `zest-dev dump` and `zest-dev load`.
+
+## Purpose
+
+An Issue Spec Representation stores one complete Zest Dev Spec directory in one forge issue. It is a snapshot format, not a synchronization protocol.
+
+The representation is designed for GitHub and Forgejo issue primitives:
+- issue title
+- issue labels
+- issue body
+- issue comments
+
+Load correctness depends only on protocol headers and Markdown content in the issue body and protocol comments. The title and labels are archive metadata for people.
+
+## Version
+
+The initial protocol version is `1`.
+
+Every protocol body/comment starts with a leading HTML comment header:
+
+```markdown
+<!--
+zest-dev-issue-spec: 1
+spec-id: 20260627-issue-dump-load
+path: spec.md
+-->
+```
+
+Rules:
+- The header must start at the beginning of the body or comment.
+- The header is YAML-like line data inside an HTML comment.
+- `zest-dev-issue-spec` is required and must be `1`.
+- `spec-id` is required and identifies the Spec directory.
+- `path` is required and identifies the file path inside the Spec directory.
+- The Markdown file content starts immediately after the header closing line and one newline.
+- The file content is stored as renderable Markdown, not inside a fenced code block.
+
+## Issue Mapping
+
+One issue represents one Spec directory.
+
+The issue body stores `spec.md`:
+
+```markdown
+<!--
+zest-dev-issue-spec: 1
+spec-id: 20260627-issue-dump-load
+path: spec.md
+-->
+---
+id: 20260627-issue-dump-load
+name: Issue Dump Load
+status: planned
+created: '2026-06-27'
+---
+
+## Overview
+
+...
+```
+
+Each additional Markdown file is stored in one issue comment:
+
+```markdown
+<!--
+zest-dev-issue-spec: 1
+spec-id: 20260627-issue-dump-load
+path: design.md
+-->
+# Design
+
+...
+```
+
+Comment order is not meaningful. `load` matches supporting files by `path`.
+
+Comments without a leading protocol header are ordinary issue discussion and are ignored by `load`.
+
+## Title And Labels
+
+`dump` creates issue titles as:
+
+```text
+[archive] <spec-id>
+```
+
+`dump` applies these labels:
+
+```text
+spec:change
+archive
+```
+
+`load` must not use title or labels as authoritative Spec data.
+
+## File Set
+
+`dump` walks the Spec directory and includes every Markdown file:
+- `spec.md` is written to the issue body.
+- Every other Markdown file is written to one protocol comment.
+
+`dump` fails when:
+- `spec.md` is missing.
+- The Spec directory contains any non-Markdown file.
+- A discovered Markdown path is invalid.
+
+Legacy `README.md` main files are not supported by this protocol.
+
+## Path Rules
+
+Paths are relative to the Spec directory.
+
+Allowed:
+- `spec.md`
+- `design.md`
+- `steps.md`
+- `notes/review.md`
+
+Rejected:
+- empty paths
+- absolute paths
+- paths containing parent-directory traversal
+- non-Markdown paths
+- duplicate paths
+- path separators that cannot be normalized safely for the current platform
+
+`load` always writes issue body content to `spec.md`. The body header path must be `spec.md`.
+
+## Spec Identity
+
+The loaded Spec identity comes from the protocol header `spec-id`, not from `spec.md` frontmatter, title, labels, issue number, or URL.
+
+`load` fails when the body protocol header is missing `spec-id` or contains an invalid `spec-id`.
+
+The `spec-id` must be a valid Spec directory name:
+
+```text
+YYYYMMDD-<slug>
+```
+
+`load` creates:
+
+```text
+specs/change/<spec-id>/
+```
+
+Protocol comments must repeat the same `spec-id`. If a protocol comment omits `spec-id` or includes a different `spec-id`, `load` fails.
+
+If the target Spec directory already exists, `load` fails.
+
+`load` does not change `specs/change/active`.
+
+## Local Representation Mode
+
+The same body/comment mapping can be represented locally for dry-run and tests:
+
+```yaml
+title: "[archive] 20260627-issue-dump-load"
+labels:
+  - spec:change
+  - archive
+body: |
+  <!--
+  zest-dev-issue-spec: 1
+  spec-id: 20260627-issue-dump-load
+  path: spec.md
+  -->
+  ...
+comments:
+  - |
+    <!--
+    zest-dev-issue-spec: 1
+    spec-id: 20260627-issue-dump-load
+    path: design.md
+    -->
+    ...
+```
+
+`dump --dry-run` emits this local representation without creating a remote issue.
+
+`load --from-file <path>` loads from this local representation without reading a remote issue.
+
+## Failure Rules
+
+The protocol is fail-fast:
+- unsupported protocol version fails
+- missing body protocol header fails
+- malformed protocol header fails
+- missing or invalid body `spec-id` fails
+- mismatched comment `spec-id` fails
+- missing `spec.md` content fails
+- invalid or duplicate file paths fail
+- existing target Spec directory fails
+- unsupported forge transport fails
+- failed remote issue or comment operations fail
+
+Remote `dump` is not transactional. If issue creation succeeds and a later comment creation fails, the command fails and reports the created issue URL. It does not silently close, delete, or repair the issue.

--- a/e2e/tests/test_issue_dump_load.py
+++ b/e2e/tests/test_issue_dump_load.py
@@ -45,6 +45,29 @@ def test_dump_dry_run_and_load_from_file_round_trip_markdown_files(cli):
     assert markdown_files(cli.project_dir / "specs" / "change" / source_id) == source_files
 
 
+def test_dump_and_load_round_trip_yaml_sensitive_markdown_paths(cli):
+    created = cli.yaml("create", "yaml-sensitive-paths")["spec"]
+    source_id = created["id"]
+    source_dir = cli.project_dir / "specs" / "change" / source_id
+    (source_dir / "notes").mkdir()
+    (source_dir / "notes" / "a: b.md").write_text("# Colon\n", encoding="utf-8")
+    (source_dir / "notes" / "foo #bar.md").write_text("# Hash\n", encoding="utf-8")
+
+    dumped = cli.yaml("dump", source_id, "--dry-run")
+    assert any("path: 'notes/a: b.md'" in comment for comment in dumped["issue"]["comments"])
+    assert any("path: 'notes/foo #bar.md'" in comment for comment in dumped["issue"]["comments"])
+
+    source_files = markdown_files(source_dir)
+    source_dir.rename(source_dir.with_name(f"{source_id}.source"))
+
+    dump_path = cli.project_dir / "yaml-sensitive.yml"
+    dump_path.write_text(yaml.safe_dump(dumped["issue"], sort_keys=False), encoding="utf-8")
+    loaded = cli.yaml("load", "--from-file", str(dump_path))
+
+    assert loaded["ok"] is True
+    assert markdown_files(cli.project_dir / "specs" / "change" / source_id) == source_files
+
+
 def test_dump_and_load_fail_fast_for_invalid_local_protocol(cli):
     created = cli.yaml("create", "invalid-dump-source")["spec"]
     spec_dir = cli.project_dir / "specs" / "change" / created["id"]
@@ -106,6 +129,30 @@ def test_dump_and_load_fail_fast_for_invalid_local_protocol(cli):
     )
     (cli.project_dir / "specs" / "change" / "20240101-valid").mkdir(parents=True)
     assert "Target Spec directory already exists" in cli.fail("load", "--from-file", str(valid_path))
+
+
+def test_load_ignores_non_protocol_html_comments(cli):
+    path = cli.project_dir / "non-protocol-comment.yml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: spec.md\n-->\n# Body\n",
+                "comments": [
+                    "<!--\nplain: comment\n-->\nThis is ordinary discussion.\n",
+                    "<!--\nnot actually the protocol\n-->\nStill discussion.\n",
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = cli.yaml("load", "--from-file", str(path))
+
+    assert loaded["ok"] is True
+    assert markdown_files(cli.project_dir / "specs" / "change" / "20240101-valid") == {
+        "spec.md": "# Body\n"
+    }
 
 
 def test_github_transport_uses_gh_and_reports_comment_failure(cli):

--- a/e2e/tests/test_issue_dump_load.py
+++ b/e2e/tests/test_issue_dump_load.py
@@ -1,0 +1,181 @@
+import json
+import os
+import stat
+from pathlib import Path
+
+import yaml
+
+
+def markdown_files(spec_dir: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(spec_dir)): path.read_text(encoding="utf-8")
+        for path in sorted(spec_dir.rglob("*.md"))
+    }
+
+
+def test_dump_dry_run_and_load_from_file_round_trip_markdown_files(cli):
+    created = cli.yaml("create", "dump-load-source")["spec"]
+    source_id = created["id"]
+    source_dir = cli.project_dir / "specs" / "change" / source_id
+    (source_dir / "notes").mkdir()
+    (source_dir / "notes" / "review.md").write_text("# Review\n\nNested notes.\n", encoding="utf-8")
+    cli.ok("set-active", source_id)
+
+    dumped = cli.yaml("dump", "active", "--dry-run")
+    assert dumped["ok"] is True
+    issue = dumped["issue"]
+    assert issue["title"] == f"[archive] {source_id}"
+    assert issue["labels"] == ["spec:change", "archive"]
+    assert issue["body"].startswith("<!--\nzest-dev-issue-spec: 1\n")
+    assert len(issue["comments"]) == 3
+
+    source_files = markdown_files(source_dir)
+    source_dir.rename(source_dir.with_name(f"{source_id}.source"))
+    (cli.project_dir / "specs" / "change" / "active").unlink()
+
+    dump_path = cli.project_dir / "dump.yml"
+    dump_path.write_text(yaml.safe_dump(issue, sort_keys=False), encoding="utf-8")
+    loaded = cli.yaml("load", "--from-file", str(dump_path))
+
+    assert loaded["ok"] is True
+    assert loaded["spec"]["id"] == source_id
+    assert loaded["spec"]["path"] == f"specs/change/{source_id}/spec.md"
+    assert loaded["source"]["type"] == "file"
+    assert not (cli.project_dir / "specs" / "change" / "active").exists()
+    assert markdown_files(cli.project_dir / "specs" / "change" / source_id) == source_files
+
+
+def test_dump_and_load_fail_fast_for_invalid_local_protocol(cli):
+    created = cli.yaml("create", "invalid-dump-source")["spec"]
+    spec_dir = cli.project_dir / "specs" / "change" / created["id"]
+    (spec_dir / "asset.txt").write_text("not markdown\n", encoding="utf-8")
+    assert "Non-Markdown file in Spec directory: asset.txt" in cli.fail("dump", created["id"], "--dry-run")
+
+    (spec_dir / "asset.txt").unlink()
+    (spec_dir / "spec.md").unlink()
+    assert "Issue Spec Representation requires spec.md" in cli.fail("dump", created["id"], "--dry-run")
+
+    cases = {
+        "missing-header.yml": {"body": "# Missing\n", "comments": []},
+        "invalid-spec-id.yml": {
+            "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: nope\npath: spec.md\n-->\n# Body\n",
+            "comments": [],
+        },
+        "mismatched-comment.yml": {
+            "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: spec.md\n-->\n# Body\n",
+            "comments": [
+                "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-other\npath: design.md\n-->\n# Design\n"
+            ],
+        },
+        "duplicate-path.yml": {
+            "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: spec.md\n-->\n# Body\n",
+            "comments": [
+                "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: design.md\n-->\n# One\n",
+                "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: design.md\n-->\n# Two\n",
+            ],
+        },
+        "invalid-path.yml": {
+            "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: spec.md\n-->\n# Body\n",
+            "comments": [
+                "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: ../escape.md\n-->\n# Escape\n"
+            ],
+        },
+        "path-conflict.yml": {
+            "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: spec.md\n-->\n# Body\n",
+            "comments": [
+                "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: notes.md/review.md\n-->\n# Conflict\n"
+            ],
+        },
+    }
+
+    for filename, representation in cases.items():
+        path = cli.project_dir / filename
+        path.write_text(yaml.safe_dump(representation, sort_keys=False), encoding="utf-8")
+        assert cli.run("load", "--from-file", str(path)).returncode != 0
+
+    valid_path = cli.project_dir / "valid.yml"
+    valid_path.write_text(
+        yaml.safe_dump(
+            {
+                "body": "<!--\nzest-dev-issue-spec: 1\nspec-id: 20240101-valid\npath: spec.md\n-->\n# Body\n",
+                "comments": [],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (cli.project_dir / "specs" / "change" / "20240101-valid").mkdir(parents=True)
+    assert "Target Spec directory already exists" in cli.fail("load", "--from-file", str(valid_path))
+
+
+def test_github_transport_uses_gh_and_reports_comment_failure(cli):
+    created = cli.yaml("create", "github-dump-source")["spec"]
+    spec_dir = cli.project_dir / "specs" / "change" / created["id"]
+    (spec_dir / "notes.md").write_text("# Notes\n", encoding="utf-8")
+
+    fake_bin = cli.project_dir / "fake-bin"
+    fake_bin.mkdir()
+    log_path = cli.project_dir / "gh.log"
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+log = pathlib.Path(os.environ["GH_LOG"])
+body = sys.stdin.read()
+log.open("a", encoding="utf-8").write(json.dumps({"args": sys.argv[1:], "stdin": body}) + "\\n")
+
+if sys.argv[1:3] == ["auth", "status"]:
+    raise SystemExit(0)
+if sys.argv[1:3] == ["issue", "create"]:
+    print("https://github.com/nettee/zest-dev/issues/123")
+    raise SystemExit(0)
+if sys.argv[1:3] == ["issue", "comment"]:
+    if os.environ.get("FAIL_COMMENT") == "1":
+        print("comment failed", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(0)
+if sys.argv[1:3] == ["issue", "view"]:
+    comments = [
+        {"body": body}
+        for body in json.loads(pathlib.Path(os.environ["ISSUE_COMMENTS"]).read_text())
+    ]
+    print(json.dumps({"body": pathlib.Path(os.environ["ISSUE_BODY"]).read_text(), "comments": comments}))
+    raise SystemExit(0)
+
+print("unexpected gh args: " + " ".join(sys.argv[1:]), file=sys.stderr)
+raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+    env = {"PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}", "GH_LOG": str(log_path)}
+
+    dumped = cli.yaml("dump", created["id"], env=env)
+    assert dumped["ok"] is True
+    assert dumped["issue"]["url"] == "https://github.com/nettee/zest-dev/issues/123"
+    log_entries = [yaml.safe_load(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert log_entries[1]["args"][:2] == ["issue", "create"]
+    assert "--label" in log_entries[1]["args"]
+    assert log_entries[2]["args"][:2] == ["issue", "comment"]
+
+    fail_env = {**env, "FAIL_COMMENT": "1"}
+    assert "created issue before failure: https://github.com/nettee/zest-dev/issues/123" in cli.fail(
+        "dump", created["id"], env=fail_env
+    )
+
+    dry_run = cli.yaml("dump", created["id"], "--dry-run")
+    body_path = cli.project_dir / "issue-body.md"
+    comments_path = cli.project_dir / "issue-comments.yml"
+    body_path.write_text(dry_run["issue"]["body"], encoding="utf-8")
+    comments_path.write_text(json.dumps(dry_run["issue"]["comments"]), encoding="utf-8")
+    load_env = {**env, "ISSUE_BODY": str(body_path), "ISSUE_COMMENTS": str(comments_path)}
+    source_files = markdown_files(spec_dir)
+    spec_dir.rename(spec_dir.with_name(f"{created['id']}.source"))
+    loaded = cli.yaml("load", "123", env=load_env)
+    assert loaded["ok"] is True
+    assert loaded["source"] == {"type": "github", "issue": "123"}
+    assert markdown_files(cli.project_dir / "specs" / "change" / created["id"]) == source_files

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -17,6 +17,8 @@ const STATUS_ORDER = {
   planned: 3,
   implemented: 4
 };
+const ISSUE_SPEC_PROTOCOL_VERSION = 1;
+const ISSUE_SPEC_LABELS = ['spec:change', 'archive'];
 
 function pathExistsIncludingDanglingSymlink(filePath) {
   try {
@@ -154,6 +156,395 @@ function getSpecFilePath(specDir) {
   }
 
   return specMdPath;
+}
+
+function validateSpecId(specId) {
+  if (!/^\d{8}-[a-z0-9][a-z0-9-]*$/.test(specId)) {
+    throw new Error(`Invalid spec-id "${specId}"`);
+  }
+}
+
+function normalizeIssueSpecPath(relativePath) {
+  if (typeof relativePath !== 'string' || relativePath.trim() === '') {
+    throw new Error('Invalid Issue Spec path: path is required');
+  }
+  if (relativePath.includes('\\') || relativePath.includes('\0')) {
+    throw new Error(`Invalid Issue Spec path: ${relativePath}`);
+  }
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`Invalid Issue Spec path: ${relativePath}`);
+  }
+
+  const normalized = path.posix.normalize(relativePath);
+  if (
+    normalized === '.' ||
+    normalized.startsWith('../') ||
+    normalized === '..' ||
+    normalized.split('/').includes('..') ||
+    normalized !== relativePath
+  ) {
+    throw new Error(`Invalid Issue Spec path: ${relativePath}`);
+  }
+  if (!normalized.endsWith('.md')) {
+    throw new Error(`Invalid Issue Spec path: ${relativePath}`);
+  }
+  const directorySegments = normalized.split('/').slice(0, -1);
+  if (directorySegments.some(segment => segment.endsWith('.md'))) {
+    throw new Error(`Invalid Issue Spec path: ${relativePath}`);
+  }
+
+  return normalized;
+}
+
+function walkSpecDirectory(specDirPath, currentDir = specDirPath, files = []) {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(specDirPath, entryPath).split(path.sep).join('/');
+
+    if (entry.isDirectory()) {
+      walkSpecDirectory(specDirPath, entryPath, files);
+    } else if (entry.isFile()) {
+      if (!entry.name.endsWith('.md')) {
+        throw new Error(`Non-Markdown file in Spec directory: ${relativePath}`);
+      }
+      files.push(relativePath);
+    } else {
+      throw new Error(`Unsupported file type in Spec directory: ${relativePath}`);
+    }
+  }
+  return files;
+}
+
+function renderIssueSpecFile(specId, relativePath, content) {
+  return [
+    '<!--',
+    `zest-dev-issue-spec: ${ISSUE_SPEC_PROTOCOL_VERSION}`,
+    `spec-id: ${specId}`,
+    `path: ${relativePath}`,
+    '-->',
+    content
+  ].join('\n');
+}
+
+function parseIssueSpecFile(text, location, { requireProtocol = true } = {}) {
+  if (typeof text !== 'string') {
+    throw new Error(`${location} must be a string`);
+  }
+
+  const match = text.match(/^<!--\n([\s\S]*?)\n-->\n?/);
+  if (!match) {
+    if (requireProtocol) {
+      throw new Error(`Missing Issue Spec protocol header in ${location}`);
+    }
+    return null;
+  }
+
+  let metadata;
+  try {
+    metadata = yaml.load(match[1]) || {};
+  } catch (error) {
+    throw new Error(`Malformed Issue Spec protocol header in ${location}: ${error.message}`);
+  }
+
+  if (metadata['zest-dev-issue-spec'] !== ISSUE_SPEC_PROTOCOL_VERSION) {
+    throw new Error(`Unsupported Issue Spec protocol version in ${location}`);
+  }
+  if (!metadata['spec-id']) {
+    throw new Error(`Missing spec-id in ${location}`);
+  }
+
+  validateSpecId(metadata['spec-id']);
+  const relativePath = normalizeIssueSpecPath(metadata.path);
+
+  return {
+    specId: metadata['spec-id'],
+    path: relativePath,
+    content: text.slice(match[0].length)
+  };
+}
+
+function specToIssueRepresentation(specIdentifier) {
+  const spec = getSpec(specIdentifier);
+  validateSpecId(spec.id);
+
+  const specDirPath = path.join(SPECS_DIR, spec.id);
+  const specMdPath = path.join(specDirPath, 'spec.md');
+  if (!fs.existsSync(specMdPath)) {
+    throw new Error('Issue Spec Representation requires spec.md');
+  }
+
+  const markdownFiles = walkSpecDirectory(specDirPath).sort();
+  if (!markdownFiles.includes('spec.md')) {
+    throw new Error('Issue Spec Representation requires spec.md');
+  }
+
+  const body = renderIssueSpecFile(
+    spec.id,
+    'spec.md',
+    fs.readFileSync(specMdPath, 'utf-8')
+  );
+  const comments = markdownFiles
+    .filter(relativePath => relativePath !== 'spec.md')
+    .map(relativePath => {
+      normalizeIssueSpecPath(relativePath);
+      return renderIssueSpecFile(
+        spec.id,
+        relativePath,
+        fs.readFileSync(path.join(specDirPath, ...relativePath.split('/')), 'utf-8')
+      );
+    });
+
+  return {
+    title: `[archive] ${spec.id}`,
+    labels: [...ISSUE_SPEC_LABELS],
+    body,
+    comments
+  };
+}
+
+function issueRepresentationToFiles(issueRepresentation) {
+  if (!issueRepresentation || typeof issueRepresentation !== 'object') {
+    throw new Error('Issue Spec Representation must be an object');
+  }
+
+  const bodyFile = parseIssueSpecFile(issueRepresentation.body, 'issue body');
+  if (bodyFile.path !== 'spec.md') {
+    throw new Error('Issue body path must be spec.md');
+  }
+  if (bodyFile.content.length === 0) {
+    throw new Error('Missing spec.md content in issue body');
+  }
+
+  const files = new Map();
+  files.set('spec.md', bodyFile.content);
+
+  const comments = issueRepresentation.comments || [];
+  if (!Array.isArray(comments)) {
+    throw new Error('Issue Spec comments must be an array');
+  }
+
+  for (const [index, comment] of comments.entries()) {
+    const commentBody = typeof comment === 'string' ? comment : comment && comment.body;
+    const parsed = parseIssueSpecFile(commentBody, `issue comment ${index + 1}`, {
+      requireProtocol: false
+    });
+    if (!parsed) {
+      continue;
+    }
+    if (parsed.specId !== bodyFile.specId) {
+      throw new Error(`Mismatched comment spec-id "${parsed.specId}" for ${parsed.path}`);
+    }
+    if (parsed.path === 'spec.md') {
+      throw new Error('Issue comments must not represent spec.md');
+    }
+    if (files.has(parsed.path)) {
+      throw new Error(`Duplicate Issue Spec path: ${parsed.path}`);
+    }
+    files.set(parsed.path, parsed.content);
+  }
+
+  return {
+    specId: bodyFile.specId,
+    files: [...files.entries()].map(([relativePath, content]) => ({ path: relativePath, content }))
+  };
+}
+
+function writeIssueRepresentation(issueRepresentation, source) {
+  const { specId, files } = issueRepresentationToFiles(issueRepresentation);
+  const specDirPath = path.join(SPECS_DIR, specId);
+  const tempDirPath = path.join(SPECS_DIR, `.${specId}.tmp-${process.pid}-${Date.now()}`);
+
+  if (fs.existsSync(specDirPath)) {
+    throw new Error(`Target Spec directory already exists: ${specDirPath}`);
+  }
+
+  try {
+    fs.mkdirSync(tempDirPath, { recursive: true });
+    for (const file of files) {
+      const relativePath = normalizeIssueSpecPath(file.path);
+      const targetPath = path.join(tempDirPath, ...relativePath.split('/'));
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.writeFileSync(targetPath, file.content, 'utf-8');
+    }
+    fs.renameSync(tempDirPath, specDirPath);
+  } catch (error) {
+    if (fs.existsSync(tempDirPath)) {
+      fs.rmSync(tempDirPath, { recursive: true, force: true });
+    }
+    throw error;
+  }
+
+  return {
+    ok: true,
+    spec: {
+      id: specId,
+      path: path.join(SPECS_DIR, specId, 'spec.md'),
+      active: getActiveChangeSpecId() === specId,
+      status: parseSpecFrontmatter(path.join(specDirPath, 'spec.md')).status || 'new'
+    },
+    source
+  };
+}
+
+function loadIssueRepresentationFromFile(filePath) {
+  if (!filePath) {
+    throw new Error('Missing --from-file path');
+  }
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Issue Spec file not found: ${filePath}`);
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  let parsed;
+  try {
+    parsed = yaml.load(content);
+  } catch (error) {
+    throw new Error(`Invalid Issue Spec file ${filePath}: ${error.message}`);
+  }
+
+  const issueRepresentation = parsed && parsed.issue ? parsed.issue : parsed;
+  return writeIssueRepresentation(issueRepresentation, { type: 'file', path: filePath });
+}
+
+function runRequiredCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf-8',
+    input: options.input,
+    cwd: process.cwd()
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run ${command}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const details = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+    throw new Error(`${command} ${args.join(' ')} failed${details ? `: ${details}` : ''}`);
+  }
+
+  return result.stdout.trim();
+}
+
+function inferForgeFromOrigin() {
+  const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
+    encoding: 'utf-8',
+    cwd: process.cwd()
+  });
+
+  if (result.status !== 0 || result.error) {
+    return 'github';
+  }
+
+  const remoteUrl = result.stdout.trim();
+  if (remoteUrl === '') {
+    return 'github';
+  }
+
+  const lowerRemoteUrl = remoteUrl.toLowerCase();
+  let host = null;
+  const sshMatch = lowerRemoteUrl.match(/^[^@]+@([^:]+):/);
+  if (sshMatch) {
+    host = sshMatch[1];
+  } else {
+    try {
+      host = new URL(lowerRemoteUrl).hostname;
+    } catch (error) {
+      host = null;
+    }
+  }
+
+  if (!host) {
+    return 'github';
+  }
+  if (host === 'github.com') {
+    return 'github';
+  }
+  if (host.includes('forgejo') || host === 'codeberg.org') {
+    return 'forgejo';
+  }
+
+  return `unsupported:${host}`;
+}
+
+function requireSupportedForge() {
+  const forge = inferForgeFromOrigin();
+  if (forge === 'forgejo') {
+    throw new Error('Unsupported forge transport: forgejo');
+  }
+  if (forge.startsWith('unsupported:')) {
+    throw new Error(`Unsupported forge transport for remote origin host: ${forge.slice('unsupported:'.length)}`);
+  }
+  return forge;
+}
+
+function requireGhAuth() {
+  runRequiredCommand('gh', ['auth', 'status']);
+}
+
+function dumpSpec(specIdentifier, options = {}) {
+  const issue = specToIssueRepresentation(specIdentifier);
+  if (options.dryRun) {
+    return { ok: true, issue };
+  }
+
+  requireSupportedForge();
+  requireGhAuth();
+
+  const createArgs = ['issue', 'create', '--title', issue.title, '--body-file', '-'];
+  for (const label of issue.labels) {
+    createArgs.push('--label', label);
+  }
+
+  const issueUrl = runRequiredCommand('gh', createArgs, { input: issue.body });
+  try {
+    for (const comment of issue.comments) {
+      runRequiredCommand('gh', ['issue', 'comment', issueUrl, '--body-file', '-'], {
+        input: comment
+      });
+    }
+  } catch (error) {
+    throw new Error(`${error.message}; created issue before failure: ${issueUrl}`);
+  }
+
+  return {
+    ok: true,
+    issue: {
+      url: issueUrl,
+      title: issue.title,
+      labels: issue.labels,
+      comments: issue.comments.length
+    }
+  };
+}
+
+function readGithubIssue(issue) {
+  requireSupportedForge();
+  requireGhAuth();
+
+  const output = runRequiredCommand('gh', ['issue', 'view', issue, '--json', 'body,comments']);
+  let parsed;
+  try {
+    parsed = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`gh issue view returned invalid JSON: ${error.message}`);
+  }
+
+  return {
+    body: parsed.body,
+    comments: Array.isArray(parsed.comments) ? parsed.comments : []
+  };
+}
+
+function loadIssueRepresentation(issueOrOptions, options = {}) {
+  if (options.fromFile) {
+    return loadIssueRepresentationFromFile(options.fromFile);
+  }
+  if (!issueOrOptions) {
+    throw new Error('Missing issue URL or number');
+  }
+
+  const issue = readGithubIssue(issueOrOptions);
+  return writeIssueRepresentation(issue, { type: 'github', issue: issueOrOptions });
 }
 
 /**
@@ -411,6 +802,8 @@ module.exports = {
   unsetActiveChangeSpec,
   updateSpecStatus,
   createBranchFromActiveChangeSpec,
+  dumpSpec,
+  loadIssueRepresentation,
   // Backwards-compatible internal aliases
   setCurrentSpec: setActiveChangeSpec,
   unsetCurrentSpec: unsetActiveChangeSpec,

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -217,11 +217,19 @@ function walkSpecDirectory(specDirPath, currentDir = specDirPath, files = []) {
 }
 
 function renderIssueSpecFile(specId, relativePath, content) {
+  const metadata = yaml
+    .dump(
+      {
+        'zest-dev-issue-spec': ISSUE_SPEC_PROTOCOL_VERSION,
+        'spec-id': specId,
+        path: relativePath
+      },
+      { lineWidth: -1 }
+    )
+    .trimEnd();
   return [
     '<!--',
-    `zest-dev-issue-spec: ${ISSUE_SPEC_PROTOCOL_VERSION}`,
-    `spec-id: ${specId}`,
-    `path: ${relativePath}`,
+    metadata,
     '-->',
     content
   ].join('\n');
@@ -237,6 +245,10 @@ function parseIssueSpecFile(text, location, { requireProtocol = true } = {}) {
     if (requireProtocol) {
       throw new Error(`Missing Issue Spec protocol header in ${location}`);
     }
+    return null;
+  }
+
+  if (!requireProtocol && !/(^|\n)zest-dev-issue-spec\s*:/.test(match[1])) {
     return null;
   }
 

--- a/specs/change/20260627-issue-dump-load/design.md
+++ b/specs/change/20260627-issue-dump-load/design.md
@@ -1,0 +1,199 @@
+# Design
+
+## Research
+
+### Existing System
+
+- The CLI uses `commander`; commands call `lib/spec-manager` functions, print YAML on success, and exit non-zero on caught errors. Source: `bin/zest-dev.js:124-227`
+- `zest-dev` is exposed as `./bin/zest-dev.js`; the package includes `bin/`, `lib/`, templates, commands, skills, scripts, plugin files, README, and license. Source: `package.json:19-33`
+- Specs live under `specs/change`; the active link is `specs/change/active`, with legacy `current` compatibility. Source: `lib/spec-manager.js:6-8,81-82`
+- Spec directories are recognized only when their names start with `YYYYMMDD-`. Source: `lib/spec-manager.js:33-42`
+- The Main Spec File is `spec.md`, with legacy `README.md` fallback. Source: `lib/spec-manager.js:145-156`
+- Creating a Spec writes three files: `spec.md`, `design.md`, and `steps.md`. Source: `lib/spec-manager.js:222-233`
+- The Spec status lifecycle is `new`, `researched`, `designed`, `planned`, `implemented`, and updates are forward-only. Source: `lib/spec-manager.js:12-19,335-337`
+- `show` returns Spec metadata only; it does not return file contents or supporting file paths. Source: `lib/spec-manager.js:162-189`
+- `update` modifies only the Main Spec File frontmatter status. Source: `lib/spec-manager.js:335-358`
+
+### Design Inputs
+
+- Project vocabulary defines a Spec as a directory containing a Main Spec File and optional Spec Supporting Files. Source: `CONTEXT.md:5-18`
+- The Main Spec File is review-oriented, while Spec Supporting Files carry lower-review-frequency workflow detail. Source: `CONTEXT.md:11-18`
+- Issue #98 requests converting a Spec between file form and issue form. Source: `https://github.com/nettee/zest-dev/issues/98`
+- User requirement: the process must be programmatic, must not use an LLM, and must be lossless. Source: user request in this spec session, 2026-06-27
+- User requirement: issue body should carry the Main Spec File, each supporting file should be an issue comment, and metadata should make dump/load smooth. Source: user request in this spec session, 2026-06-27
+- User requirement: the EAG can use a test Spec for one dump and one load, then verify no information changed. Source: user request in this spec session, 2026-06-27
+- User requirement: future support must include Forgejo, not only GitHub. Source: user request in this spec session, 2026-06-27
+
+### Constraints & Dependencies
+
+- The repository's fast-fail rule requires required missing inputs, malformed protocol data, failed subprocesses, and violated invariants to fail clearly instead of continuing with placeholders or fabricated data. Source: `AGENTS.md:12-41`
+- E2E tests run the real CLI as subprocesses and parse YAML stdout. Source: `e2e/tests/conftest.py:43`
+- Lifecycle tests already cover split template creation, active/legacy behavior, and status transitions. Source: `e2e/tests/test_spec_lifecycle.py:9-63,100-151,206-239`
+- Package testing packs and installs the CLI tarball before running the same pytest suite. Source: `package.json:34-38`, `e2e/helpers/package_env.py:29`
+
+### Key References
+
+- `bin/zest-dev.js:129-280` - current command registration pattern.
+- `lib/spec-manager.js:195-244` - create flow and split Spec file layout.
+- `lib/template/spec.md:1-29` - Main Spec File template and links to supporting files.
+- `lib/template/design.md:1-5` - Design supporting file template.
+- `lib/template/steps.md:1-5` - Steps supporting file template.
+- `docs/issue-spec-representation.md:1-199` - Issue Spec Representation v1 protocol.
+
+## Design Detail
+
+### Architecture Overview
+
+```mermaid
+flowchart LR
+  A["Spec directory"] --> B["Spec directory representation"]
+  B --> C["Issue Spec Representation"]
+  C --> D["Forge issue transport"]
+  D --> C
+  C --> B
+  B --> A
+```
+
+### Design Decisions
+
+- Decision: The Issue Spec Representation is self-describing and forge-neutral. Required protocol data lives in the issue body and comments; title and labels are human-facing hints, not required load inputs. Source: `CONTEXT.md:19-22`, user confirmation in this spec session, 2026-06-27
+- Decision: Losslessness is Markdown-file losslessness for Spec files, not a general-purpose filesystem mirror. Source: `CONTEXT.md:7-22`, user confirmation in this spec session, 2026-06-27
+- Decision: Separate the pure representation protocol from forge transport adapters. Source: `package.json:19-33`, `bin/zest-dev.js:124-227`, user confirmation in this spec session, 2026-06-27
+- Decision: One issue corresponds to one Spec directory and carries one complete Spec snapshot. Source: user confirmation in this spec session, 2026-06-27
+- Decision: Represent each file as renderable Markdown content with machine metadata in an HTML comment header at the beginning. Source: user confirmation in this spec session, 2026-06-27
+- Decision: Keep protocol metadata minimal: preserve Spec id, file paths, and file content; do not include role or sha256 fields. Source: user confirmation in this spec session, 2026-06-27
+- Decision: The loaded Spec identity comes from the protocol header `spec-id`, not from Main Spec File frontmatter, issue title, labels, issue number, or URL. Source: `docs/issue-spec-representation.md:131-153`, user confirmation in this spec session, 2026-06-27
+- Decision: `dump` publishes a new issue snapshot and does not update existing issues. Source: user confirmation in this spec session, 2026-06-27
+- Decision: `load` creates the Spec directory but does not change the active Spec by default. Source: `lib/spec-manager.js:247-278`, user confirmation in this spec session, 2026-06-27
+- Decision: CLI commands stay forge-neutral as `dump` and `load`; the forge is inferred from the default git remote, falling back to GitHub when inference fails. Source: `package.json:9`, `git remote -v`, user confirmation in this spec session, 2026-06-27
+- Decision: Issue title and labels are human-facing archive metadata, not authoritative load inputs. Source: user confirmation in this spec session, 2026-06-27
+- Decision: `load` ignores non-protocol issue comments. Source: user confirmation in this spec session, 2026-06-27
+- Decision: Supporting-file comments are matched to files by the `path` field in their protocol HTML comment header. Source: user confirmation in this spec session, 2026-06-27
+- Decision: Supporting-file paths may include subdirectories; they are not limited to top-level Markdown files. Source: user confirmation in this spec session, 2026-06-27
+- Decision: `dump` includes every Markdown file under the Spec directory, with `spec.md` in the issue body and all other Markdown files in protocol comments. Source: user confirmation in this spec session, 2026-06-27
+- Decision: `dump` fails when the Spec directory contains non-Markdown files. Source: user confirmation in this spec session, 2026-06-27
+- Decision: The issue dump/load protocol does not support legacy `README.md` main files; Specs must use `spec.md`. Source: `lib/spec-manager.js:145-156`, user confirmation in this spec session, 2026-06-27
+- Decision: First-version remote transport implements GitHub only; Forgejo remains a future adapter behind the forge-neutral protocol boundary. Source: `package.json:9`, `git remote -v`, user confirmation in this spec session, 2026-06-27
+- Decision: The first GitHub transport uses the `gh` CLI. Source: user confirmation in this spec session, 2026-06-27
+- Decision: Remote `dump` is not transactional; if issue creation succeeds but later comment creation fails, the command fails and reports the created issue URL. Source: user confirmation in this spec session, 2026-06-27
+- Decision: Provide a local representation mode for dry-run, diagnostics, and EAG validation without network access. Source: user confirmation in this spec session, 2026-06-27
+- Decision: The Issue Spec Representation protocol is documented as a project doc and treated as an implementation contract. Source: `docs/issue-spec-representation.md:1-199`, user request in this spec session, 2026-06-27
+
+### Change Scope
+
+Impact Areas:
+- CLI commands: add `dump` and `load` commands with local and GitHub-backed modes.
+- Spec manager: add pure functions for reading/writing Spec directories and rendering/parsing Issue Spec Representations.
+- Forge transport: add a GitHub adapter using `gh`; keep Forgejo behind the same adapter boundary for later implementation.
+- Documentation: add and maintain the Issue Spec Representation protocol document.
+- E2E tests: validate local round-trip, fail-fast behavior, command wiring, package installation, and GitHub adapter subprocess behavior.
+
+Planned File Changes:
+- `docs/issue-spec-representation.md` - protocol contract for issue body/comment representation.
+- `lib/spec-manager.js` - core local representation, load/dump orchestration, exports.
+- `bin/zest-dev.js` - command registration and CLI option parsing.
+- `e2e/tests/test_spec_lifecycle.py` or a new e2e test file - dump/load behavior and fail-fast coverage.
+- `README.md` or command docs - user-facing usage notes if command behavior changes documented CLI surface.
+
+### Interfaces / APIs
+
+- `zest-dev dump <spec|active> --dry-run` emits a local Issue Spec Representation.
+- `zest-dev dump <spec|active>` creates a new forge issue snapshot; first implementation supports GitHub through `gh`.
+- `zest-dev load --from-file <path>` loads from a local representation artifact.
+- `zest-dev load <issue-url-or-number>` loads from a remote issue through the inferred forge adapter.
+- Core functions should expose a local conversion path equivalent to `Spec directory -> Issue Spec Representation -> Spec directory`.
+
+### Test Strategy
+
+- EAG: create a test Spec directory with `spec.md`, top-level supporting Markdown, and nested supporting Markdown; dump to local representation; load into a fresh directory; compare relative Markdown paths and exact file content. Source: `docs/issue-spec-representation.md:98-129,155-183`
+- Fail-fast tests: missing `spec.md`, non-Markdown file, invalid path, duplicate protocol path, missing body protocol header, missing or invalid `spec-id`, mismatched comment `spec-id`, and existing target directory. Source: `docs/issue-spec-representation.md:185-199`
+- CLI tests: verify `dump --dry-run` and `load --from-file` parse arguments, output YAML, do not modify active symlink, and run in local/package environments. Source: `bin/zest-dev.js:129-280`, `e2e/tests/conftest.py:43`, `package.json:34-38`
+- GitHub adapter tests: stub `gh` subprocesses to verify issue title, labels, body, comments, issue reads, and partial-failure reporting. Source: `docs/issue-spec-representation.md:81-96,185-199`
+
+### Edge Cases
+
+- Non-protocol issue comments are ignored during load.
+- Protocol comment order is irrelevant.
+- Duplicate protocol paths fail.
+- Legacy `README.md` main files fail.
+- Forgejo inference before adapter support fails with an unsupported-forge error.
+- Remote dump partial failure returns failure and reports the created issue URL without cleanup mutation.
+
+### Pseudocode
+
+Dump flow:
+1. Resolve `<spec|active>` to a Spec directory.
+2. Require `spec.md`.
+3. Walk the directory and collect Markdown files; fail on non-Markdown files.
+4. Render issue body from `spec.md` and protocol comments from all other Markdown files.
+5. For `--dry-run`, print local representation.
+6. Otherwise infer forge, require supported transport, create issue, then create comments.
+
+Load flow:
+1. Read local representation or remote issue body/comments.
+2. Require body protocol header with `path: spec.md`.
+3. Parse protocol comments and ignore ordinary comments.
+4. Validate relative Markdown paths and duplicate paths.
+5. Read `spec-id` from the body protocol header and derive target `specs/change/<spec-id>/`.
+6. Fail if target exists.
+7. Write all represented Markdown files.
+
+### Derived Rules
+
+- `load` must parse the protocol blocks from issue body/comments instead of inferring required Spec metadata from title or labels.
+- Missing protocol markers, unsupported protocol versions, malformed metadata, missing required files, duplicate file paths, or path/content mismatches in round-trip tests are hard failures.
+- GitHub and Forgejo integrations should adapt issue body/comments/title/labels to the same Issue Spec Representation rather than owning separate Spec protocols.
+- `dump` includes the Main Spec File and Markdown Spec Supporting Files inside the Spec directory.
+- `dump` does not need to support symlinks, non-Markdown files, binary files, or arbitrary nested filesystem state.
+- `load` verifies the represented Markdown file paths are valid and unique, then writes those Markdown files back to a Spec directory.
+- Core protocol functions convert `Spec directory <-> Issue Spec Representation` without network access or forge-specific APIs.
+- GitHub and Forgejo code should only adapt remote issue body/comments/title/labels to the core Issue Spec Representation.
+- The EAG should validate the pure local protocol round trip first; live forge API checks can be separate integration coverage.
+- `dump` emits the complete represented Markdown file set for the Spec directory.
+- `load` reconstructs one Spec directory from one complete issue representation and does not merge with an existing local Spec.
+- If the target Spec directory already exists, first-version `load` fails instead of overwriting or partially merging.
+- Missing, duplicate, or manifest-inconsistent comments are hard failures.
+- The issue body begins with a protocol HTML comment header for the Main Spec File, followed by the raw Markdown content of that file.
+- Each supporting-file comment begins with a protocol HTML comment header for that file, followed by the raw Markdown content of that file.
+- The parser reads only the leading protocol HTML comment as metadata; all remaining comment/body text is file Markdown content and must round-trip unchanged under the Markdown-file losslessness boundary.
+- The issue body does not need a `role` metadata field because the body is always the Main Spec File.
+- Supporting-file comments do not need a `role` metadata field because comments always represent Spec Supporting Files.
+- The EAG should compare loaded file paths and file content exactly, instead of relying on protocol checksum fields.
+- `load` reads `spec-id` from the body protocol header.
+- Every protocol comment must repeat the same `spec-id`.
+- `load` creates `specs/change/<spec-id>/` from the header `spec-id`.
+- Missing `spec-id`, mismatched comment `spec-id`, or a `spec-id` that is not a valid `YYYYMMDD-*` Spec directory name is a hard failure.
+- Issue title and labels are not authoritative for reconstructing the Spec.
+- `dump` should not accept an existing issue as a target for mutation.
+- Existing issue update, comment deletion, comment reordering, and remote conflict reconciliation are out of scope.
+- Multiple dumps of the same Spec produce multiple issue snapshots.
+- `load` outputs the loaded Spec metadata and source issue information without modifying `specs/change/active`.
+- Users can run `zest-dev set-active <spec-id>` explicitly after load.
+- A future convenience option such as `--set-active` must be explicit if added.
+- `dump` and `load` user-facing command names must not be GitHub-specific.
+- The first implementation should inspect the default remote, infer GitHub or Forgejo when possible, and use GitHub as the default when the remote is ambiguous.
+- Explicit forge selection can be an override option, but normal usage should not require it when the repository remote is enough.
+- `dump` creates issue titles as `[archive] <spec-id>`.
+- `dump` labels created issues with `spec:change` and `archive`.
+- `load` must not require or trust the issue title or labels when reconstructing the Spec.
+- `load` parses only issue body/comment content that starts with the Zest Dev protocol HTML comment header.
+- Ordinary issue comments without the protocol header are ignored.
+- Each protocol supporting-file comment must include a valid relative Markdown `path`.
+- Duplicate protocol comment paths are hard failures.
+- Protocol comment order is not meaningful.
+- Valid file paths must still be relative paths within the target Spec directory.
+- Absolute paths, parent-directory traversal, empty paths, and non-Markdown paths are hard failures.
+- `dump` discovers Markdown files by walking the Spec directory rather than parsing links in `spec.md`.
+- Every discovered Markdown file except `spec.md` becomes one protocol issue comment.
+- Unsupported non-Markdown files must not be silently ignored.
+- `dump` fails when `spec.md` is missing, even if a legacy `README.md` exists.
+- `load` always restores the issue body content to `spec.md`.
+- If remote inference identifies Forgejo before a Forgejo adapter exists, commands fail with a clear unsupported-forge error.
+- GitHub implementation choices must not leak into the protocol format.
+- Missing `gh`, failed `gh auth`, failed issue creation, failed comment creation, and failed issue reads are hard failures.
+- The implementation should not add a GitHub HTTP client dependency for the first version.
+- The implementation should not silently close, delete, or mutate partially created issues after a later failure.
+- Failure output should include enough remote issue information for the user to inspect or clean up manually.
+- `dump --dry-run` should emit the Issue Spec Representation without creating a remote issue.
+- `load --from-file <path>` should load from a local representation artifact.
+- The EAG should use local representation mode to prove protocol losslessness without depending on forge availability.

--- a/specs/change/20260627-issue-dump-load/spec.md
+++ b/specs/change/20260627-issue-dump-load/spec.md
@@ -1,0 +1,71 @@
+---
+id: 20260627-issue-dump-load
+name: Issue Dump Load
+status: planned
+created: '2026-06-27'
+---
+
+## Overview
+
+Add programmatic `dump` and `load` capabilities that convert a Zest Dev Spec between its file-system directory form and a forge issue form without using an LLM and without losing represented Markdown file information.
+
+Initial direction:
+- `dump` writes the Main Spec File to the issue body.
+- `dump` writes each additional Markdown file as a separate issue comment.
+- The issue title, labels, body, and comments carry enough protocol metadata for smooth `load`.
+- `load` reconstructs the Spec directory from the issue representation.
+- The E2E Acceptance Gate should dump and load a test Spec, then verify represented Markdown file paths and content are unchanged.
+
+Source issue: [nettee/zest-dev#98](https://github.com/nettee/zest-dev/issues/98).
+
+## Research
+
+See [design.md](./design.md).
+
+## Design
+
+### Design Summary
+
+Implement a forge-neutral Issue Spec Representation protocol, documented in [docs/issue-spec-representation.md](../../../docs/issue-spec-representation.md), then add `zest-dev dump` and `zest-dev load` around it. The core protocol layer must work without network access; the first remote transport uses GitHub through `gh`, while Forgejo remains a future adapter behind the same representation boundary.
+
+See [design.md](./design.md) for design detail.
+
+### E2E Acceptance Gate (EAG)
+
+Dump a test Spec directory with multiple Markdown files to a local Issue Spec Representation, load it into a fresh Spec directory, and verify the original and loaded Spec have identical Markdown file paths and file content. Also verify fail-fast cases for missing `spec.md`, non-Markdown files, duplicate protocol paths, missing or invalid `spec-id`, mismatched comment `spec-id`, and existing target directory.
+
+## Plan
+
+- [ ] Step 1: Protocol document and core local representation
+  - [ ] Substep 1.1 Implement: Add parser/renderer for Issue Spec Representation v1.
+  - [ ] Substep 1.2 Implement: Walk Spec directories and build representation from all Markdown files.
+  - [ ] Substep 1.3 Implement: Load local representation into a new Spec directory.
+  - [ ] Substep 1.4 Verify: Add E2E coverage for local round-trip and fail-fast protocol errors.
+- [ ] Step 2: CLI commands and local mode
+  - [ ] Substep 2.1 Implement: Add `zest-dev dump <spec|active> --dry-run`.
+  - [ ] Substep 2.2 Implement: Add `zest-dev load --from-file <path>`.
+  - [ ] Substep 2.3 Verify: Cover command output, active-spec behavior, and package test path.
+- [ ] Step 3: GitHub transport
+  - [ ] Substep 3.1 Implement: Infer forge/repo from the default remote, falling back to GitHub.
+  - [ ] Substep 3.2 Implement: Create GitHub issues and comments through `gh`.
+  - [ ] Substep 3.3 Implement: Read GitHub issue body/comments through `gh` for remote load.
+  - [ ] Substep 3.4 Verify: Add adapter-focused tests with stubbed `gh` behavior.
+- [ ] Step 4: Documentation sync and acceptance
+  - [ ] Substep 4.1 Implement: Update README or command docs with `dump/load` usage.
+  - [ ] Substep 4.2 Verify: Run local E2E suite.
+  - [ ] Substep 4.3 Verify: Run package E2E suite when practical.
+
+## Progress
+
+- [ ] Step 1: Protocol document and core local representation
+- [ ] Step 2: CLI commands and local mode
+- [ ] Step 3: GitHub transport
+- [ ] Step 4: Documentation sync and acceptance
+
+## Implementation
+
+See [steps.md](./steps.md).
+
+## Deferred Follow-Ups (DFU)
+
+None.

--- a/specs/change/20260627-issue-dump-load/spec.md
+++ b/specs/change/20260627-issue-dump-load/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260627-issue-dump-load
 name: Issue Dump Load
-status: planned
+status: implemented
 created: '2026-06-27'
 ---
 
@@ -68,11 +68,11 @@ Depends on: Step 4
 
 ## Progress
 
-- [ ] Step 1 (AFK): Protocol Document And Core Local Representation
-- [ ] Step 2 (AFK): CLI Local Mode
-- [ ] Step 3 (AFK): GitHub Transport
-- [ ] Step 4 (AFK): EAG Validation
-- [ ] Step 5 (AFK): Documentation Sync
+- [x] Step 1 (AFK): Protocol Document And Core Local Representation
+- [x] Step 2 (AFK): CLI Local Mode
+- [x] Step 3 (AFK): GitHub Transport
+- [x] Step 4 (AFK): EAG Validation
+- [x] Step 5 (AFK): Documentation Sync
 
 ## Implementation
 

--- a/specs/change/20260627-issue-dump-load/spec.md
+++ b/specs/change/20260627-issue-dump-load/spec.md
@@ -36,31 +36,43 @@ Dump a test Spec directory with multiple Markdown files to a local Issue Spec Re
 
 ## Plan
 
-- [ ] Step 1: Protocol document and core local representation
-  - [ ] Substep 1.1 Implement: Add parser/renderer for Issue Spec Representation v1.
-  - [ ] Substep 1.2 Implement: Walk Spec directories and build representation from all Markdown files.
-  - [ ] Substep 1.3 Implement: Load local representation into a new Spec directory.
-  - [ ] Substep 1.4 Verify: Add E2E coverage for local round-trip and fail-fast protocol errors.
-- [ ] Step 2: CLI commands and local mode
-  - [ ] Substep 2.1 Implement: Add `zest-dev dump <spec|active> --dry-run`.
-  - [ ] Substep 2.2 Implement: Add `zest-dev load --from-file <path>`.
-  - [ ] Substep 2.3 Verify: Cover command output, active-spec behavior, and package test path.
-- [ ] Step 3: GitHub transport
-  - [ ] Substep 3.1 Implement: Infer forge/repo from the default remote, falling back to GitHub.
-  - [ ] Substep 3.2 Implement: Create GitHub issues and comments through `gh`.
-  - [ ] Substep 3.3 Implement: Read GitHub issue body/comments through `gh` for remote load.
-  - [ ] Substep 3.4 Verify: Add adapter-focused tests with stubbed `gh` behavior.
-- [ ] Step 4: Documentation sync and acceptance
-  - [ ] Substep 4.1 Implement: Update README or command docs with `dump/load` usage.
-  - [ ] Substep 4.2 Verify: Run local E2E suite.
-  - [ ] Substep 4.3 Verify: Run package E2E suite when practical.
+### Step 1 (AFK): Protocol Document And Core Local Representation
+
+Goal: Establish the forge-neutral Issue Spec Representation and prove local lossless round-trip behavior.
+Scope: Keep [docs/issue-spec-representation.md](../../../docs/issue-spec-representation.md) aligned with implementation, add parser/renderer code, walk Spec directories for Markdown files, load local representations into new Spec directories, and cover local round-trip plus fail-fast protocol errors.
+Depends on: None
+
+### Step 2 (AFK): CLI Local Mode
+
+Goal: Expose the pure local protocol path through the public CLI.
+Scope: Add `zest-dev dump <spec|active> --dry-run` and `zest-dev load --from-file <path>`, preserving YAML-style command output, active-spec behavior, and package-install coverage.
+Depends on: Step 1
+
+### Step 3 (AFK): GitHub Transport
+
+Goal: Support real issue archive creation and loading for the first forge transport.
+Scope: Infer forge/repo from the default remote with GitHub fallback, use `gh` to create issues/comments and read issue body/comments, fail clearly for unsupported Forgejo, and test the adapter with stubbed `gh` behavior including partial failure reporting.
+Depends on: Step 2
+
+### Step 4 (AFK): EAG Validation
+
+Goal: Validate the completed change against the Spec's EAG before wrap-up work.
+Scope: Run the local representation round-trip EAG and fail-fast cases defined in the Design section, then run relevant local/package E2E coverage.
+Depends on: Step 3
+
+### Step 5 (AFK): Documentation Sync
+
+Goal: Keep project documentation aligned with the implemented behavior.
+Scope: If the implementation changes documented behavior, usage, commands, setup, or workflows, update the relevant project docs.
+Depends on: Step 4
 
 ## Progress
 
-- [ ] Step 1: Protocol document and core local representation
-- [ ] Step 2: CLI commands and local mode
-- [ ] Step 3: GitHub transport
-- [ ] Step 4: Documentation sync and acceptance
+- [ ] Step 1 (AFK): Protocol Document And Core Local Representation
+- [ ] Step 2 (AFK): CLI Local Mode
+- [ ] Step 3 (AFK): GitHub Transport
+- [ ] Step 4 (AFK): EAG Validation
+- [ ] Step 5 (AFK): Documentation Sync
 
 ## Implementation
 

--- a/specs/change/20260627-issue-dump-load/steps.md
+++ b/specs/change/20260627-issue-dump-load/steps.md
@@ -4,48 +4,48 @@
 
 ### Implementation
 
-Pending.
+Added the Issue Spec Representation core in `lib/spec-manager.js`: Spec directory Markdown walking, protocol header rendering/parsing, strict path/spec-id validation, duplicate detection, and local reconstruction into a new Spec directory.
 
 ### Verification
 
-Pending.
+Covered by the new E2E round-trip test that dumps a Spec with top-level and nested Markdown files, loads it into a fresh directory, and compares exact Markdown paths and file contents.
 
 ## Step 2 (AFK): CLI Local Mode
 
 ### Implementation
 
-Pending.
+Added public `zest-dev dump <spec|active> --dry-run` and `zest-dev load --from-file <path>` commands in `bin/zest-dev.js`, preserving YAML output and leaving the active Spec unchanged on load.
 
 ### Verification
 
-Pending.
+Verified through E2E CLI calls using `dump active --dry-run` and `load --from-file`, including package-install coverage.
 
 ## Step 3 (AFK): GitHub Transport
 
 ### Implementation
 
-Pending.
+Added GitHub transport through `gh`: remote dump creates a new issue and protocol comments, remote load reads issue body/comments, Forgejo inference fails clearly until a future adapter exists, and partial comment failure reports the created issue URL.
 
 ### Verification
 
-Pending.
+Covered by an E2E fake-`gh` adapter test for issue creation, comment creation, remote load, and partial comment failure reporting.
 
 ## Step 4 (AFK): EAG Validation
 
 ### Implementation
 
-Pending.
+Ran the local representation EAG and fail-fast cases for missing `spec.md`, non-Markdown files, missing protocol header, invalid `spec-id`, mismatched comment `spec-id`, duplicate paths, and existing target directory.
 
 ### Verification
 
-Pending.
+Passed `pnpm test:local` and `pnpm test:package`.
 
 ## Step 5 (AFK): Documentation Sync
 
 ### Implementation
 
-Pending.
+Updated `README.md` CLI reference with `dump` and `load`. The existing protocol document already matched the implemented behavior.
 
 ### Verification
 
-Pending.
+Documentation changes were included in the passing local and package E2E runs.

--- a/specs/change/20260627-issue-dump-load/steps.md
+++ b/specs/change/20260627-issue-dump-load/steps.md
@@ -1,6 +1,6 @@
 # Steps
 
-## Step 1: Protocol document and core local representation
+## Step 1 (AFK): Protocol Document And Core Local Representation
 
 ### Implementation
 
@@ -10,7 +10,7 @@ Pending.
 
 Pending.
 
-## Step 2: CLI commands and local mode
+## Step 2 (AFK): CLI Local Mode
 
 ### Implementation
 
@@ -20,7 +20,7 @@ Pending.
 
 Pending.
 
-## Step 3: GitHub transport
+## Step 3 (AFK): GitHub Transport
 
 ### Implementation
 
@@ -30,7 +30,17 @@ Pending.
 
 Pending.
 
-## Step 4: Documentation sync and acceptance
+## Step 4 (AFK): EAG Validation
+
+### Implementation
+
+Pending.
+
+### Verification
+
+Pending.
+
+## Step 5 (AFK): Documentation Sync
 
 ### Implementation
 

--- a/specs/change/20260627-issue-dump-load/steps.md
+++ b/specs/change/20260627-issue-dump-load/steps.md
@@ -1,0 +1,41 @@
+# Steps
+
+## Step 1: Protocol document and core local representation
+
+### Implementation
+
+Pending.
+
+### Verification
+
+Pending.
+
+## Step 2: CLI commands and local mode
+
+### Implementation
+
+Pending.
+
+### Verification
+
+Pending.
+
+## Step 3: GitHub transport
+
+### Implementation
+
+Pending.
+
+### Verification
+
+Pending.
+
+## Step 4: Documentation sync and acceptance
+
+### Implementation
+
+Pending.
+
+### Verification
+
+Pending.


### PR DESCRIPTION
## Summary

- Add `zest-dev dump` and `zest-dev load` for local Issue Spec Representation round trips and GitHub issue snapshots via `gh`.
- Implement fail-fast protocol validation for required `spec.md`, spec ids, Markdown paths, duplicate paths, unsupported forges, and partial GitHub comment failures.
- Add E2E coverage for local round trip, protocol errors, GitHub transport stubs, package installs, and update CLI docs/spec progress.

Closes #98.

## Validation

- `pnpm test:local`
- `pnpm test:package`