### PR TITLE
fix(cli): accept spec path identifiers

### DIFF
--- a/e2e/tests/test_issue_dump_load.py
+++ b/e2e/tests/test_issue_dump_load.py
@@ -53,7 +53,7 @@ def test_dump_and_load_round_trip_yaml_sensitive_markdown_paths(cli):
     (source_dir / "notes" / "a: b.md").write_text("# Colon\n", encoding="utf-8")
     (source_dir / "notes" / "foo #bar.md").write_text("# Hash\n", encoding="utf-8")
 
-    dumped = cli.yaml("dump", source_id, "--dry-run")
+    dumped = cli.yaml("dump", f"specs/change/{source_id}", "--dry-run")
     assert any("path: 'notes/a: b.md'" in comment for comment in dumped["issue"]["comments"])
     assert any("path: 'notes/foo #bar.md'" in comment for comment in dumped["issue"]["comments"])
 

--- a/e2e/tests/test_spec_lifecycle.py
+++ b/e2e/tests/test_spec_lifecycle.py
@@ -237,3 +237,20 @@ def test_update_and_active_alias(cli):
     implemented = cli.yaml("update", planned, "implemented")
     assert implemented["status"]["from"] == "planned"
     assert implemented["status"]["to"] == "implemented"
+
+
+def test_spec_commands_accept_path_identifiers(cli):
+    spec_id = cli.yaml("create", "path-identifier")["spec"]["id"]
+    spec_dir = f"specs/change/{spec_id}"
+    spec_file = f"{spec_dir}/spec.md"
+
+    assert cli.yaml("show", spec_dir)["id"] == spec_id
+    assert cli.yaml("show", f"{spec_dir}/")["id"] == spec_id
+    assert cli.yaml("show", spec_file)["id"] == spec_id
+
+    cli.ok("set-active", spec_dir)
+    assert cli.yaml("show", "active")["id"] == spec_id
+
+    update = cli.yaml("update", spec_file, "researched")
+    assert update["spec"]["id"] == spec_id
+    assert update["spec"]["status"] == "researched"

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -164,6 +164,20 @@ function validateSpecId(specId) {
   }
 }
 
+function normalizeSpecIdentifier(specIdentifier) {
+  if (specIdentifier === 'active' || specIdentifier === 'current') {
+    return specIdentifier;
+  }
+
+  const trimmed = String(specIdentifier).replace(/[\\/]+$/, '');
+  const basename = path.basename(trimmed);
+  if (basename === 'spec.md' || basename === 'README.md') {
+    return path.basename(path.dirname(trimmed));
+  }
+
+  return basename;
+}
+
 function normalizeIssueSpecPath(relativePath) {
   if (typeof relativePath !== 'string' || relativePath.trim() === '') {
     throw new Error('Invalid Issue Spec path: path is required');
@@ -565,9 +579,9 @@ function loadIssueRepresentation(issueOrOptions, options = {}) {
  * Get spec details by ID (full dir name) or "active"
  */
 function getSpec(specIdentifier) {
-  let specId = specIdentifier;
+  let specId = normalizeSpecIdentifier(specIdentifier);
 
-  if (specIdentifier === 'active' || specIdentifier === 'current') {
+  if (specId === 'active' || specId === 'current') {
     specId = getActiveChangeSpecId();
     if (!specId) {
       throw new Error('No active change spec set');
@@ -653,8 +667,7 @@ function createSpec(slug) {
  * Set active change spec
  */
 function setActiveChangeSpec(specId) {
-  // Allow full relative paths like "specs/20260224-foo" or "specs/20260224-foo/"
-  specId = path.basename(specId.replace(/\/+$/, ''));
+  specId = normalizeSpecIdentifier(specId);
   const specDirs = getSpecDirs();
   const specDir = specDirs.find(dir => dir === specId);
 


### PR DESCRIPTION
## Summary
- Normalize spec command arguments so directory paths and spec.md/README.md paths resolve to the spec id
- Reuse normalization for show/update/dump and set-active flows
- Add E2E coverage for path-form identifiers

## Tests
- pnpm test:local
- pnpm test:package