### PR TITLE
Publish zest-dev to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# Explicit npm ignore file.
+# Published content is primarily controlled by package.json "files".
+
+specs/
+e2e/
+test-package-env/
+node_modules/
+.npm/
+.git/
+.github/
+.cursor/
+.opencode/
+.agents/
+.codex/
+*.tgz

--- a/README.md
+++ b/README.md
@@ -4,7 +4,29 @@ A lightweight, human-interactive development workflow for AI-assisted coding.
 
 ## Quick Start
 
-Assuming `zest-dev` is already installed and available in PATH, initialize the editor-facing commands and skills in your project:
+Install the CLI from npm, then initialize the editor-facing commands and skills in your project:
+
+```bash
+npm install -g zest-dev
+zest-dev init
+```
+
+If you prefer not to install globally, run it with `npx`:
+
+```bash
+npx zest-dev init
+```
+
+After installation, verify the CLI is available:
+
+```bash
+zest-dev --version
+zest-dev --help
+```
+
+### Initialize a Project
+
+From the project where you want to use Zest Dev, run:
 
 ```bash
 zest-dev init
@@ -25,6 +47,20 @@ npm link
 zest-dev --help
 zest-dev init
 ```
+
+### Publishing to npm
+
+Publishing writes to the public npm registry and should remain a human-authorized release step.
+
+Before publishing, validate the package locally:
+
+```bash
+npm pack --dry-run --json
+pnpm test:local
+pnpm test:package
+```
+
+Then have the release operator confirm package ownership, version, tag, registry, and authentication requirements before running `npm publish`. If the npm account requires 2FA, the operator must complete the OTP prompt.
 
 ## Usage Workflow
 

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -21,6 +21,7 @@ const {
 const { deployPlugin } = require('../lib/plugin-deployer');
 const { generatePrompt } = require('../lib/prompt-generator');
 const { setupRalphFromActiveSpec } = require('../lib/ralph-setup');
+const packageJson = require('../package.json');
 
 const program = new Command();
 
@@ -126,7 +127,7 @@ function hasDeployedCommandMarkdowns() {
 program
   .name('zest-dev')
   .description('A lightweight, human-interactive development workflow for AI-assisted coding')
-  .version('0.1.0');
+  .version(packageJson.version);
 
 // zest-dev status
 program

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",

--- a/specs/change/20260630-publish-to-npm/design.md
+++ b/specs/change/20260630-publish-to-npm/design.md
@@ -1,0 +1,93 @@
+# Design
+
+## Research
+
+### Existing System
+
+- The package is named `zest-dev`, version `0.1.0`, licensed MIT, and includes npm metadata for author, repository, keywords, dependencies, and scripts. Source: `package.json:1-47`
+- The package exposes the CLI through `bin.zest-dev = ./bin/zest-dev.js`. Source: `package.json:18-21`
+- The CLI binary has a Node shebang and registers the `zest-dev` program name, description, and version `0.1.0`. Source: `bin/zest-dev.js:1`, `bin/zest-dev.js:126-129`
+- The package `files` allowlist includes `bin/`, `commands/`, `skills/`, `agents/`, `lib/`, `scripts/`, `plugin/`, `index.js`, `README.md`, and `LICENSE`. Source: `package.json:22-33`
+- README currently documents local development via `npm install` and `npm link`, but its Quick Start assumes `zest-dev` is already installed. Source: `README.md:5-27`
+- Local and package tests are available as `pnpm test:local` and `pnpm test:package`. Source: `package.json:34-38`, `e2e/README.md:12-29`
+- Package E2E testing runs `npm pack`, installs the produced tarball into an isolated package environment, and checks `npx zest-dev --version`. Source: `e2e/helpers/package_env.py:29-50`
+- The E2E suite covers local and packaged CLI execution paths and required setup/package install failure visibility. Source: `e2e/README.md:31-43`
+- `.gitignore` excludes generated package tarballs and optional npm cache output. Source: `.gitignore:71-84`
+
+### Design Inputs
+
+- `npm pack --dry-run --json` currently reports package `zest-dev@0.1.0`, 39 entries, and includes the intended CLI, library, command, skill, agent, plugin, README, LICENSE, script, and package files. Source: local command `npm pack --dry-run --json`, 2026-06-30
+- `npm pack --dry-run` warns that no `.npmignore` exists and npm is using `.gitignore` for file exclusion. Source: local command `npm pack --dry-run --json`, 2026-06-30
+- The public npm registry already has `zest-dev` at version `0.1.0`. Source: local command `npm view zest-dev version --json`, 2026-06-30
+- npm documents `npm pack --dry-run` as a no-change way to report what would be packed, and says dry-run is honored by `pack` and `publish`. Source: npm docs, `npm-pack`, Description / Configuration: dry-run, https://docs.npmjs.com/cli/v11/commands/npm-pack/
+- npm documents `npm publish <package-spec>` as publishing to the registry, with the public npm registry as default unless overridden. Source: npm docs, `npm-publish`, Description, https://docs.npmjs.com/cli/v11/commands/npm-publish/
+- npm documents `name` and `version` as required for publishing, semver-compatible versions, `private: true` as publish-blocking, `files` as package content control, and `bin` as the standard CLI executable mapping. Source: npm docs, `package-json`, `name`, `version`, `private`, `files`, `bin`, https://docs.npmjs.com/cli/v11/configuring-npm/package-json/
+- npm documents that 2FA publishing requires a second authentication step and that `otp` is a one-time password; if omitted and challenged, npm prompts on the command line. Source: npm docs, Two-factor authentication / `npm-publish` Configuration: otp, https://docs.npmjs.com/about-two-factor-authentication/, https://docs.npmjs.com/cli/v11/commands/npm-publish/
+- npm documents granular access tokens as website-created; CLI creation is not currently supported. Source: npm docs, Creating and viewing access tokens, https://docs.npmjs.com/creating-and-viewing-access-tokens/
+- npm provenance requires supported cloud CI/CD, such as GitHub Actions or GitLab CI/CD; first publish with provenance uses `npm publish --provenance --access public`. Source: npm docs, Generating provenance statements, https://docs.npmjs.com/generating-provenance-statements/
+
+### Constraints & Dependencies
+
+- Registry writes and npm account authentication are human-sensitive and should not be performed by AI without explicit instruction.
+- This repository's safety rules prefer fail-fast behavior and forbid hidden fallback data that makes a failed required step look successful. Source: `AGENTS.md:12-41`
+- The first implementation must handle the already-published `0.1.0` fact by choosing a publishable next version or intentionally deciding not to publish until ownership/version is resolved. Source: local command `npm view zest-dev version --json`, 2026-06-30
+- If provenance is required, CI/trusted publishing setup may be a separate workflow because this repository currently has no `.github/workflows/` files. Source: file search `.github/workflows/*`, 2026-06-30
+
+### Key References
+
+- `package.json:1-47` - package metadata, bin mapping, files allowlist, scripts, dependencies.
+- `bin/zest-dev.js:1,126-129` - executable shebang and CLI version registration.
+- `README.md:5-27` - current install/setup documentation gap.
+- `e2e/helpers/package_env.py:29-50` - package E2E pack/install/version flow.
+- `e2e/README.md:31-43` - packaged CLI behavior coverage and failure policy.
+- npm docs: `npm-pack`, `npm-publish`, `package-json`, 2FA, tokens, and provenance pages listed above.
+
+## Design Detail
+
+### Design Decisions
+
+- Decision: Use a manual npm publish gate rather than fully automating publish from the agent, because npm publish writes to the public registry and may require human OTP/token handling. Source: npm 2FA docs and `npm-publish` `otp` configuration; safety boundary from user requirement for HITL steps
+- Decision: Keep the package content source as the existing `package.json` `files` allowlist, but require `npm pack --dry-run --json` inspection before publishing. Source: `package.json:22-33`, npm `package-json` `files` docs, npm `npm-pack` dry-run docs
+- Decision: Treat `pnpm test:package` as the EAG because it packs, installs, and runs the CLI from an isolated package environment. Source: `package.json:34-38`, `e2e/helpers/package_env.py:29-50`
+- Decision: Require explicit version handling before publish because npm already reports `zest-dev` version `0.1.0`. Source: local command `npm view zest-dev version --json`, 2026-06-30
+- Decision: Document a plain local publish path first; defer CI/trusted publishing unless the Human chooses provenance as a release requirement. Source: npm provenance docs; `.github/workflows/*` search found no workflow files, 2026-06-30
+
+### System Procedure
+
+```mermaid
+flowchart TD
+  A[AI checks metadata and docs] --> B[AI runs pack dry-run and tests]
+  B --> C{Human authorizes release?}
+  C -- no --> D[Stop before registry write]
+  C -- yes --> E[Human runs npm publish and handles auth/OTP]
+  E --> F[AI validates reported output and package install behavior]
+  F --> G[AI syncs docs if needed]
+```
+
+### Change Scope
+
+Impact Areas:
+- Package metadata and CLI version consistency.
+- README installation and release guidance.
+- Package tarball contents and packaged-install validation.
+- Human release operation for npm registry writes.
+
+Planned File Changes:
+- `package.json` - update metadata/version/publish-related fields only if required for a publishable release.
+- `bin/zest-dev.js` - keep CLI `--version` aligned with package version if implementation chooses to remove hardcoding or bump version.
+- `README.md` - document npm install usage and any release-readiness instructions needed for users/maintainers.
+- Optional release documentation file - add only if README would become too release-operator-heavy.
+
+### Edge Cases
+
+- `zest-dev@0.1.0` already exists on npm; publishing the same name/version should fail and must not be papered over.
+- npm login, OTP prompts, package ownership, and access-token creation require Human action.
+- `npm pack --dry-run` can pass while package contents are semantically wrong; the file list must be inspected against intended user install behavior.
+- Provenance may require CI setup that is larger than a first manual publish path.
+
+### Verification Strategy
+
+- Run `npm pack --dry-run --json` and inspect package contents.
+- Run `pnpm test:local` before publishing.
+- Run `pnpm test:package` before publishing and again as the EAG after the publish attempt.
+- For HITL publish output, fail fast on any npm error and avoid declaring release success unless npm reports success and the package can be viewed/installed as expected.

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -1,0 +1,16 @@
+# Journal
+
+## Step 1 (AFK): Release Readiness Fixes
+
+Status: completed.
+
+Actions:
+- Reviewed the planned npm publish spec and release-readiness scope.
+- Confirmed the existing public npm package version is `zest-dev@0.1.0`, so the repository package version must move forward before publish.
+- Bumped `package.json` to `0.1.1`.
+- Updated the CLI version wiring so `zest-dev --version` reads from `package.json`.
+- Updated README Quick Start with npm installation, `npx`, version/help verification, and pre-publish validation commands.
+
+Notes:
+- Full tarball inspection and E2E validation are intentionally left for Step 2.
+- Actual npm publish remains blocked behind HITL authorization and publish steps.

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -14,3 +14,23 @@ Actions:
 Notes:
 - Full tarball inspection and E2E validation are intentionally left for Step 2.
 - Actual npm publish remains blocked behind HITL authorization and publish steps.
+
+## Step 2 (AFK): Package Contents and E2E Validation
+
+Status: completed.
+
+Actions:
+- Ran `npm pack --dry-run --json` and inspected the produced manifest for `zest-dev@0.1.1`.
+- Verified the package contains the intended public package surface: `LICENSE`, `README.md`, `package.json`, CLI binary, library code, templates, commands, skills, agents, plugin compatibility files, and helper scripts.
+- Verified non-package project artifacts are absent from the dry-run file list.
+- Added `.npmignore` as an explicit repository ignore file for npm packaging intent.
+- Ran `pnpm test:local` and `pnpm test:package`.
+
+Results:
+- `npm pack --dry-run --json`: package file list accepted for publish readiness; 39 entries.
+- `pnpm test:local`: 22 passed, 1 skipped.
+- `pnpm test:package`: 23 passed.
+
+Notes:
+- npm still printed a gitignore-fallback warning even after adding `.npmignore`; this is not blocking because the dry-run manifest is correct and the `files` allowlist controls package contents.
+- Next step is HITL release authorization before any registry write.

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -117,3 +117,15 @@ Results:
 
 Conclusion:
 - EAG passed.
+
+## Step 6 (AFK): Documentation Sync
+
+Status: completed.
+
+Actions:
+- Reviewed README after the successful npm release.
+- Confirmed install guidance is already present for global npm install and `npx` usage.
+- Confirmed release validation and human-authorized publish guidance is already present.
+
+Result:
+- No additional documentation changes were required after publishing `zest-dev@1.0.0`.

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -7,7 +7,7 @@ Status: completed.
 Actions:
 - Reviewed the planned npm publish spec and release-readiness scope.
 - Confirmed the existing public npm package version is `zest-dev@0.1.0`, so the repository package version must move forward before publish.
-- Bumped `package.json` to `0.1.1`.
+- Bumped `package.json` to `0.1.1`; later retargeted the release to `1.0.0` by Human request.
 - Updated the CLI version wiring so `zest-dev --version` reads from `package.json`.
 - Updated README Quick Start with npm installation, `npx`, version/help verification, and pre-publish validation commands.
 
@@ -50,3 +50,30 @@ Human action required:
 - Confirm default public npm registry.
 - Confirm whether manual publish without provenance is acceptable.
 - Confirm readiness to handle npm auth, OTP, or token prompts outside the agent.
+
+### Version retarget update
+
+Status: in progress.
+
+Human requested the release target move from `0.1.1` to `1.0.0`.
+
+AI actions:
+- Checked `npm view zest-dev@1.0.0 version --json`; npm returned `E404`, so `1.0.0` is not currently published.
+- Updated `package.json` to `1.0.0`.
+- Updated Step 3 release authorization notes to use `1.0.0`.
+
+Follow-up:
+- Re-run package dry-run and E2E validation for `1.0.0` before asking for final release authorization. Completed below.
+
+Validation after retargeting:
+- `node bin/zest-dev.js --version`: `1.0.0`.
+- `npm pack --dry-run --json`: package `zest-dev@1.0.0`, 39 entries.
+- `pnpm test:local`: 22 passed, 1 skipped.
+- `pnpm test:package`: 23 passed.
+
+Updated release authorization target:
+- Package: `zest-dev`
+- Version: `1.0.0`
+- Dist-tag: `latest`
+- Registry: default public npm registry
+- Proposed Step 4 command: `npm publish`

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -77,3 +77,26 @@ Updated release authorization target:
 - Dist-tag: `latest`
 - Registry: default public npm registry
 - Proposed Step 4 command: `npm publish`
+
+Step 3 outcome:
+- Human requested the publish command and proceeded with publishing the validated `1.0.0` target.
+
+## Step 4 (HITL): npm Publish
+
+Status: completed.
+
+AI actions:
+- Provided the Human with the exact publish command: `npm publish`.
+- Asked the Human to share the complete npm output for interpretation.
+
+Human actions:
+- Ran `npm publish` from the repository root.
+- Completed npm's browser authentication flow.
+- Shared npm output showing publication to `https://registry.npmjs.org/` with tag `latest` and default access.
+
+Result:
+- npm output ended with `+ zest-dev@1.0.0`, indicating the package publish succeeded.
+
+Notes:
+- The Human performed the registry-writing operation and authentication.
+- Next step is AFK EAG validation.

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -34,3 +34,19 @@ Results:
 Notes:
 - npm still printed a gitignore-fallback warning even after adding `.npmignore`; this is not blocking because the dry-run manifest is correct and the `files` allowlist controls package contents.
 - Next step is HITL release authorization before any registry write.
+
+## Step 3 (HITL): Human Release Authorization
+
+Status: waiting for Human confirmation.
+
+AI actions completed:
+- Rechecked npm registry metadata: `zest-dev` latest is `0.1.0`.
+- Prepared the release authorization summary for Human review.
+- Identified the proposed Step 4 publish command as `npm publish` from the repository root, assuming the Human confirms a normal manual public release without provenance.
+
+Human action required:
+- Confirm package ownership/publish permission for `zest-dev`.
+- Confirm version `0.1.1` and dist-tag `latest`.
+- Confirm default public npm registry.
+- Confirm whether manual publish without provenance is acceptable.
+- Confirm readiness to handle npm auth, OTP, or token prompts outside the agent.

--- a/specs/change/20260630-publish-to-npm/journal.md
+++ b/specs/change/20260630-publish-to-npm/journal.md
@@ -100,3 +100,20 @@ Result:
 Notes:
 - The Human performed the registry-writing operation and authentication.
 - Next step is AFK EAG validation.
+
+## Step 5 (AFK): EAG Validation
+
+Status: completed.
+
+Actions:
+- Checked npm registry version metadata after publish.
+- Checked npm dist-tags after publish.
+- Ran the Spec EAG verification path: `pnpm test:package`.
+
+Results:
+- `npm view zest-dev version --json`: `1.0.0`.
+- `npm view zest-dev dist-tags --json`: `latest` points to `1.0.0`.
+- `pnpm test:package`: 23 passed.
+
+Conclusion:
+- EAG passed.

--- a/specs/change/20260630-publish-to-npm/spec.md
+++ b/specs/change/20260630-publish-to-npm/spec.md
@@ -1,0 +1,98 @@
+---
+id: 20260630-publish-to-npm
+name: Publish To Npm
+status: planned
+created: '2026-06-30'
+---
+
+## Overview
+
+Publish `zest-dev` to npm so users can install and run the CLI without cloning this repository or using `npm link`.
+
+Goals:
+- Confirm the package metadata, CLI entrypoint, package contents, and packaged-install behavior are publish-ready.
+- Separate agent-doable release preparation from human-only or dangerous npm registry actions.
+- Produce a clear release procedure for the first npm publish.
+
+Scope:
+- Prepare this repository for publishing the current `zest-dev` package to the public npm registry.
+- Validate the packed package and documented install path.
+- Include Human-in-the-loop publishing steps for authentication, OTP/token handling, and the actual registry write.
+
+Success Criteria:
+- `npm pack --dry-run` shows only intended package contents.
+- Existing local and packaged CLI tests pass before publish.
+- The Plan clearly distinguishes AFK steps from HITL steps and states what AI and Human each do in every HITL step.
+
+## Research
+
+See [design.md](./design.md).
+
+## Design
+
+### Design Summary
+
+Treat npm publishing as a release-readiness and operator handoff change, not as a fully automated registry write. The AI prepares and validates package metadata, tarball contents, test coverage, README install guidance, and a release checklist. The Human performs npm-account-sensitive actions: confirming package ownership, choosing final version/tag, authenticating, entering OTP or using a protected token, and running the final `npm publish` command.
+
+See [design.md](./design.md) for design detail.
+
+### E2E Acceptance Gate (EAG)
+
+Acceptance behavior: A freshly packed package installs into an isolated project and exposes a working `zest-dev` CLI with the repository's packaged-install E2E behavior intact.
+
+Verification path: `pnpm test:package`
+
+## Plan
+
+### Step 1 (AFK): Release Readiness Fixes
+
+Goal: Make the package publish-ready before any registry write.
+Scope: Review and update package metadata, version wiring, README install guidance, and any package content controls needed for the intended public npm package.
+Depends on: None
+
+### Step 2 (AFK): Package Contents and E2E Validation
+
+Goal: Prove the packed artifact contains the intended files and works after installation.
+Scope: Run `npm pack --dry-run --json`, inspect the file list, run `pnpm test:local`, and run `pnpm test:package`; fix any required readiness issues that are safe for AI to change.
+Depends on: Step 1
+
+### Step 3 (HITL): Human Release Authorization
+
+Goal: Confirm the irreversible npm release parameters before publishing.
+Scope: AI summarizes validated package name, version, tag, tarball contents, and exact publish command; Human confirms npm account/package ownership, final version/tag, registry target, whether provenance is required, and whether to proceed.
+Depends on: Step 2
+
+### Step 4 (HITL): npm Publish
+
+Goal: Publish the validated package to the public npm registry.
+Scope: AI provides the exact command and watches/interprets output if the Human shares it; Human runs the registry-writing `npm publish` command, completes login/OTP/token prompts, and reports success or failure output back to AI.
+Depends on: Step 3
+
+### Step 5 (AFK): EAG Validation
+
+Goal: Validate the completed change against the Spec's EAG before wrap-up work.
+Scope: Run `pnpm test:package` to verify the packaged-install acceptance behavior defined in the Design section.
+Depends on: Step 4
+
+### Step 6 (AFK): Documentation Sync
+
+Goal: Keep project documentation aligned with the implemented behavior.
+Scope: If the implementation or release outcome changes documented install, setup, commands, publishing, or workflow behavior, update the relevant project docs.
+Depends on: Step 5
+
+## Progress
+
+- [x] Step 1 (AFK): Release Readiness Fixes
+- [ ] Step 2 (AFK): Package Contents and E2E Validation
+- [ ] Step 3 (HITL): Human Release Authorization
+- [ ] Step 4 (HITL): npm Publish
+- [ ] Step 5 (AFK): EAG Validation
+- [ ] Step 6 (AFK): Documentation Sync
+
+## Implementation
+
+See [steps.md](./steps.md).
+
+## Deferred Follow-Ups (DFU)
+
+None.

--- a/specs/change/20260630-publish-to-npm/spec.md
+++ b/specs/change/20260630-publish-to-npm/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260630-publish-to-npm
 name: Publish To Npm
-status: planned
+status: implemented
 created: '2026-06-30'
 ---
 
@@ -87,7 +87,7 @@ Depends on: Step 5
 - [x] Step 3 (HITL): Human Release Authorization
 - [x] Step 4 (HITL): npm Publish
 - [x] Step 5 (AFK): EAG Validation
-- [ ] Step 6 (AFK): Documentation Sync
+- [x] Step 6 (AFK): Documentation Sync
 
 ## Implementation
 

--- a/specs/change/20260630-publish-to-npm/spec.md
+++ b/specs/change/20260630-publish-to-npm/spec.md
@@ -86,7 +86,7 @@ Depends on: Step 5
 - [x] Step 2 (AFK): Package Contents and E2E Validation
 - [x] Step 3 (HITL): Human Release Authorization
 - [x] Step 4 (HITL): npm Publish
-- [ ] Step 5 (AFK): EAG Validation
+- [x] Step 5 (AFK): EAG Validation
 - [ ] Step 6 (AFK): Documentation Sync
 
 ## Implementation

--- a/specs/change/20260630-publish-to-npm/spec.md
+++ b/specs/change/20260630-publish-to-npm/spec.md
@@ -84,8 +84,8 @@ Depends on: Step 5
 
 - [x] Step 1 (AFK): Release Readiness Fixes
 - [x] Step 2 (AFK): Package Contents and E2E Validation
-- [ ] Step 3 (HITL): Human Release Authorization
-- [ ] Step 4 (HITL): npm Publish
+- [x] Step 3 (HITL): Human Release Authorization
+- [x] Step 4 (HITL): npm Publish
 - [ ] Step 5 (AFK): EAG Validation
 - [ ] Step 6 (AFK): Documentation Sync
 

--- a/specs/change/20260630-publish-to-npm/spec.md
+++ b/specs/change/20260630-publish-to-npm/spec.md
@@ -83,7 +83,7 @@ Depends on: Step 5
 ## Progress
 
 - [x] Step 1 (AFK): Release Readiness Fixes
-- [ ] Step 2 (AFK): Package Contents and E2E Validation
+- [x] Step 2 (AFK): Package Contents and E2E Validation
 - [ ] Step 3 (HITL): Human Release Authorization
 - [ ] Step 4 (HITL): npm Publish
 - [ ] Step 5 (AFK): EAG Validation

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -61,3 +61,13 @@ Completed npm publish:
 Notes:
 - Registry write was performed by the Human, not by AI.
 - Step 5 will validate the released package path.
+
+## Step 5
+
+Completed EAG validation:
+- Ran `npm view zest-dev version --json`: `1.0.0`.
+- Ran `npm view zest-dev dist-tags --json`: `latest` points to `1.0.0`.
+- Ran `pnpm test:package`: 23 passed.
+
+Result:
+- The Design EAG passed: the packaged-install E2E behavior remains intact after the npm publish.

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -46,3 +46,18 @@ Human must confirm before Step 4:
 - Publishing to the default public npm registry under `latest` is intended.
 - Manual publish without provenance is acceptable, or they explicitly request a provenance/trusted-publishing path instead.
 - They are ready to handle npm login, OTP, or access-token prompts locally.
+
+Outcome:
+- Human proceeded with Step 4 using the validated `1.0.0` release target.
+
+## Step 4
+
+Completed npm publish:
+- AI provided the publish command: `npm publish`.
+- Human ran the command and completed npm's browser authentication flow.
+- npm output reported publishing to `https://registry.npmjs.org/` with tag `latest` and default access.
+- npm output ended with `+ zest-dev@1.0.0`.
+
+Notes:
+- Registry write was performed by the Human, not by AI.
+- Step 5 will validate the released package path.

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -21,3 +21,23 @@ Completed package contents and E2E validation:
 
 Notes:
 - Added `.npmignore` as an explicit ignore file, but npm still emitted its gitignore-fallback warning during dry-run. The published content remains controlled and verified through `package.json` `files` plus the dry-run manifest.
+
+## Step 3
+
+Status: awaiting Human release authorization.
+
+AI summary for Human review:
+- Package: `zest-dev`
+- Current repository version: `0.1.1`
+- Current npm latest version: `0.1.0`
+- Proposed npm dist-tag: `latest`
+- Proposed registry: default public npm registry
+- Provenance: not included in the first manual publish command unless Human explicitly requires it
+- Proposed publish command for Step 4: `npm publish`
+
+Human must confirm before Step 4:
+- They control or can publish to the npm package `zest-dev`.
+- `0.1.1` is the intended release version.
+- Publishing to the default public npm registry under `latest` is intended.
+- Manual publish without provenance is acceptable, or they explicitly request a provenance/trusted-publishing path instead.
+- They are ready to handle npm login, OTP, or access-token prompts locally.

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -71,3 +71,10 @@ Completed EAG validation:
 
 Result:
 - The Design EAG passed: the packaged-install E2E behavior remains intact after the npm publish.
+
+## Step 6
+
+Completed documentation sync:
+- Reviewed README install and publish guidance after the successful npm release.
+- Confirmed Step 1 already updated Quick Start with `npm install -g zest-dev`, `npx zest-dev init`, CLI verification, and pre-publish validation guidance.
+- No additional documentation changes were required after the successful `1.0.0` publish.

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -9,3 +9,15 @@ Completed release-readiness updates:
 
 Verification:
 - Deferred full package validation to Step 2.
+
+## Step 2
+
+Completed package contents and E2E validation:
+- Ran `npm pack --dry-run --json` for `zest-dev@0.1.1`.
+- Inspected the tarball manifest: 39 entries, including `LICENSE`, `README.md`, `package.json`, `bin/`, `lib/`, `commands/`, `skills/`, `agents/`, `scripts/`, and `plugin/` content.
+- Confirmed generated specs, E2E fixtures, caches, node modules, npm cache, and package tarballs are not in the package file list.
+- Ran `pnpm test:local`: 22 passed, 1 skipped.
+- Ran `pnpm test:package`: 23 passed.
+
+Notes:
+- Added `.npmignore` as an explicit ignore file, but npm still emitted its gitignore-fallback warning during dry-run. The published content remains controlled and verified through `package.json` `files` plus the dry-run manifest.

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -1,0 +1,11 @@
+# Steps
+
+## Step 1
+
+Completed release-readiness updates:
+- Bumped package version from `0.1.0` to `0.1.1` because `zest-dev@0.1.0` already exists on npm.
+- Changed `bin/zest-dev.js` to read `--version` from `package.json` instead of hardcoding it.
+- Updated README Quick Start with npm install, `npx`, verification, and human-authorized publishing guidance.
+
+Verification:
+- Deferred full package validation to Step 2.

--- a/specs/change/20260630-publish-to-npm/steps.md
+++ b/specs/change/20260630-publish-to-npm/steps.md
@@ -3,7 +3,7 @@
 ## Step 1
 
 Completed release-readiness updates:
-- Bumped package version from `0.1.0` to `0.1.1` because `zest-dev@0.1.0` already exists on npm.
+- Bumped package version from `0.1.0` to `0.1.1` because `zest-dev@0.1.0` already exists on npm; later retargeted the release to `1.0.0` by Human request.
 - Changed `bin/zest-dev.js` to read `--version` from `package.json` instead of hardcoding it.
 - Updated README Quick Start with npm install, `npx`, verification, and human-authorized publishing guidance.
 
@@ -13,14 +13,19 @@ Verification:
 ## Step 2
 
 Completed package contents and E2E validation:
-- Ran `npm pack --dry-run --json` for `zest-dev@0.1.1`.
+- Ran `npm pack --dry-run --json` for `zest-dev@0.1.1`, then reran it for `zest-dev@1.0.0` after the Human retargeted the release version.
 - Inspected the tarball manifest: 39 entries, including `LICENSE`, `README.md`, `package.json`, `bin/`, `lib/`, `commands/`, `skills/`, `agents/`, `scripts/`, and `plugin/` content.
 - Confirmed generated specs, E2E fixtures, caches, node modules, npm cache, and package tarballs are not in the package file list.
 - Ran `pnpm test:local`: 22 passed, 1 skipped.
 - Ran `pnpm test:package`: 23 passed.
+- After retargeting to `1.0.0`, reran `node bin/zest-dev.js --version`: `1.0.0`.
+- After retargeting to `1.0.0`, reran `npm pack --dry-run --json`: package `zest-dev@1.0.0`, 39 entries.
+- After retargeting to `1.0.0`, reran `pnpm test:local`: 22 passed, 1 skipped.
+- After retargeting to `1.0.0`, reran `pnpm test:package`: 23 passed.
 
 Notes:
 - Added `.npmignore` as an explicit ignore file, but npm still emitted its gitignore-fallback warning during dry-run. The published content remains controlled and verified through `package.json` `files` plus the dry-run manifest.
+- The release target is now `1.0.0`.
 
 ## Step 3
 
@@ -28,7 +33,7 @@ Status: awaiting Human release authorization.
 
 AI summary for Human review:
 - Package: `zest-dev`
-- Current repository version: `0.1.1`
+- Current repository version: `1.0.0`
 - Current npm latest version: `0.1.0`
 - Proposed npm dist-tag: `latest`
 - Proposed registry: default public npm registry
@@ -37,7 +42,7 @@ AI summary for Human review:
 
 Human must confirm before Step 4:
 - They control or can publish to the npm package `zest-dev`.
-- `0.1.1` is the intended release version.
+- `1.0.0` is the intended release version.
 - Publishing to the default public npm registry under `latest` is intended.
 - Manual publish without provenance is acceptable, or they explicitly request a provenance/trusted-publishing path instead.
 - They are ready to handle npm login, OTP, or access-token prompts locally.


### PR DESCRIPTION
## Summary
- prepare npm package release metadata and installation docs
- bump package version to 1.0.0 and sync CLI --version with package.json
- add Zest Dev spec/journal for npm publish workflow and record successful publish

## Verification
- npm pack --dry-run --json
- pnpm test:local
- pnpm test:package
- npm view zest-dev version --json => 1.0.0
- npm view zest-dev dist-tags --json => latest: 1.0.0