### PR TITLE
Fix trusted publishing 404 on npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,9 +23,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.14.0'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm install --global npm@^11.5.1
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
@@ -39,6 +41,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Show publish toolchain versions
+        run: node --version && npm --version && pnpm --version
 
       - name: Run local integration tests
         run: pnpm test:local

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "name": "nettee",
     "email": "nettee.liu@gmail.com"
   },
-  "repository": "https://github.com/nettee/zest-dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nettee/zest-dev.git"
+  },
   "license": "MIT",
   "keywords": [
     "workflow",

--- a/specs/change/20260704-auto-publish-cli-version-ci/journal.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/journal.md
@@ -61,3 +61,10 @@
 - `npm view zest-dev version --json` still reports `1.0.0`, while merged `package.json` is `1.0.1`; publish is not complete.
 - `npm owner ls zest-dev` reports package owner `nettee <anchori@163.com>`.
 - External research is in progress to identify the exact Trusted Publishing remediation before rerunning the release.
+
+## 2026-07-04 - Step 5 remediation prepared
+
+- Prepared a follow-up fix branch after research identified three high-probability causes for misleading Trusted Publishing 404s.
+- Removed `registry-url` from `actions/setup-node` in `publish-npm.yml` so GitHub Actions does not inject `_authToken` config that can block OIDC publishing.
+- Upgraded the publish workflow runtime to Node `22.14.0` and npm `^11.5.1`, matching current npm Trusted Publishing requirements.
+- Normalized `package.json.repository` to `{ type: "git", url: "git+https://github.com/nettee/zest-dev.git" }` so published metadata matches the GitHub repo exactly.

--- a/specs/change/20260704-auto-publish-cli-version-ci/journal.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/journal.md
@@ -68,3 +68,8 @@
 - Removed `registry-url` from `actions/setup-node` in `publish-npm.yml` so GitHub Actions does not inject `_authToken` config that can block OIDC publishing.
 - Upgraded the publish workflow runtime to Node `22.14.0` and npm `^11.5.1`, matching current npm Trusted Publishing requirements.
 - Normalized `package.json.repository` to `{ type: "git", url: "git+https://github.com/nettee/zest-dev.git" }` so published metadata matches the GitHub repo exactly.
+
+## 2026-07-04 - Step 5 remediation PR created
+
+- Created follow-up PR: https://github.com/nettee/zest-dev/pull/105
+- This PR is intended to unblock a rerun of the `Publish npm` workflow so the real release validation can continue.

--- a/specs/change/20260704-auto-publish-cli-version-ci/journal.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/journal.md
@@ -52,3 +52,12 @@
 
 - Human configured npm Trusted Publisher for `nettee/zest-dev` with workflow filename `publish-npm.yml`.
 - npm shows publish permissions for the trusted publisher, so no expiring `NPM_TOKEN` secret is needed.
+
+## 2026-07-04 - Step 5 publish validation failed
+
+- PR #104 was merged to `main` as merge commit `c65782e`.
+- The `Publish npm` workflow ran on `main` and failed in the `npm publish --access public --provenance` step.
+- Provenance signing reached npm successfully, but the final registry publish failed with `npm error code E404` and `404 Not Found - PUT https://registry.npmjs.org/zest-dev - Not found`.
+- `npm view zest-dev version --json` still reports `1.0.0`, while merged `package.json` is `1.0.1`; publish is not complete.
+- `npm owner ls zest-dev` reports package owner `nettee <anchori@163.com>`.
+- External research is in progress to identify the exact Trusted Publishing remediation before rerunning the release.


### PR DESCRIPTION
## Summary

- remove `registry-url` from `actions/setup-node` in `publish-npm.yml` to avoid injected auth config that can block npm OIDC trusted publishing
- upgrade the publish workflow to Node `22.14.0` and npm `^11.5.1`
- normalize `package.json.repository` to `git+https://github.com/nettee/zest-dev.git`
- record the failed publish validation and remediation in the active spec journal

## Why

The first real publish validation after merging #104 failed with:

- `npm error code E404`
- `404 Not Found - PUT https://registry.npmjs.org/zest-dev - Not found`

Research points to three likely causes addressed here:

- `setup-node` auth injection interfering with OIDC trusted publishing
- npm CLI / Node version too old for trusted publishing reliability
- repository metadata needing exact GitHub repo match

## Validation

- `pnpm test:ci-version-freshness`
- `pnpm test:ci-pr-bump`
- `pnpm test:ci-publish`
- `git diff --check`