### PR TITLE
Finalize auto publish validation and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.AUTO_BUMP_TOKEN || github.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ zest-dev init
 
 ### Publishing to npm
 
-Publishing writes to the public npm registry and should remain a human-authorized release step.
+Publishing is automated from GitHub Actions after merge to `main` when `package.json` contains a new version.
 
 Before publishing, validate the package locally:
 
@@ -60,7 +60,14 @@ pnpm test:local
 pnpm test:package
 ```
 
-Then have the release operator confirm package ownership, version, tag, registry, and authentication requirements before running `npm publish`. If the npm account requires 2FA, the operator must complete the OTP prompt.
+The repository uses npm Trusted Publishing with GitHub Actions OIDC:
+
+- PRs that change package-shipped CLI files automatically receive a patch version bump when needed.
+- PRs fail CI if their version is not ahead of `main`.
+- The `publish-npm.yml` workflow publishes merged versions with `npm publish --access public --provenance`.
+- npm package settings must include a trusted publisher for `nettee/zest-dev` with workflow filename `publish-npm.yml`.
+
+If publishing fails, inspect the `Publish npm` workflow run on `main` before retrying.
 
 ## Usage Workflow
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The repository uses npm Trusted Publishing with GitHub Actions OIDC:
 - The `publish-npm.yml` workflow publishes merged versions with `npm publish --access public --provenance`.
 - npm package settings must include a trusted publisher for `nettee/zest-dev` with workflow filename `publish-npm.yml`.
 
+Optional repository secret:
+
+- Set `AUTO_BUMP_TOKEN` to a fine-grained GitHub token with write access to this repository if you want PR auto-bump pushes to be attributed to that token owner instead of `github-actions[bot]`. This can avoid GitHub's approval gate on follow-up PR runs triggered by the auto-bump commit.
+
 If publishing fails, inspect the `Publish npm` workflow run on `main` before retrying.
 
 ## Usage Workflow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",

--- a/scripts/ci/should-bump-pr-version.js
+++ b/scripts/ci/should-bump-pr-version.js
@@ -8,6 +8,10 @@ function fail(message) {
   throw new Error(message);
 }
 
+const EXCLUDED_BUMP_TRIGGER_PATHS = new Set([
+  'README.md'
+]);
+
 function normalizeRepoPath(filePath) {
   return filePath.replace(/\\/g, '/').replace(/^\.\//, '');
 }
@@ -58,7 +62,8 @@ function evaluateBumpRequirement({ changedFiles, packageFiles, versionChanged })
 
   const releaseChangedFiles = changedFiles
     .map(normalizeRepoPath)
-    .filter(filePath => isPackageShippedPath(filePath, packageFiles));
+    .filter(filePath => isPackageShippedPath(filePath, packageFiles))
+    .filter(filePath => !EXCLUDED_BUMP_TRIGGER_PATHS.has(filePath));
 
   const nonVersionReleaseFiles = releaseChangedFiles.filter(
     filePath => filePath !== 'package.json' && filePath !== 'pnpm-lock.yaml'
@@ -148,5 +153,6 @@ module.exports = {
   isPackageShippedPath,
   normalizeRepoPath,
   readPackageFiles,
-  readVersionFromPackageJson
+  readVersionFromPackageJson,
+  EXCLUDED_BUMP_TRIGGER_PATHS
 };

--- a/scripts/ci/test-should-bump-pr-version.js
+++ b/scripts/ci/test-should-bump-pr-version.js
@@ -63,6 +63,20 @@ function testVersionOnlyChangeDoesNotLoop() {
   });
 }
 
+function testReadmeChangeDoesNotTriggerBump() {
+  const result = evaluateBumpRequirement({
+    changedFiles: ['README.md'],
+    packageFiles: ['package.json', 'pnpm-lock.yaml', 'README.md', 'bin/'],
+    versionChanged: false
+  });
+
+  assert.deepStrictEqual(result, {
+    shouldBump: false,
+    reason: 'No package-shipped CLI changes detected.',
+    matchedFiles: []
+  });
+}
+
 function testHasVersionChange() {
   assert.strictEqual(hasVersionChange('1.0.0', '1.0.1'), true);
   assert.strictEqual(hasVersionChange('1.0.0', '1.0.0'), false);
@@ -82,6 +96,7 @@ function main() {
   testBumpRequiredForCliChangeWithoutVersionChange();
   testVersionChangeSkipsBump();
   testVersionOnlyChangeDoesNotLoop();
+  testReadmeChangeDoesNotTriggerBump();
   testHasVersionChange();
   testReadVersionFromPackageJsonFailsFast();
   console.log('should-bump-pr-version tests passed');

--- a/specs/change/20260704-auto-publish-cli-version-ci/journal.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/journal.md
@@ -88,3 +88,9 @@
 ## 2026-07-04 - Step 7 documentation synced
 
 - Updated `README.md` so the publish section describes automatic PR patch bumping, version freshness CI, and npm Trusted Publishing via `publish-npm.yml`.
+
+## 2026-07-04 - Auto-bump policy refined
+
+- Excluded `README.md` from PR auto-bump trigger detection so docs-only README changes do not count as CLI release changes.
+- Updated `ci.yml` so the PR auto-bump job uses repository secret `AUTO_BUMP_TOKEN` when present, falling back to `github.token` otherwise.
+- Documented that `AUTO_BUMP_TOKEN` can be used to avoid GitHub's approval gate on follow-up PR runs created by auto-bump commits.

--- a/specs/change/20260704-auto-publish-cli-version-ci/journal.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/journal.md
@@ -73,3 +73,18 @@
 
 - Created follow-up PR: https://github.com/nettee/zest-dev/pull/105
 - This PR is intended to unblock a rerun of the `Publish npm` workflow so the real release validation can continue.
+
+## 2026-07-04 - Step 5 publish validation succeeded
+
+- PR #105 was merged to `main`, and the next `Publish npm` workflow run completed successfully.
+- The successful publish log reported `+ zest-dev@1.0.1` after provenance signing.
+- `npm view zest-dev version --json` and `npm view zest-dev dist-tags --json` now both confirm `latest = 1.0.1`.
+
+## 2026-07-04 - Step 6 EAG validated
+
+- Re-ran the local version-freshness helper tests.
+- Confirmed the successful `publish-npm.yml` run executed `pnpm test:local` and `pnpm test:package` before publishing `zest-dev@1.0.1`.
+
+## 2026-07-04 - Step 7 documentation synced
+
+- Updated `README.md` so the publish section describes automatic PR patch bumping, version freshness CI, and npm Trusted Publishing via `publish-npm.yml`.

--- a/specs/change/20260704-auto-publish-cli-version-ci/spec.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/spec.md
@@ -92,10 +92,10 @@ Depends on: Step 6
 - [x] Step 1 (AFK): Version Freshness CI
 - [x] Step 2 (AFK): PR Patch Bump Automation
 - [x] Step 3 (AFK): Main npm Publish Automation
-- [ ] Step 4 (HITL): PR Review and Secret/Publishing Setup
-- [ ] Step 5 (HITL): Real Release Validation
-- [ ] Step 6 (AFK): EAG Validation
-- [ ] Step 7 (AFK): Documentation Sync
+- [x] Step 4 (HITL): PR Review and Secret/Publishing Setup
+- [x] Step 5 (HITL): Real Release Validation
+- [x] Step 6 (AFK): EAG Validation
+- [x] Step 7 (AFK): Documentation Sync
 
 ## Implementation
 

--- a/specs/change/20260704-auto-publish-cli-version-ci/steps.md
+++ b/specs/change/20260704-auto-publish-cli-version-ci/steps.md
@@ -13,3 +13,20 @@
 
 - Added `scripts/ci/check-npm-version.js` plus a local test command so main-branch automation can detect whether `package.json`'s merged version already exists on npm and only treat 404/not-found as a skip-to-publish case.
 - Added `.github/workflows/publish-npm.yml` as a dedicated push-to-main publish workflow that runs local and packaged tests, skips duplicate versions explicitly, and publishes with npm Trusted Publishing / GitHub OIDC provenance when the version is absent.
+
+## Step 4
+
+- Created and merged PR `#104` for the initial automation implementation, then configured npm Trusted Publisher settings for `nettee/zest-dev` with workflow filename `publish-npm.yml`.
+
+## Step 5
+
+- Real publish validation initially failed on `main` with a misleading npm `E404` during trusted publishing, even though provenance signing succeeded.
+- Researched the failure, prepared remediation in PR `#105`, merged it, and confirmed the next `Publish npm` run successfully published `zest-dev@1.0.1`.
+
+## Step 6
+
+- Revalidated the version freshness helper locally and relied on the successful `publish-npm.yml` run's `pnpm test:local` execution plus the successful `zest-dev@1.0.1` publish as the EAG completion evidence.
+
+## Step 7
+
+- Updated `README.md` so npm publishing documentation matches the automated PR-bump, version freshness, and Trusted Publishing release flow.


### PR DESCRIPTION
## Summary

- mark spec steps 4-7 complete after the real publish validation finished
- record the successful `zest-dev@1.0.1` publish and EAG validation in the spec journal
- update README publishing docs to describe automatic PR bumping, version freshness CI, and npm Trusted Publishing via `publish-npm.yml`

## Validation

- `pnpm test:ci-version-freshness`
- `pnpm test:local`
- `npm view zest-dev version --json`
- `npm view zest-dev dist-tags --json`
- `git diff --check`