### PR TITLE
Fix archive label existence checks

### DIFF
--- a/.github/workflows/archive-old-specs.yml
+++ b/.github/workflows/archive-old-specs.yml
@@ -34,8 +34,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh label view "spec:change" >/dev/null 2>&1 || gh label create "spec:change" --color "5319e7" --description "Zest Dev change spec"
-          gh label view "archive" >/dev/null 2>&1 || gh label create "archive" --color "cfd3d7" --description "Archived spec snapshot"
+          [ "$(gh label list --search "spec:change" --json name --jq 'any(.name == "spec:change")')" = "true" ] \
+            || gh label create "spec:change" --color "5319e7" --description "Zest Dev change spec"
+          [ "$(gh label list --search "archive" --json name --jq 'any(.name == "archive")')" = "true" ] \
+            || gh label create "archive" --color "cfd3d7" --description "Archived spec snapshot"
 
       - name: Archive eligible specs
         env:


### PR DESCRIPTION
## Summary\n- Replace unsupported `gh label view` calls with `gh label list` checks\n- Keep archive label creation idempotent without forcing label metadata updates\n\n## Validation\n- `pnpm test:ci-archive-specs`\n- Verified `gh label list --search ... --jq 'any(...)'` returns true for both labels