### PR TITLE
fix: skip non-markdown files when dumping specs

### DIFF
--- a/e2e/tests/test_issue_dump_load.py
+++ b/e2e/tests/test_issue_dump_load.py
@@ -72,7 +72,9 @@ def test_dump_and_load_fail_fast_for_invalid_local_protocol(cli):
     created = cli.yaml("create", "invalid-dump-source")["spec"]
     spec_dir = cli.project_dir / "specs" / "change" / created["id"]
     (spec_dir / "asset.txt").write_text("not markdown\n", encoding="utf-8")
-    assert "Non-Markdown file in Spec directory: asset.txt" in cli.fail("dump", created["id"], "--dry-run")
+    dumped = cli.yaml("dump", created["id"], "--dry-run")
+    assert dumped["ok"] is True
+    assert "asset.txt" not in yaml.safe_dump(dumped["issue"])
 
     (spec_dir / "asset.txt").unlink()
     (spec_dir / "spec.md").unlink()

--- a/lib/spec-manager.js
+++ b/lib/spec-manager.js
@@ -220,7 +220,7 @@ function walkSpecDirectory(specDirPath, currentDir = specDirPath, files = []) {
       walkSpecDirectory(specDirPath, entryPath, files);
     } else if (entry.isFile()) {
       if (!entry.name.endsWith('.md')) {
-        throw new Error(`Non-Markdown file in Spec directory: ${relativePath}`);
+        continue;
       }
       files.push(relativePath);
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",


### PR DESCRIPTION
## Summary
- skip non-Markdown regular files while building issue archive dumps
- keep load-side issue spec path validation restricted to Markdown files
- update E2E coverage to assert non-Markdown local files are omitted from dumps

## Validation
- uv run pytest tests/test_issue_dump_load.py -v
- node scripts/ci/test-archive-old-specs.js
- pnpm test:local