### PR TITLE
Optimize Zest Dev prompts for GPT-5.6

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,7 +41,7 @@ The `## Design Detail` section in `design.md` that carries lower-review-frequenc
 _Avoid_: design summary, main design
 
 **Steps File**:
-The `steps.md` Spec Supporting File that records implementation and verification by Plan Step. It does not split implementation and verification into separate global sections.
+The `steps.md` Spec Supporting File that acts as a selective implementation journal by completed Plan Step. Each entry records the implemented outcome, verification, and downstream impact without repeating Plan or Design prose; later steps read only relevant history.
 _Avoid_: implementation log, verification log
 
 **Spec Template**:

--- a/bin/zest-dev.js
+++ b/bin/zest-dev.js
@@ -41,6 +41,11 @@ function getOptionalGlobalOpenCodeCommandDir() {
   return path.join(homeDir, '.config', 'opencode', 'commands');
 }
 
+function getOptionalHomeDir() {
+  const homeDir = process.env.HOME || process.env.USERPROFILE;
+  return homeDir && path.isAbsolute(homeDir) ? homeDir : null;
+}
+
 function getDeployedCommandDirs() {
   const dirs = [
     path.join(process.cwd(), '.cursor/commands'),
@@ -50,6 +55,25 @@ function getDeployedCommandDirs() {
   const globalOpenCodeCommandDir = getOptionalGlobalOpenCodeCommandDir();
   if (globalOpenCodeCommandDir) {
     dirs.push(globalOpenCodeCommandDir);
+  }
+
+  return dirs;
+}
+
+function getDeployedZestDevSkillDirs() {
+  const dirs = [
+    path.join(process.cwd(), '.opencode/skills/zest-dev'),
+    path.join(process.cwd(), '.agents/skills/zest-dev')
+  ];
+
+  const globalOpenCodeCommandDir = getOptionalGlobalOpenCodeCommandDir();
+  if (globalOpenCodeCommandDir) {
+    dirs.push(path.join(path.dirname(globalOpenCodeCommandDir), 'skills/zest-dev'));
+  }
+
+  const homeDir = getOptionalHomeDir();
+  if (homeDir) {
+    dirs.push(path.join(homeDir, '.agents/skills/zest-dev'));
   }
 
   return dirs;
@@ -124,6 +148,12 @@ function hasDeployedCommandMarkdowns() {
   });
 }
 
+function hasDeployedZestDevSkill() {
+  return getDeployedZestDevSkillDirs().some(dirPath =>
+    fs.existsSync(path.join(dirPath, 'SKILL.md'))
+  );
+}
+
 program
   .name('zest-dev')
   .description('A lightweight, human-interactive development workflow for AI-assisted coding')
@@ -136,9 +166,9 @@ program
   .action(() => {
     try {
       const status = getSpecsStatus();
-      if (hasDeployedCommandMarkdowns()) {
+      if (hasDeployedCommandMarkdowns() || hasDeployedZestDevSkill()) {
         status.agent_hints = [
-          'Run `zest-dev init` to update deployed command markdown files.'
+          'Run `zest-dev init` to update deployed commands and skills.'
         ];
       }
 

--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -133,6 +133,9 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     implement_phase = (skills_dir / "zest-dev" / "implement.md").read_text(encoding="utf-8")
     assert "When test-driven development fits the behavior and files being changed" in implement_phase
     assert "If required evidence, configuration, credentials, or a consequential Design decision is missing" in implement_phase
+    assert "Treat `steps.md` as a selective implementation journal, not required full-context input" in implement_phase
+    assert "Scan its step headings and `Downstream impact` entries" in implement_phase
+    assert "without restating Goal or Scope" in implement_phase
     assert "mark the corresponding `spec.md` → `## Progress` checkbox as `[x]`" in implement_phase
     assert "DFU is fixed during the Design Phase" in implement_phase
     assert "confirm the DFU with the user instead of silently appending it" in implement_phase

--- a/e2e/tests/test_init_deployment.py
+++ b/e2e/tests/test_init_deployment.py
@@ -85,20 +85,29 @@ def test_default_global_init_deploys_expected_artifacts(cli):
         assert "**Step 1:" not in (commands_dir / filename).read_text(encoding="utf-8")
 
     skill_content = (skills_dir / "zest-dev" / "SKILL.md").read_text(encoding="utf-8")
-    assert "This skill defines the workflow for planned feature work" in skill_content
-    assert "always include a dedicated EAG Validation step before the final Documentation Sync step" in skill_content
+    assert "This file owns routing and shared invariants" in skill_content
+    assert "Preserve required facts, decisions, constraints, caveats" in skill_content
     for filename in SKILL_PHASE_FILES:
         assert (skills_dir / "zest-dev" / filename).exists()
+
+    source_root = cli.packaged_cli_root if cli.is_packaged else Path(__file__).resolve().parents[2]
+    source_skill_dir = source_root / "skills" / "zest-dev"
+    for filename in ["SKILL.md", *SKILL_PHASE_FILES]:
+        expected = (source_skill_dir / filename).read_text(encoding="utf-8")
+        assert (skills_dir / "zest-dev" / filename).read_text(encoding="utf-8") == expected
+        assert (codex_skill_dir / filename).read_text(encoding="utf-8") == expected
 
     brainstorming_skill = (skills_dir / "brainstorming" / "SKILL.md").read_text(encoding="utf-8")
     assert "include a dedicated `EAG Validation` step before the final `Documentation Sync` step" in brainstorming_skill
 
     research_phase = (skills_dir / "zest-dev" / "research.md").read_text(encoding="utf-8")
-    assert "Summarize your understanding of the request and confirm it with the user" in research_phase
+    assert "Stop when material Design inputs have representative evidence" in research_phase
+    assert "Label inference separately from directly supported facts" in research_phase
 
     design_phase = (skills_dir / "zest-dev" / "design.md").read_text(encoding="utf-8")
     assert "If the status is `designed`, `planned`, or `implemented`, confirm that the user wants to revise the existing design before continuing." in design_phase
     assert "Fill the Design Section:" in design_phase
+    assert "a source supports the factual premise, not the normative choice itself" in design_phase
     assert "### E2E Acceptance Gate (EAG)" in design_phase
     assert "The EAG is the Design Section's automated end-to-end acceptance gate, not a general test plan." in design_phase
     assert "`### E2E Acceptance Gate (EAG)`" in design_phase
@@ -115,22 +124,22 @@ def test_default_global_init_deploys_expected_artifacts(cli):
     assert "Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that." in plan_phase
     assert "Do not use markdown checkboxes in `## Plan`." in plan_phase
     assert "Add or update `spec.md` → `## Progress` with a thin progress checklist:" in plan_phase
-    assert "### Step 3 (AFK): EAG Validation" in plan_phase
-    assert "### Step 4 (AFK): Documentation Sync" in plan_phase
+    assert "Add a dedicated Plan step for EAG Validation" in plan_phase
+    assert "Add a final Plan step for Documentation Sync when the Design is expected to change documented behavior" in plan_phase
     assert "Step N (AFK): ..." in plan_phase
     assert "Report every Plan step's `Type` as `AFK` or `HITL`." in plan_phase
     assert "For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues." in plan_phase
 
     implement_phase = (skills_dir / "zest-dev" / "implement.md").read_text(encoding="utf-8")
-    assert "try to use the registered `tdd` skill" in implement_phase
-    assert "judge applicability from the spec, plan step, and files being changed" in implement_phase
+    assert "When test-driven development fits the behavior and files being changed" in implement_phase
+    assert "If required evidence, configuration, credentials, or a consequential Design decision is missing" in implement_phase
     assert "mark the corresponding `spec.md` → `## Progress` checkbox as `[x]`" in implement_phase
     assert "DFU is fixed during the Design Phase" in implement_phase
     assert "confirm the DFU with the user instead of silently appending it" in implement_phase
     assert "mark the corresponding `## Plan` checkbox" not in implement_phase
 
     codex_skill = (codex_skill_dir / "SKILL.md").read_text(encoding="utf-8")
-    assert "This skill defines the workflow for planned feature work" in codex_skill
+    assert "This file owns routing and shared invariants" in codex_skill
     for subagent in CODEX_SUBAGENTS:
         content = (codex_agents_dir / subagent).read_text(encoding="utf-8")
         assert "name = " in content

--- a/e2e/tests/test_spec_lifecycle.py
+++ b/e2e/tests/test_spec_lifecycle.py
@@ -52,6 +52,10 @@ def test_create_uses_builtin_split_templates(cli):
     assert "## Design Detail" in design
     assert "## Design\n" not in design
     assert "## Step 1" in steps
+    assert "### Changed" in steps
+    assert "### Verified" in steps
+    assert "### Downstream impact" in steps
+    assert "Selective implementation journal" in steps
     assert "## Implementation" not in steps
     assert "## Verification" not in steps
     assert "Phase 3: Test and verify" not in content

--- a/e2e/tests/test_spec_lifecycle.py
+++ b/e2e/tests/test_spec_lifecycle.py
@@ -184,14 +184,15 @@ def test_status_agent_hints(cli):
     cursor_commands = cli.project_dir / ".cursor" / "commands"
     cursor_commands.mkdir(parents=True)
     (cursor_commands / "zest-dev-new.md").write_text("# test", encoding="utf-8")
-    assert cli.yaml("status", env=status_env)["agent_hints"] == ["Run `zest-dev init` to update deployed command markdown files."]
+    update_hint = "Run `zest-dev init` to update deployed commands and skills."
+    assert cli.yaml("status", env=status_env)["agent_hints"] == [update_hint]
 
     global_env = isolated_global_env(cli.project_dir / "global-hint-env")
     (cursor_commands / "zest-dev-new.md").unlink()
     global_commands = Path(global_env["XDG_CONFIG_HOME"]) / "opencode" / "commands"
     global_commands.mkdir(parents=True)
     (global_commands / "zest-dev-new.md").write_text("# test", encoding="utf-8")
-    assert cli.yaml("status", env=global_env)["agent_hints"] == ["Run `zest-dev init` to update deployed command markdown files."]
+    assert cli.yaml("status", env=global_env)["agent_hints"] == [update_hint]
 
     status = cli.yaml("status", env={"HOME": "", "XDG_CONFIG_HOME": "relative-config"})
     assert status["specs_count"] == 2
@@ -201,6 +202,11 @@ def test_status_agent_hints(cli):
     (other_commands / "pr.md").write_text("# unrelated", encoding="utf-8")
     (global_commands / "zest-dev-new.md").unlink()
     assert "agent_hints" not in cli.yaml("status", env=status_env)
+
+    local_codex_skill = cli.project_dir / ".agents" / "skills" / "zest-dev"
+    local_codex_skill.mkdir(parents=True)
+    (local_codex_skill / "SKILL.md").write_text("# deployed skill", encoding="utf-8")
+    assert cli.yaml("status", env=status_env)["agent_hints"] == [update_hint]
 
 
 def test_update_and_active_alias(cli):

--- a/lib/template/steps.md
+++ b/lib/template/steps.md
@@ -1,5 +1,17 @@
 # Steps
 
-## Step 1
+<!-- Selective implementation journal. Add one section per completed Plan step; do not repeat Plan Goal/Scope or Design prose. -->
 
-<!-- Implementation and verification notes for the matching Plan step. Add one section per Plan step. -->
+## Step 1: Title
+
+### Changed
+
+<!-- Implemented outcome. -->
+
+### Verified
+
+<!-- Relevant command or check and its result. -->
+
+### Downstream impact
+
+None.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -10,19 +10,7 @@ version: 0.1.0
 
 Zest Dev is a lightweight, human-interactive workflow for spec-driven development.
 
-This skill defines the workflow for planned feature work:
-- `new`
-- `research`
-- `design`
-- `plan`
-- `implement`
-
-To keep this file concise, the detailed workflows live in sibling phase docs:
-- `new.md`
-- `research.md`
-- `design.md`
-- `plan.md`
-- `implement.md`
+Planned feature work progresses through `new → researched → designed → planned → implemented`. This file owns routing and shared invariants; sibling phase files own phase-specific behavior and output guidance.
 
 ## When This Skill Should Trigger
 
@@ -67,89 +55,17 @@ Use this skill when the user:
 - Ask targeted clarifying questions when requirements or architecture are underspecified.
 - If the user says “whatever you think is best,” provide your recommendation and get confirmation when the choice is consequential.
 
-## Entry Modes
-
-Examples:
-- “create a spec for this”
-- “research this change”
-- “design the architecture”
-- “plan the implementation”
-- “implement the active spec”
-
-Infer the intended phase from user intent and current spec status.
-
-## Workflow Overview
-
-```text
-User intent
-          ↓
-  Zest Dev skill phase routing
-          ↓
-     zest-dev CLI + spec files
-          ↓
- spec updated with brief, reviewable content
-```
-
-Valid progression:
-
-```text
-new → researched → designed → planned → implemented
-```
-
 ## Phase Routing
 
-### New phase
-Use when there is no spec yet and the user wants to formalize a requirement.
+Infer the intended phase from user intent and the active spec status, then read its canonical file:
 
-### Research phase
-Use when a spec exists and the team needs repository facts, patterns, and options.
-
-### Design phase
-Use when research or direct understanding is sufficient to choose an implementation design.
-
-### Plan phase
-Use when the design is ready to turn into issue-scale implementation steps.
-
-### Implement phase
-Use when the plan is ready for coding.
-
-## Canonical Phase Workflow Files
-
-### New
-- The canonical New workflow lives in `new.md`.
-- Use it for spec creation, overview writing, and first-step guidance.
-
-### Research
-- The canonical Research workflow lives in `research.md`.
-- Use it for repository discovery, factual research writing, and status advancement to `researched`.
-
-### Design
-- The canonical Design workflow lives in `design.md`.
-- Use it for clarifications, architecture synthesis, design decisions, Deferred Follow-Ups (DFU), and status advancement to `designed`.
-
-### Plan
-- The canonical Plan workflow lives in `plan.md`.
-- Use it for issue-scale step shaping and status advancement to `planned`.
-- During planning, always include a dedicated EAG Validation step before the final Documentation Sync step.
-
-### Implement
-- The canonical Implement workflow lives in `implement.md`.
-- Use it for implementation, test writing, notes updates, and status advancement to `implemented` only when the full plan is complete.
-
-## Content Guidance Ownership
-
-Concrete section-writing guidance lives in the phase files:
-- `new.md` defines how to write `## Overview`.
-- `research.md` defines how to write `design.md` → `## Research`.
-- `design.md` defines how to write the Design Section: `spec.md` → `## Design` for Design Summary and EAG, `spec.md` → `## Deferred Follow-Ups (DFU)`, plus `design.md` → `## Design Detail`.
-- `plan.md` defines how to write `spec.md` → `## Plan` and `## Progress`.
-- `implement.md` defines how to update `spec.md` → `## Progress` and write `steps.md`.
+- `new.md`: create and activate a spec; write `## Overview`.
+- `research.md`: gather repository facts in `design.md` → `## Research`; advance to `researched`.
+- `design.md`: resolve consequential questions; write Design, EAG, DFU, and Design Detail; advance to `designed`.
+- `plan.md`: create issue-scale Plan and Progress entries; advance to `planned`.
+- `implement.md`: implement and validate the Plan; update Progress and `steps.md`; advance to `implemented` only when complete.
 
 ## Guardrails
 
 - Do not hardcode platform-specific agent handles in workflow text.
 - Prefer generic role language such as explorer, architect, or reviewer subagent.
-
-## Summary
-
-Use this skill for workflow logic, the CLI for lifecycle transitions, and the spec file as the durable record.

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -46,7 +46,7 @@ Use this skill when the user:
 - Use pseudocode and flow descriptions instead of production code.
 - Keep Research factual.
 - Keep Design opinionated.
-- In implementation notes, record what changed, how it was verified, and material deviations without repeating the Plan or Design.
+- Treat `steps.md` as a selective implementation journal. Record what changed, how it was verified, and downstream impact without repeating the Plan or Design.
 
 ### Reading discipline
 - Before writing or deciding, read the active spec and the relevant repository files.

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when the user:
 ## Shared Rules
 
 ### Language
-- Always respond in the user's language unless the user asks to switch languages.
+- Use the user's current language for conversation and prose artifacts. Preserve code identifiers, commands, quoted text, and established project terminology in their original form; switch languages when the user requests it.
 
 ### Source of truth
 - Treat this skill as the workflow source for the five core phases.
@@ -40,12 +40,13 @@ Use this skill when the user:
   - `implemented`
 
 ### Spec writing principles
-- Prioritize brevity.
-- Prefer bullets over long prose.
+- Preserve required facts, decisions, constraints, caveats, evidence gaps, open questions, acceptance behavior, and next actions.
+- Remove repetition, generic background, and implementation detail that does not change the contract.
+- Prefer bullets when they make the artifact easier to review; use prose or a diagram when relationships would otherwise be unclear.
 - Use pseudocode and flow descriptions instead of production code.
 - Keep Research factual.
 - Keep Design opinionated.
-- Keep implementation notes concise and implementation-focused.
+- In implementation notes, record what changed, how it was verified, and material deviations without repeating the Plan or Design.
 
 ### Reading discipline
 - Before writing or deciding, read the active spec and the relevant repository files.

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -48,8 +48,10 @@ Fill the Design Section:
    - Do not add DFU items on your own initiative.
    - Do not put current-Spec implementation work, Documentation Sync work, or Progress items in DFU.
    - List all design decisions.
-   - Every design decision must cite its fact source inline or immediately adjacent to it.
-   - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.
+   - For each design decision, cite the factual premises that materially support it inline or immediately adjacent to it.
+   - State the decision's rationale, trade-off, or inference separately; a source supports the factual premise, not the normative choice itself.
+   - Reuse factual sources already captured in `## Research` when possible; gather new evidence when a material premise is unsupported.
+   - Preserve material source conflicts or evidence gaps as explicit constraints or open questions until they are resolved.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
 
 ## Constraints

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -47,7 +47,7 @@ Fill the Design Section:
    - Add DFU items only when the user explicitly says they want to handle that work later, or when a clear functional gap is discovered and you confirm with the user before placing it into DFU.
    - Do not add DFU items on your own initiative.
    - Do not put current-Spec implementation work, Documentation Sync work, or Progress items in DFU.
-   - List all design decisions.
+   - Record design decisions that materially affect behavior, contracts, architecture boundaries, compatibility, rollout, or verification.
    - For each design decision, cite the factual premises that materially support it inline or immediately adjacent to it.
    - State the decision's rationale, trade-off, or inference separately; a source supports the factual premise, not the normative choice itself.
    - Reuse factual sources already captured in `## Research` when possible; gather new evidence when a material premise is unsupported.

--- a/skills/zest-dev/design.md
+++ b/skills/zest-dev/design.md
@@ -5,18 +5,25 @@ Canonical workflow for designing an active change spec.
 ## When to use
 - Research or direct understanding is sufficient to choose an implementation design
 
-## Workflow
-1. Run `zest-dev status` and verify an active change spec exists.
-2. Run `zest-dev show active`, read the main spec file, and read `design.md`.
-3. Check status gating before proceeding:
+## Outcome
+Choose one reviewable architecture, grounded in the Research and repository evidence, that defines the implementation boundary and how its user- or system-visible behavior will be verified.
+
+## Success means
+- The active spec, current status, main spec, and `design.md` were read.
+- Consequential open questions are resolved before the architecture is finalized.
+- The Design Summary, EAG, Design Detail, Change Scope, edge cases, and verification strategy are mutually consistent.
+- The chosen architecture includes its rationale and matching test strategy.
+- The spec advances to `designed` and Design stops before implementation planning.
+
+## Status gate
+- Run `zest-dev status` and `zest-dev show active` before designing.
+- Check the current status:
    - If the status is `new`, suggest research first unless the task is simple and sufficiently understood.
    - If the status is `researched`, continue.
    - If the status is `designed`, `planned`, or `implemented`, confirm that the user wants to revise the existing design before continuing.
-4. Identify underspecified areas: scope, edge cases, contracts, compatibility, testing, rollout.
-5. Ask the user clarifying questions when needed.
-6. Wait for answers before finalizing the architecture when the open questions are consequential.
-7. Synthesize one recommended architecture by default, including the matching test strategy.
-8. Fill the Design Section:
+
+## Required output
+Fill the Design Section:
    - In `spec.md` → `## Design`, write:
      - `### Design Summary`
      - `### E2E Acceptance Gate (EAG)`
@@ -44,8 +51,15 @@ Canonical workflow for designing an active change spec.
    - Every design decision must cite its fact source inline or immediately adjacent to it.
    - Reuse sources already captured in `## Research` when possible; gather new factual sources when needed.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
-9. Run `zest-dev update active designed`.
-10. Present the design and stop.
+
+## Constraints
+- Identify underspecified scope, edge cases, contracts, compatibility, testing, and rollout concerns.
+- Ask only questions whose answers can materially change the architecture or implementation boundary.
+- Synthesize one recommended architecture by default.
+
+## Stop or block
+- If a consequential question remains unanswered, stop and name what decision is blocked.
+- Otherwise run `zest-dev update active designed`, present the Design, and stop without creating the Plan.
 
 ## Rule
 This is where decisions, trade-offs, and recommendations belong.

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -9,20 +9,27 @@ Canonical workflow for implementing an active change spec.
 Complete the planned change in repository code, keep implementation state observable, and finish only when the Design's behavior and relevant validation pass.
 
 ## Success means
-- The active spec has status `planned`, and the main spec, `design.md`, `steps.md`, and relevant implementation files were read.
+- The active spec has status `planned`, and `## Progress` identifies the current incomplete Plan step.
+- The current Plan step, its dependencies, the relevant Design contract, and relevant implementation files were read.
 - Each completed Plan step is implemented with its relevant tests passing.
-- `## Progress` and `steps.md` accurately report completed work, verification, and material deviations.
+- `## Progress` reports completion state, while `steps.md` records completed-step outcomes, verification, and downstream impact.
 - The spec advances to `implemented` only when every Plan step is complete.
 
 ## Constraints
+- Use `spec.md` → `## Progress` to find the first incomplete step, then read that Plan step and its dependencies before coding.
+- Read the Design sections, Research evidence, and repository files that materially affect the current step; do not reload unrelated background by default.
+- Treat `steps.md` as a selective implementation journal, not required full-context input:
+    - Scan its step headings and `Downstream impact` entries to locate relevant history.
+    - Read a completed step section when the current step depends on it or when it records a deviation, invariant, interface, migration state, or other downstream impact relevant to the current work.
+    - For legacy entries without `Downstream impact`, read the completed section when the current Plan step depends on it.
 - Implement the feature following the Plan, Design, and repository conventions.
 - Write or update tests alongside the implementation.
 - When test-driven development fits the behavior and files being changed, use the registered `tdd` skill and its red-green-refactor loop.
 - After each completed Plan step, mark the corresponding `spec.md` → `## Progress` checkbox as `[x]` only when that step is complete and relevant tests pass; preserve the `Step N (AFK): ...` or `Step N (HITL): ...` title format.
-- Fill `steps.md` with one section per completed Plan step. Each section should briefly combine:
-    - what changed
-    - how the step was verified
-    - any design deviation or follow-up relevant to that step
+- Append or update one `steps.md` section per completed Plan step using:
+    - `Changed`: the implemented outcome, without restating Goal or Scope.
+    - `Verified`: the relevant command or check and its result.
+    - `Downstream impact`: a concise invariant, deviation, interface, migration state, or dependency that later steps must preserve; write `None.` when there is no downstream impact.
 - Do not add new Deferred Follow-Ups (DFU) during implementation. DFU is fixed during the Design Phase; if implementation reveals missing deferred work that changes the Design boundary, revise the Design and confirm the DFU with the user instead of silently appending it.
 
 ## Stop or block

--- a/skills/zest-dev/implement.md
+++ b/skills/zest-dev/implement.md
@@ -5,22 +5,31 @@ Canonical workflow for implementing an active change spec.
 ## When to use
 - The plan is ready for coding
 
-## Workflow
-1. Run `zest-dev status` and verify an active change spec exists with status `planned`.
-2. Run `zest-dev show active`, read the main spec file, read `design.md`, and read `steps.md`.
-3. Read all relevant implementation files before coding.
-4. When the implementation work is suitable for test-driven development, try to use the registered `tdd` skill and its red-green-refactor loop; judge applicability from the spec, plan step, and files being changed.
-5. Implement the feature following the plan, design, and repository conventions.
-6. Write or update tests alongside the implementation, not afterward.
-7. Run relevant tests during implementation, fix issues, and continue until the relevant tests pass.
-8. After each completed plan step, mark the corresponding `spec.md` → `## Progress` checkbox as `[x]` only when that step is complete and relevant tests pass; preserve the `Step N (AFK): ...` or `Step N (HITL): ...` title format.
-9. Fill `steps.md` with one section per completed Plan step. Each section should briefly combine:
+## Outcome
+Complete the planned change in repository code, keep implementation state observable, and finish only when the Design's behavior and relevant validation pass.
+
+## Success means
+- The active spec has status `planned`, and the main spec, `design.md`, `steps.md`, and relevant implementation files were read.
+- Each completed Plan step is implemented with its relevant tests passing.
+- `## Progress` and `steps.md` accurately report completed work, verification, and material deviations.
+- The spec advances to `implemented` only when every Plan step is complete.
+
+## Constraints
+- Implement the feature following the Plan, Design, and repository conventions.
+- Write or update tests alongside the implementation.
+- When test-driven development fits the behavior and files being changed, use the registered `tdd` skill and its red-green-refactor loop.
+- After each completed Plan step, mark the corresponding `spec.md` → `## Progress` checkbox as `[x]` only when that step is complete and relevant tests pass; preserve the `Step N (AFK): ...` or `Step N (HITL): ...` title format.
+- Fill `steps.md` with one section per completed Plan step. Each section should briefly combine:
     - what changed
     - how the step was verified
     - any design deviation or follow-up relevant to that step
-10. Do not add new Deferred Follow-Ups (DFU) during implementation. DFU is fixed during the Design Phase; if implementation reveals missing deferred work that changes the Design boundary, revise the Design and confirm the DFU with the user instead of silently appending it.
-11. If the full spec is complete, run `zest-dev update active implemented`.
-12. If only part of the work is complete, keep the current non-final status and document what was done.
+- Do not add new Deferred Follow-Ups (DFU) during implementation. DFU is fixed during the Design Phase; if implementation reveals missing deferred work that changes the Design boundary, revise the Design and confirm the DFU with the user instead of silently appending it.
+
+## Stop or block
+- Run the most relevant tests and checks during implementation. Fix failures caused by the change before marking a step complete.
+- If required evidence, configuration, credentials, or a consequential Design decision is missing, stop and report the blocker instead of guessing or marking partial work successful.
+- If only part of the Plan is complete, keep the current non-final status and document what was done.
+- When the full Plan is complete and relevant validation passes, run `zest-dev update active implemented`.
 
 ## Rule
 Only mark the spec `implemented` when the whole plan is finished.

--- a/skills/zest-dev/new.md
+++ b/skills/zest-dev/new.md
@@ -6,14 +6,19 @@ Canonical workflow for creating a new change spec.
 - No active spec exists yet
 - The user wants to formalize a new requirement
 
-## Workflow
-1. Extract a human-readable name and kebab-case slug.
-2. Run `zest-dev create <slug>`.
-3. Set the created spec active with `zest-dev set-active <spec-id>`.
-4. Read the created spec file.
-5. Fill `## Overview` using only information the user actually provided.
-6. Ask clarifying questions only when the requirement is too vague to produce a useful overview.
-7. Confirm spec id, path, active status, and next step.
+## Outcome
+Create and activate a reviewable change spec whose Overview captures the user's actual requirement without inventing missing detail.
+
+## Success means
+- The spec was created through `zest-dev create <slug>` and activated through `zest-dev set-active <spec-id>`.
+- `## Overview` states the known problem, desired outcome, and material boundaries.
+- Any missing information that prevents a useful Overview is resolved with the smallest targeted question.
+- The user receives the spec id, path, active status, and recommended next phase.
+
+## Constraints
+- Read the created spec before editing it.
+- Derive a human-readable name and kebab-case slug from the request.
+- Use only information the user provided or explicitly confirmed.
 
 ## Overview content may include
 - Problem Statement
@@ -23,3 +28,7 @@ Canonical workflow for creating a new change spec.
 - Success Criteria
 
 Do not invent missing sections.
+
+## Stop or block
+- Stop after presenting the created and activated spec; do not begin Research unless requested.
+- If the request is too vague to state a meaningful problem or outcome, ask for the smallest missing requirement before filling the Overview.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -11,7 +11,7 @@ Turn the approved Design into a compact sequence of issue-scale implementation s
 ## Success means
 - The active spec, current status, main spec, and `design.md` were read.
 - Every Plan step has a meaningful goal, bounded scope, dependency, and AFK/HITL type.
-- Functional work is followed by EAG Validation and the final documentation check.
+- Functional work is followed by EAG Validation, with a final Documentation Sync step when the Design is expected to affect project documentation.
 - `## Progress` mirrors the Plan step titles exactly.
 - An eligible `designed` spec advances to `planned`; revised later-phase specs keep their status.
 
@@ -38,10 +38,9 @@ Turn the approved Design into a compact sequence of issue-scale implementation s
    - The step should tell the implementer to validate the completed change against the Design section's EAG.
    - When the Design says there is no EAG, the step should explicitly confirm that no dedicated automated end-to-end gate exists and use the best available validation already defined by the Spec.
    - Do not redefine the EAG during planning. Reuse the Design section's acceptance behavior and verification path as written.
-- Add a final Plan step for Documentation Sync:
-   - Always include this as the final Plan step.
-   - The step should tell the implementer to update relevant project documentation if the implemented change makes that necessary.
-   - Do not decide during planning whether documentation must change. Leave that check to implementation, when the final code and behavior are visible.
+- Add a final Plan step for Documentation Sync when the Design is expected to change documented behavior, usage, commands, setup, or workflows:
+   - The step should tell the implementer which documentation areas to re-evaluate after the final code and behavior are visible.
+   - When no documentation impact is expected, make EAG Validation the final step and state that assumption in its Scope.
    - Do not automatically include glossary or ADR work. Treat those as special documentation updates only when the implemented change genuinely calls for them.
 
 ## Required output
@@ -51,7 +50,7 @@ Fill `## Plan` with compact structured steps:
    - Prefer steps that each deliver one meaningful vertical slice and remain easy to review.
    - Good step boundaries usually align with one user-visible workflow, one subsystem integration boundary, one migration or rollout step, or one stabilization milestone.
    - Each step should be issue-scale: large enough to matter, small enough for a coding agent to implement and validate in one focused session.
-   - Keep fields brief. Do not turn each step into a second design document.
+   - Preserve the goal, implementation boundary, validation scope, dependency, and any acceptance detail needed to remove ambiguity; omit repeated Design prose.
    - Include `Goal`, `Scope`, and `Depends on`; the type belongs in the step heading, not as a separate field.
    - Use `Depends on: None` when the step has no dependency.
    - Add acceptance criteria only when they are necessary to remove ambiguity.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -55,45 +55,28 @@ Fill `## Plan` with compact structured steps:
    - Include `Goal`, `Scope`, and `Depends on`; the type belongs in the step heading, not as a separate field.
    - Use `Depends on: None` when the step has no dependency.
    - Add acceptance criteria only when they are necessary to remove ambiguity.
-   - Format as structured prose, for example:
+   - Use this field schema:
       ```markdown
-      ### Step 1 (AFK): Foo
+      ### Step N (AFK|HITL): Title
 
-      Goal: Deliver the smallest useful end-to-end Foo behavior.
-      Scope: Update the Foo command path and its integration tests.
-      Depends on: None
-
-      ### Step 2 (HITL): Bar
-
-      Goal: Choose and apply the Bar user-facing behavior.
-      Scope: Confirm the behavior with the user, then update Bar prompts and docs.
-      Depends on: Step 1
-
-      ### Step 3 (AFK): EAG Validation
-
-      Goal: Validate the completed change against the Spec's EAG before wrap-up work.
-      Scope: Run the automated end-to-end verification path defined in the Design section, or confirm that the Design explicitly says there is no EAG and use the best available Spec-defined validation.
-      Depends on: Step 2
-
-      ### Step 4 (AFK): Documentation Sync
-
-      Goal: Keep project documentation aligned with the implemented behavior.
-      Scope: If the implementation changes documented behavior, usage, commands, setup, or workflows, update the relevant project docs.
-      Depends on: Step 3
+      Goal: <meaningful outcome>
+      Scope: <bounded implementation and validation scope>
+      Depends on: <Step N or None>
       ```
+
 Add or update `spec.md` → `## Progress` with a thin progress checklist:
    - Add one checkbox per Plan step.
    - Keep each checklist item to the step title only.
    - Preserve the step type marker after the step number, matching the Plan heading form: `Step N (AFK): ...` or `Step N (HITL): ...`.
    - This checklist is for implementation progress tracking, not for describing the plan.
    - Do not include Deferred Follow-Ups (DFU), because DFU is outside the current Spec's Plan.
-   - Format:
+   - Mirror the Plan titles exactly:
       ```markdown
       ## Progress
 
-      - [ ] Step 1 (AFK): Foo
-      - [ ] Step 2 (HITL): Bar
+      - [ ] Step N (AFK|HITL): Title
       ```
+
 ## Status update
 - Update status based on the starting state:
    - If the spec started as `designed`, run `zest-dev update active planned`.
@@ -106,6 +89,3 @@ Add or update `spec.md` → `## Progress` with a thin progress checklist:
    - Report every Plan step's `Type` as `AFK` or `HITL`.
    - For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues.
    - If all steps are `AFK`, say that no user action is required before implementation.
-
-## Rule
-This is where Design becomes issue-scale spec-local implementation steps. Do not publish issues unless the user explicitly asks for that.

--- a/skills/zest-dev/plan.md
+++ b/skills/zest-dev/plan.md
@@ -5,14 +5,25 @@ Canonical workflow for planning implementation of an active change spec.
 ## When to use
 - The design is ready to turn into implementation steps
 
-## Workflow
-1. Run `zest-dev status` and verify an active change spec exists.
-2. Run `zest-dev show active` and read the main spec file and `design.md`.
-3. Check status before proceeding:
+## Outcome
+Turn the approved Design into a compact sequence of issue-scale implementation slices that an implementer can execute and verify without reconstructing the architecture.
+
+## Success means
+- The active spec, current status, main spec, and `design.md` were read.
+- Every Plan step has a meaningful goal, bounded scope, dependency, and AFK/HITL type.
+- Functional work is followed by EAG Validation and the final documentation check.
+- `## Progress` mirrors the Plan step titles exactly.
+- An eligible `designed` spec advances to `planned`; revised later-phase specs keep their status.
+
+## Status gate
+- Run `zest-dev status` and `zest-dev show active` before planning.
+- Check the current status:
    - If the status is `new` or `researched`, suggest design first unless the implementation approach is already sufficiently decided.
    - If the status is `designed`, continue.
    - If the status is `planned` or `implemented`, confirm that the user wants to revise the existing plan before continuing.
-4. Identify implementation steps using issue-scale slicing:
+
+## Slicing constraints
+- Identify implementation steps using issue-scale slicing:
    - Use the slicing spirit of Matt Pocock's registered `to-issues` skill as a reference for scale and sequencing.
    - Do not create GitHub issues or external issue-tracker entries unless the user explicitly asks for that.
    - Treat each Plan step as the spec-local counterpart to an issue-sized vertical slice.
@@ -22,19 +33,19 @@ Canonical workflow for planning implementation of an active change spec.
    - Do not mark a step as `HITL` merely because the output is documentation, runbook text, an operator-facing procedure, or a workflow that humans will later execute.
    - Mark steps as `AFK` when an agent can implement them independently from the written spec and repository context.
    - Capture dependencies between steps.
-5. Add a dedicated Plan step for EAG Validation:
+- Add a dedicated Plan step for EAG Validation:
    - Place it after the functional implementation steps and before Documentation Sync.
    - The step should tell the implementer to validate the completed change against the Design section's EAG.
    - When the Design says there is no EAG, the step should explicitly confirm that no dedicated automated end-to-end gate exists and use the best available validation already defined by the Spec.
    - Do not redefine the EAG during planning. Reuse the Design section's acceptance behavior and verification path as written.
-6. Add a final Plan step for Documentation Sync:
+- Add a final Plan step for Documentation Sync:
    - Always include this as the final Plan step.
    - The step should tell the implementer to update relevant project documentation if the implemented change makes that necessary.
    - Do not decide during planning whether documentation must change. Leave that check to implementation, when the final code and behavior are visible.
    - Do not automatically include glossary or ADR work. Treat those as special documentation updates only when the implemented change genuinely calls for them.
-7. Ask the user clarifying questions when needed.
-8. Wait for answers before finalizing the plan when the open questions are consequential.
-9. Fill `## Plan` with compact structured steps:
+
+## Required output
+Fill `## Plan` with compact structured steps:
    - Do not use markdown checkboxes in `## Plan`.
    - Put the step type directly after the step number in every step heading: `Step 1 (AFK): ...` or `Step 2 (HITL): ...`.
    - Prefer steps that each deliver one meaningful vertical slice and remain easy to review.
@@ -70,7 +81,7 @@ Canonical workflow for planning implementation of an active change spec.
       Scope: If the implementation changes documented behavior, usage, commands, setup, or workflows, update the relevant project docs.
       Depends on: Step 3
       ```
-10. Add or update `spec.md` → `## Progress` with a thin progress checklist:
+Add or update `spec.md` → `## Progress` with a thin progress checklist:
    - Add one checkbox per Plan step.
    - Keep each checklist item to the step title only.
    - Preserve the step type marker after the step number, matching the Plan heading form: `Step N (AFK): ...` or `Step N (HITL): ...`.
@@ -83,11 +94,15 @@ Canonical workflow for planning implementation of an active change spec.
       - [ ] Step 1 (AFK): Foo
       - [ ] Step 2 (HITL): Bar
       ```
-11. Update status based on the starting state:
+## Status update
+- Update status based on the starting state:
    - If the spec started as `designed`, run `zest-dev update active planned`.
    - If the spec started as `planned`, skip the update and keep the status as-is.
    - If the spec started as `implemented`, skip the update and keep the status as-is while revising the plan.
-12. Present the plan and stop:
+## Stop or block
+- Ask only questions whose answers materially change step scope, dependencies, acceptance, or AFK/HITL classification.
+- If such a question remains unanswered, stop and name the blocked Plan decision.
+- Otherwise present the plan and stop:
    - Report every Plan step's `Type` as `AFK` or `HITL`.
    - For each `HITL` step, tell the user what needs to be discussed, reviewed, judged, or approved in conversation before implementation continues.
    - If all steps are `AFK`, say that no user action is required before implementation.

--- a/skills/zest-dev/research.md
+++ b/skills/zest-dev/research.md
@@ -5,15 +5,17 @@ Canonical workflow for researching an active change spec.
 ## When to use
 - An active spec exists and the team needs repository facts, patterns, and options
 
-## Workflow
-1. Run `zest-dev status` and verify an active change spec exists.
-2. Run `zest-dev show active`, read the main spec file, and read `design.md`.
-3. If the status is `new`, continue. If later, confirm whether the user wants to refresh research.
-4. Clarify missing requirement details if needed.
-5. Summarize your understanding of the request and confirm it with the user before deeper exploration when the requirements are still ambiguous.
-6. Explore the codebase and locate relevant files.
-7. Read the identified files.
-8. Fill `design.md` → `## Research` with facts only:
+## Outcome
+Produce a concise, source-backed account of the existing system and the constraints that materially inform Design, without choosing an architecture.
+
+## Success means
+- An active spec and its current status were verified with `zest-dev status` and `zest-dev show active`.
+- The main spec, `design.md`, and relevant repository sources were read.
+- `design.md` → `## Research` contains enough evidence for Design to proceed and makes material evidence gaps visible.
+- A `new` spec advances to `researched`; a later-phase research refresh keeps its existing status.
+
+## Required output
+Fill `design.md` → `## Research` with facts only:
    - Existing System
    - Design Inputs
    - Constraints & Dependencies
@@ -24,9 +26,17 @@ Canonical workflow for researching an active change spec.
    - Merge same-file citations into ranges or grouped refs: `src/media.ts:770-811,829,855,877-890`.
    - Move long evidence lists to `Key References`; keep inline `Source:` entries short.
    - Do not list competing options, rank alternatives, or recommend a choice; capture existing patterns, reference code, docs, best practices, and implementation considerations as design raw materials.
-9. If the current status is `new`, run `zest-dev update active researched`.
-10. If this is a refresh for a later-phase spec, keep the current status and do not downgrade it.
-11. Summarize findings and point to the design phase.
+
+## Constraints
+- Clarify missing requirement details only when they materially affect what must be researched.
+- When the request is still ambiguous, summarize the current understanding and confirm it before deep exploration.
+- If the current status is later than `new`, confirm that the user wants to refresh Research before changing it.
+- Keep Research factual; leave choices and recommendations to Design.
+
+## Stop or block
+- Stop when the Design inputs have representative evidence and any material gaps or conflicts are recorded.
+- If a required repository source cannot be found or read, report the missing evidence instead of filling the gap by assumption.
+- After writing Research, update an eligible `new` spec to `researched`, summarize the findings, and point to Design without starting it.
 
 ## Rule
 Document what exists and what can inform design, not competing options or what should be chosen.

--- a/skills/zest-dev/research.md
+++ b/skills/zest-dev/research.md
@@ -6,7 +6,7 @@ Canonical workflow for researching an active change spec.
 - An active spec exists and the team needs repository facts, patterns, and options
 
 ## Outcome
-Produce a concise, source-backed account of the existing system and the constraints that materially inform Design, without choosing an architecture.
+Produce a source-backed account of the existing system and the constraints that materially inform Design, without choosing an architecture.
 
 ## Success means
 - An active spec and its current status were verified with `zest-dev status` and `zest-dev show active`.

--- a/skills/zest-dev/research.md
+++ b/skills/zest-dev/research.md
@@ -20,8 +20,11 @@ Fill `design.md` → `## Research` with facts only:
    - Design Inputs
    - Constraints & Dependencies
    - Key References
-   - Every finding must cite its fact source inline or immediately adjacent to it.
+   - Every factual claim must cite its source inline or immediately adjacent to it.
    - Valid fact sources include code (`path/to/file:line`), database artifacts (schema/table/migration/query reference), and documentation (doc path, URL, or section).
+   - Label inference separately from directly supported facts and cite the facts the inference depends on.
+   - State material conflicts between sources instead of silently choosing one.
+   - Record required evidence that is missing or unavailable; do not turn absence of evidence into a factual conclusion.
    - Keep sources compact: cite the smallest useful evidence, usually 1 representative line or short range per finding.
    - Merge same-file citations into ranges or grouped refs: `src/media.ts:770-811,829,855,877-890`.
    - Move long evidence lists to `Key References`; keep inline `Source:` entries short.
@@ -34,7 +37,7 @@ Fill `design.md` → `## Research` with facts only:
 - Keep Research factual; leave choices and recommendations to Design.
 
 ## Stop or block
-- Stop when the Design inputs have representative evidence and any material gaps or conflicts are recorded.
+- Stop when material Design inputs have representative evidence and any gaps, conflicts, or inferences are explicit.
 - If a required repository source cannot be found or read, report the missing evidence instead of filling the gap by assumption.
 - After writing Research, update an eligible `new` spec to `researched`, summarize the findings, and point to Design without starting it.
 


### PR DESCRIPTION
## Summary

- restructure Zest Dev phase prompts around outcomes, success criteria, constraints, and stop conditions
- remove repeated workflow scaffolding and distinguish sourced facts from design judgment
- reserve absolute rules for true invariants and make documentation sync conditional
- treat `steps.md` as a selective implementation journal with explicit downstream impact
- detect deployed skill copies and verify OpenCode/Codex deployments match the packaged source

## Why

GPT-5.6 performs better with outcome-first, lean prompt contracts that preserve evidence and completion boundaries while leaving room to choose an efficient path. The previous workflow repeated phase guidance, overused absolute rules, and loaded completed implementation history by default.

## Validation

- `pnpm test:local` — 22 passed, 1 skipped
- `pnpm test:package` — 23 passed