### PR TITLE
docs(skill): scope EAG to one-time spec acceptance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -37,6 +37,10 @@ New-format Specs progress through `new → designed → planned → implemented`
 - Keep Design Decisions normative, with rationale and trade-offs separated from their factual premises.
 - Before writing or deciding, read the active Spec and the repository files that materially affect the current content.
 
+### Acceptance-gate scope
+
+Treat EAG (E2E Acceptance Gate) as a one-time, Spec-local acceptance step. Keep its harness, command, environment variables, and evidence collection temporary or inside the Spec; do not promote them into repository-wide scripts, CLI commands, product concepts, or general documentation unless the user explicitly requests a reusable capability. After acceptance, remove temporary EAG artifacts while preserving the result in the Spec.
+
 ### Continuation
 
 - Infer the user's requested outcome and continue until its content contract is satisfied.


### PR DESCRIPTION
## Summary

- Clarify that EAG (E2E Acceptance Gate) is a one-time, Spec-local acceptance step.
- Keep EAG harnesses, commands, environment variables, and evidence collection out of repository-wide scripts, CLI commands, product concepts, and general documentation unless a reusable capability is explicitly requested.
- Preserve the acceptance result in the Spec and remove temporary EAG artifacts after acceptance.

## Validation

- `pnpm test:local` — 23 passed, 1 skipped (the package-only deployment test is expected to skip in the local runner).
