### PR TITLE
fix(skill): use valid zest-dev identifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ This repository's custom command prompts are designed for **OpenCode / oh-my-ope
 - Do **not** hardcode specific oh-my-opencode-slim agent handles in prompts unless there is a strong reason; let the runtime choose the best matching subagent.
 - For user interaction, say **ask the user directly** or **use the question tool** rather than Claude-specific names.
 - For codebase work, describe the goal (read files, search code, inspect references, run shell commands) rather than enumerating a Claude-only tool contract.
-- When referring to a skill in prompts or command docs, refer to it by its registered skill name (for example `Zest Dev`), not by repository or deployed file paths.
-- Keep lifecycle invariants, recording rules, and reusable content guidance in skills. The main `Zest Dev` skill should route by requested outcome; Section Guides should define the Overview, Design, Plan, and Implementation content contracts through progressive disclosure.
+- When referring to a skill in prompts or command docs, refer to it by its registered skill name (for example `zest-dev`), not by repository or deployed file paths.
+- Keep lifecycle invariants, recording rules, and reusable content guidance in skills. The main `zest-dev` skill should route by requested outcome; Section Guides should define the Overview, Design, Plan, and Implementation content contracts through progressive disclosure.
 - Keep command prompts thin. Commands should provide a simple entry prompt and route intent into the relevant skill workflow; they should not duplicate detailed process, rules, or templates.
 - Keep the CLI-created Spec templates thin. They should create the required Main Spec, Design Record, and Implementation File structure with brief placeholders only; concrete writing guidance belongs in the Zest Dev Section Guides.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If publishing fails, inspect the `Publish npm` workflow run on `main` before ret
 
 Zest Dev uses a **content-contract skill / approach command** model:
 
-- the `Zest Dev` skill owns Spec lifecycle and recording contracts
+- the `zest-dev` skill owns Spec lifecycle and recording contracts
 - Section Guides define Overview, Design, Plan, and Implementation content
 - two thin commands choose how a new Spec reaches Designed Status
 - the `zest-dev` CLI manages Spec files and lifecycle state

--- a/commands/grilling.md
+++ b/commands/grilling.md
@@ -3,4 +3,4 @@ description: Create a new Spec through the Grilling Design Approach
 argument-hint: <requirement>
 ---
 
-Use the Zest Dev skill to create and activate a new Spec for $ARGUMENTS, then satisfy Designed Status through the Grilling Design Approach.
+Use the `zest-dev` skill to create and activate a new Spec for $ARGUMENTS, then satisfy Designed Status through the Grilling Design Approach.

--- a/commands/lightweight.md
+++ b/commands/lightweight.md
@@ -3,4 +3,4 @@ description: Create a new Spec through the Lightweight Design Approach
 argument-hint: <requirement>
 ---
 
-Use the Zest Dev skill to create and activate a new Spec for $ARGUMENTS, then satisfy Designed Status through the Lightweight Design Approach.
+Use the `zest-dev` skill to create and activate a new Spec for $ARGUMENTS, then satisfy Designed Status through the Lightweight Design Approach.

--- a/e2e/tests/conftest.py
+++ b/e2e/tests/conftest.py
@@ -26,7 +26,7 @@ DFU_RALPH_TASK = (
     "If the spec has Deferred Follow-Ups (DFU), create one GitHub issue "
     "for each DFU item and link those issues in the PR."
 )
-RALPH_TASK_PROMPT = "Use the Zest Dev skill to implement the active planned Spec.\n"
+RALPH_TASK_PROMPT = "Use the `zest-dev` skill to implement the active planned Spec.\n"
 
 
 class Cli:

--- a/lib/ralph-setup.js
+++ b/lib/ralph-setup.js
@@ -5,7 +5,7 @@ const { getSpec } = require('./spec-manager');
 
 const FINAL_RALPH_TASK = 'Make sure all tasks are done in ralph loops, and then create PR. If there is a related issue, make sure to link it in the PR.';
 const DFU_RALPH_TASK = 'If the spec has Deferred Follow-Ups (DFU), create one GitHub issue for each DFU item and link those issues in the PR.';
-const RALPH_TASK_PROMPT = 'Use the Zest Dev skill to implement the active planned Spec.';
+const RALPH_TASK_PROMPT = 'Use the `zest-dev` skill to implement the active planned Spec.';
 
 function findSection(content, heading) {
   const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zest-dev",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A lightweight, human-interactive development workflow for AI-assisted coding",
   "author": {
     "name": "nettee",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ A plugin for Zest Dev's spec-driven development workflow.
 
 ## Architecture
 
-- the `Zest Dev` skill owns Spec lifecycle and recording contracts
+- the `zest-dev` skill owns Spec lifecycle and recording contracts
 - Section Guides define Overview, Design, Plan, and Implementation content
 - commands select a Design Approach without duplicating skill rules
 - `plugin/commands`, `plugin/skills`, and `plugin/agents` are symlinks for plugin compatibility
@@ -35,4 +35,4 @@ Both commands preserve the user's language and route into the same Designed Cont
 zest-dev init
 ```
 
-The default global initialization deploys the two OpenCode commands, the Zest Dev skill, and the supported Codex subagents. Target-specific and local initialization remain available through the CLI options.
+The default global initialization deploys the two OpenCode commands, the `zest-dev` skill, and the supported Codex subagents. Target-specific and local initialization remain available through the CLI options.

--- a/skills/zest-dev/SKILL.md
+++ b/skills/zest-dev/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Zest Dev
+name: zest-dev
 description: Use for creating, designing, planning, implementing, or continuing a Zest Dev Spec, including lightweight and grilling-based design workflows.
 version: 0.1.0
 ---


### PR DESCRIPTION
## Summary

- change the registered Skill name from `Zest Dev` to the valid `zest-dev` slug
- update runtime prompts, documentation, and test expectations to use the registered identifier
- retain “Zest Dev” as the product and document title

## Why

Pi only accepts Skill names containing lowercase letters, digits, and hyphens. The previous frontmatter value caused an invalid-name warning during startup.

## Validation

- `pnpm test:local` — 23 passed, 1 skipped
- parsed the `SKILL.md` frontmatter with Ruby YAML
- verified the skill name matches Pi's lowercase slug constraint
- ran `git diff --check`
